### PR TITLE
Resolved Issue #6

### DIFF
--- a/rhealpixdggs/ellipsoids.py
+++ b/rhealpixdggs/ellipsoids.py
@@ -29,7 +29,7 @@ from numpy import pi, sqrt, sin, cos, arcsin, arctanh, deg2rad, rad2deg
 from random import uniform
 
 # Import my modules.
-from rhealpixdggs.utils import my_round, auth_lat, auth_rad
+from utils import my_round, auth_lat, auth_rad
 
 # Parameters of some common ellipsoids.
 WGS84_A = 6378137.0

--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -12,6 +12,8 @@ drawing figures.
 - AR, 2013-07-23: Ported to Python 3.3.
 - Robert Gibb (RG), 2020-07-13: Issue #1 Multiple tests fail due to rounding errors
 - RG, 2020-07-31: Issue #5 Moved healpix_diagram to GRS2013 to remove sage dependence
+- RG, 2020-09-08: Issue #6 In in_healpix_image added +-eps to the extreme corner vertices
+                           added calling function abbrev to error statements
 
 NOTE:
 
@@ -84,7 +86,7 @@ def healpix_sphere_inverse(x, y):
     """
     # Throw error if input coordinates are out of bounds.
     if not in_healpix_image(x, y):
-        print("Error: input coordinates (%f, %f) are out of bounds" % (x, y))
+        print("Error (hsi): input coordinates (%.20f,%.20f) are out of bounds" % (x, y))
         return float("inf"), float("inf")
     y0 = pi / 4
     # Equatorial region.
@@ -153,8 +155,9 @@ def healpix_ellipsoid_inverse(x, y, e=0):
     """
     # Throw error if input coordinates are out of bounds.
     if not in_healpix_image(x, y):
-        print("Error: input coordinates (%f, %f) are out of bounds" % (x, y))
+        print("Error (hei): input coordinates (%.20f,%.20f) are out of bounds" % (x, y))
         return
+
     lam, beta = healpix_sphere_inverse(x, y)
     phi = auth_lat(beta, e, radians=True, inverse=True)
     return lam, phi
@@ -205,7 +208,7 @@ def in_healpix_image(x, y):
     # points on the boundary count as lying in the image.
     eps = 1e-10
     vertices = [
-        (-pi - eps, pi / 4),
+        (-pi - eps, pi / 4 + eps),
         (-3 * pi / 4, pi / 2 + eps),
         (-pi / 2, pi / 4 + eps),
         (-pi / 4, pi / 2 + eps),
@@ -213,8 +216,8 @@ def in_healpix_image(x, y):
         (pi / 4, pi / 2 + eps),
         (pi / 2, pi / 4 + eps),
         (3 * pi / 4, pi / 2 + eps),
-        (pi + eps, pi / 4),
-        (pi + eps, -pi / 4),
+        (pi + eps, pi / 4 + eps),
+        (pi + eps, -pi / 4 - eps),
         (3 * pi / 4, -pi / 2 - eps),
         (pi / 2, -pi / 4 - eps),
         (pi / 4, -pi / 2 - eps),
@@ -222,7 +225,7 @@ def in_healpix_image(x, y):
         (-pi / 4, -pi / 2 - eps),
         (-pi / 2, -pi / 4 - eps),
         (-3 * pi / 4, -pi / 2 - eps),
-        (-pi - eps, -pi / 4),
+        (-pi - eps, -pi / 4 - eps),
     ]
     poly = Path(vertices)
     return bool(poly.contains_point([x, y]))

--- a/rhealpixdggs/projection_wrapper.py
+++ b/rhealpixdggs/projection_wrapper.py
@@ -6,6 +6,7 @@ CHANGELOG:
 - Alexander Raichev (AR), 2013-01-25: Refactored code from release 0.3.
 - AR, 2013-07-23: Ported to Python 3.3.
 - Robert Gibb (RG), 2020-07-13: Issue #1 Multiple tests fail due to rounding errors
+- RG, 2020-09-08: Issue #6 Added optional region="none" arg to all projection calls
 
 NOTE:
 
@@ -91,7 +92,7 @@ class Proj(object):
             result.append(" " * 8 + k + " = " + str(v))
         return "\n".join(result)
 
-    def __call__(self, u, v, inverse=False):
+    def __call__(self, u, v, inverse=False, region="none"):
         ellipsoid = self.ellipsoid
         proj = self.proj
         kwargs = self.kwargs


### PR DESCRIPTION
Occasionally a computed cell vertex would be up to 1e15 outside the cell. This was allowed for by expanding the rhealpix/healpix boundary vertices by (eps = 1e15) in the in_rhealpix_image test. But the test for applying combine_triangles in rhealpix didnt accomodate a +-eps dither in coordinate values. combine_triangles() cannot know the origin of the coordinate it is testing, but cell.vertices() & cell.boundary() already know the region of the cell that owns the coordinates. So adding cell.region() as an optional argument to the rheal[ix transformation functions, allows vertices() & boundaries() to force the combine_triangles() behaviour to follow the cell, not the individual coordinates. This has been tested for cells with all 0s, 1s, 2s, 6s, 7s, or 8s on faces OPQR. ie equatorial cells with a northern or southern border on the edge of the equatorial region.