### PR TITLE
Fix an issue in RHEALPixDGGS.cell_from_point() when N_side>10

### DIFF
--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -739,6 +739,11 @@ class RHEALPixDGGS(object):
             >>> c = rdggs.cell_from_point(1, p)
             >>> print(c)
             Q3
+            >>> rdggs = RHEALPixDGGS(N_side=15)
+            >>> p = (80, -20)
+            >>> c = rdggs.cell_from_point(1, p, plane=False)
+            >>> print(c)
+            (Q, 178)
 
         """
         # Get the rectangular coordinates of p.
@@ -811,7 +816,7 @@ class RHEALPixDGGS(object):
 
         # Use the column and row SUIDs of c to get the SUID of c.
         for i in range(resolution):
-            suid.append(self.child_order[(int(suid_row[i]), int(suid_col[i]))])
+            suid.append(self.child_order[(int(suid_row[i], N), int(suid_col[i], N))])
         return Cell(self, suid)
 
     def cell_from_region(self, ul, dr, plane=True):


### PR DESCRIPTION
I created rHEALPix DGGS with N_side = 13 and wanted to use `RHEALPixDGGS.cells_from_region()` method, but encountered an exception that comes from `RHEALPixDGGS.cell_from_point()`. This is the issue only when N_side is larger than 10. After fixing it, I got expected results.

Since _base_ argument for `int()` and `numpy.base_repr()` [is in](https://docs.python.org/3/library/functions.html#int) [range 2-36](https://numpy.org/doc/stable/reference/generated/numpy.base_repr.html), maybe N_side should be constrained to be less than or equal to 36?

I believe there is a similar issue in the _cells.py_ module:
https://github.com/manaakiwhenua/rhealpixdggs-py/blob/b4581ef48896787eddde432c09fc22dabec95d07/rhealpixdggs/cell.py#L112-L116
but since `b = N_side**2`, this creates an issue already when N_side is larger than 6. This seems to be trickier to fix, so I didn't try it for now.