### PR TITLE
Return 'cap' as ellipsoidal shape for resolution 0 cells N and S

### DIFF
--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -1018,8 +1018,6 @@ class Cell(object):
             quad
             >>> print(Cell(rdggs, ['N', 2]).ellipsoidal_shape())
             dart
-            >>> print(Cell(rdggs, ['N']).ellipsoidal_shape())
-            cap
 
         """
         suid = self.suid

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -1018,11 +1018,15 @@ class Cell(object):
             quad
             >>> print(Cell(rdggs, ['N', 2]).ellipsoidal_shape())
             dart
+            >>> print(Cell(rdggs, ['N']).ellipsoidal_shape())
+            cap
 
         """
         suid = self.suid
         if suid[0] in CELLS0[1:5]:
             return "quad"
+        if suid == tuple(CELLS0[0]) or suid == tuple(CELLS0[5]):
+            return "cap"
         N = self.N_side
         # Cap check.
         cap = True

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -60,6 +60,9 @@ WGS84_123 = dggs.RHEALPixDGGS(
 WGS84_123_RADIANS = dggs.RHEALPixDGGS(
     ellipsoid=WGS84_ELLIPSOID_RADIANS, north_square=1, south_square=2, N_side=3
 )
+WGS84_122 = dggs.RHEALPixDGGS(
+            ellipsoid=WGS84_ELLIPSOID, north_square=1, south_square=2, N_side=2
+        )
 
 
 class SCENZGridTestCase(unittest.TestCase):
@@ -545,6 +548,11 @@ class SCENZGridTestCase(unittest.TestCase):
                     u = [s] + t
                     X = rdggs.cell(u)
                     self.assertEqual(X.ellipsoidal_shape(), "skew_quad")
+        rdggs = WGS84_122
+        cell_n = rdggs.cell((CELLS0[0],))
+        cell_s = rdggs.cell((CELLS0[5],))
+        self.assertEqual(cell_n.ellipsoidal_shape(), "cap")
+        self.assertEqual(cell_s.ellipsoidal_shape(), "cap")
 
     def test_centroid(self):
         # Warning: This test is slow.


### PR DESCRIPTION
Just a tiny suggestion.
Currently, when `N_side` is even, `Cell.ellipsoidal_shape()` returns 'dart' for resolution 0 cells N and S. I believe it should return 'cap'.