### PR TITLE
Demaion/polyfill

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,7 @@
+0.5.4
+^^^^^
+Code unchanged from 0.5.3 other than updating to Python 3.11
+
 0.5.3
 ^^^^^
 - v0.5.3: 0.5.1 with:

--- a/README.rst
+++ b/README.rst
@@ -10,19 +10,21 @@ Release Notes
 -------------
 This package was originally authored in 2013 and has had only minor code updates since then.
 
-0.5.4 - current
+0.5.5 - current
 ^^^^^^^^^^^^^^^
-Code unchanged from 0.5.3 other than updating to Python 3.11
+Added a series of wrapper functions that expose some of the rHEALPix functionality in an API roughly
+in line with what Uber's H3 provides.
 
 Refer to file CHANGES.rst for a more detailed history of changes.
 
 Requirements 
 -------------
 * ``requirements.txt`` - all the module requirements for operation
-    - `NumPy >=1.7 <http://www.numpy.org/>`_ Base N-dimensional array package
-    - `SciPy >=0.12 <http://www.scipy.org/>`_ Fundamental library for scientific computing
-    - `Matplotlib >=1.2.1 <http://matplotlib.org/>`_ Comprehensive 2D Plotting
-    - `Pyproj >=1.9.3 <http://code.google.com/p/pyproj/>`_ Python interface to the PROJ.4 cartographic library
+    - `NumPy >=1.25.2,<2 <https://www.numpy.org/>`_ Base N-dimensional array package
+    - `SciPy >=1.11.2 <https://www.scipy.org/>`_ Fundamental library for scientific computing
+    - `Matplotlib >=3.7.2 <https://matplotlib.org/>`_ Comprehensive 2D Plotting
+    - `Pyproj >=3.6.1 <https://code.google.com/p/pyproj/>`_ Python interface to the PROJ.4 cartographic library
+    - `Shapely >=2.0.1 <https://shapely.readthedocs.io/>`_ Manipulation and analysis of planar GEOS geometries
 * ``requirements.dev.txt`` - packages needed for developing this package
 
 Installation

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -1023,10 +1023,10 @@ class Cell(object):
         suid = self.suid
         if suid[0] in CELLS0[1:5]:
             return "quad"
+        # Cap check.
         if suid == tuple(CELLS0[0]) or suid == tuple(CELLS0[5]):
             return "cap"
         N = self.N_side
-        # Cap check.
         cap = True
         if N % 2 != 1:
             cap = False

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -465,7 +465,7 @@ def polyfill(
     else:
         cells.sort()
 
-    return set(cells)
+    return cells
 
 
 def linetrace(

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -17,6 +17,7 @@ from rhealpixdggs.cell import CELLS0
 
 PARENT_RESOLUTION_WARNING = "WARNING: You requested a parent resolution that is higher than the cell resolution. Returning the cell address itself."
 CHILD_RESOLUTION_WARNING = "WARNING: You requested a child resolution that is lower than the cell resolution. Returning the cell address itself."
+CELL_CENTRE_WARNING = "WARNING: You requested a centre cell for a DGGS that has an even number of cells on a side. Returning None."
 CELL_RING_WARNING = "WARNING: Implementation of cell rings is incomplete. Requesting a {0} ring that involves more than two resolution 0 cube faces will return unexpected results."
 POLYFILL_GEOMETRY_WARNING = "WARNING: Empty or missing geometry, unsupported geometry type (not Polygon or MultiPolygon), or geometry with no area. Returning None."
 
@@ -110,7 +111,7 @@ def rhp_to_parent(
     # Handle mismatch between cell resolution and requested parent resolution
     elif res > child_res:
         if verbose:
-            print(PARENT_RESOLUTION_WARNING)
+            warn(PARENT_RESOLUTION_WARNING)
         return rhpindex
 
     # Standard case (including child_res == res)
@@ -127,17 +128,23 @@ def rhp_to_center_child(
 
     Returns None if the cell index is invalid.
 
-    TODO: come up with a scheme for even numbers on a side
+    Returns None if the DGGS has an even number of cells on a side.
     """
     # Stop early if the cell index is invalid
     if not rhp_is_valid(rhpindex, dggs):
+        return None
+
+    # DGGSs with even numbers of cells on a side never have a cell at the centre
+    if (dggs.N_side % 2) == 0:
+        if verbose:
+            warn(CELL_CENTRE_WARNING)
         return None
 
     # Handle mismatch between cell resolution and requested child resolution
     parent_res = len(rhpindex)
     if res is not None and res < parent_res:
         if verbose:
-            print(CHILD_RESOLUTION_WARNING)
+            warn(CHILD_RESOLUTION_WARNING)
         return rhpindex
 
     # Standard case (including parent_res == res)

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -466,7 +466,7 @@ def polyfill(
     else:
         poly_cells.sort()
 
-    return poly_cells
+    return set(poly_cells)
 
 
 def linetrace(

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -398,9 +398,9 @@ def polyfill(
     dggs: RHEALPixDGGS = WGS84_003,
 ) -> set[str]:
     """
-    Turn the area contained in a shapely polygon or multipolygon into a sorted set
-    of cell indices at the requested resolution. A cell index is included if its
-    centroid is inside the geometry defined by the boundaries and holes.
+    Turn the area contained in a shapely polygon or multipolygon into a set of cell
+    indices at the requested resolution. A cell index is included if its centroid is
+    inside the geometry defined by the boundaries and holes.
 
     Returns an empty set if no cell centroids fall within the input geometry.
 
@@ -436,7 +436,7 @@ def polyfill(
         geoms = geometry.geoms
 
     # Collect cells in regions of interest
-    cells = []
+    cells = set()
     for geom in geoms:
         # Region of interest is the bounding box around the geometry
         bbox = geom.bounds
@@ -455,17 +455,13 @@ def polyfill(
             # Check each cell against geometry, add to results if inside polygon
             for cell in roi_cells:
                 if geom.contains(Point(cell.centroid(plane))):
-                    cells.append(str(cell))
+                    cells.add(str(cell))
 
-    # Merge cells inside polygon into larger ones where possible (will sort cell ids)
+    # Merge cells inside polygon into larger ones where possible
     if compress:
-        cells = compress_order_cells(cells)
+        cells = set(compress_order_cells(cells))
 
-    # Sort cell ids separately
-    else:
-        cells.sort()
-
-    return set(cells)
+    return cells
 
 
 def linetrace(

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -399,9 +399,9 @@ def polyfill(
     dggs: RHEALPixDGGS = WGS84_003,
 ) -> list[str]:
     """
-    Turn the area contained in a shapely polygon or multipolygon into a list of cell
-    indices at the requested resolution. A cell index is included if its centroid is
-    inside the geometry defined by the boundaries and holes.
+    Turn the area contained in a shapely polygon or multipolygon into a sorted list
+    of cell indices at the requested resolution. A cell index is included if its
+    centroid is inside the geometry defined by the boundaries and holes.
 
     Returns an empty list if no cell centroids fall within the input geometry.
 
@@ -412,11 +412,9 @@ def polyfill(
 
     Returns None if no cells match the geometry for some reason.
 
-    NOTE: The list of cell indices is not guaranteed to be ordered.
-
-    TODO: define what happens if the holes are not completely inside the outer
-          boundary - return None? Return polyfill for the outer boundary? (Check
-          what h3 does...or go with what shapely geometries can do?)
+    Throws an error if the geometry is invalid in other ways, e.g. if a point on a hole
+    boundary is outside the exterior boundary of its polygon, or if two polygons in a
+    multipolygon overlap.
 
     TODO: deal with the antimeridian
     """
@@ -461,12 +459,12 @@ def polyfill(
         if geometry.contains(Point(cell.centroid(plane))):
             poly_cells.append(str(cell))
 
-    # Eliminate duplicates (can occur with overlapping polygons)
-    poly_cells = list(set(poly_cells))
-
-    # Merge cells inside polygon into larger ones where possible
+    # Merge cells inside polygon into larger ones where possible (will sort cell ids)
     if compress:
         poly_cells = compress_order_cells(poly_cells)
+    # Sort cell ids separately
+    else:
+        poly_cells.sort()
 
     return poly_cells
 

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -396,7 +396,7 @@ def polyfill(
     compress: bool = False,
     verbose: bool = False,
     dggs: RHEALPixDGGS = WGS84_003,
-) -> list[str]:
+) -> set[str]:
     """
     Turn the area contained in a shapely polygon or multipolygon into a sorted set
     of cell indices at the requested resolution. A cell index is included if its
@@ -465,7 +465,7 @@ def polyfill(
     else:
         cells.sort()
 
-    return cells
+    return set(cells)
 
 
 def linetrace(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 import codecs
 import os
 
-VERSION = "0.5.4"
+VERSION = "0.5.5"
 
 
 def open_local(paths, mode="r", encoding="utf8"):

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -446,7 +446,7 @@ class RhpWrappersTestCase(unittest.TestCase):
         result = rhpw.polyfill(plane_poly, 10)
         self.assertEqual(
             result,
-            {
+            [
                 "N2160556110",
                 "N2160556111",
                 "N2160556112",
@@ -456,11 +456,11 @@ class RhpWrappersTestCase(unittest.TestCase):
                 "N2160556116",
                 "N2160556117",
                 "N2160556118",
-            },
+            ],
         )
 
         # Compressed from polygon - plane
-        self.assertEqual(rhpw.polyfill(plane_poly, 10, compress=True), {"N216055611"})
+        self.assertEqual(rhpw.polyfill(plane_poly, 10, compress=True), ["N216055611"])
 
         # Test data - sphere
         eq_poly_n = sh.Polygon(
@@ -490,17 +490,17 @@ class RhpWrappersTestCase(unittest.TestCase):
         # )  # TODO: hole
 
         # Polygon tests - sphere
-        self.assertEqual(rhpw.polyfill(eq_poly_n, 0, False), {"Q"})
-        self.assertEqual(rhpw.polyfill(eq_poly_s, 0, False), {"Q"})
-        self.assertEqual(rhpw.polyfill(po_poly_n, 1, False), {"N2"})
-        self.assertEqual(rhpw.polyfill(po_poly_s, 1, False), {"S7"})
+        self.assertEqual(rhpw.polyfill(eq_poly_n, 0, False), ["Q"])
+        self.assertEqual(rhpw.polyfill(eq_poly_s, 0, False), ["Q"])
+        self.assertEqual(rhpw.polyfill(po_poly_n, 1, False), ["N2"])
+        self.assertEqual(rhpw.polyfill(po_poly_s, 1, False), ["S7"])
         # self.assertEqual(rhpw.polyfill(eq_poly_am, 0, False), ["R"])
 
         # Multipolygon tests - sphere
         result = rhpw.polyfill(
             sh.MultiPolygon(polygons=[eq_poly_n, po_poly_n, po_poly_s]), 1, False
         )  # TODO: add eq_poly_am, add "R*" to results list
-        self.assertEqual(result, {"N2", "Q1", "Q3", "Q4", "S7"})
+        self.assertEqual(result, ["N2", "Q1", "Q3", "Q4", "S7"])
 
         # Test data - malformed
         no_area = sh.Polygon(shell=((0, 0), (1, 0), (2, 0), (0, 0)))
@@ -516,8 +516,8 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(rhpw.polyfill(sh.Point(), 0))
         self.assertIsNone(rhpw.polyfill(no_area, 0))
         self.assertIsNone(rhpw.polyfill(multi_overlap, 0, False))
-        self.assertEqual(rhpw.polyfill(plane_poly, 1), set())
-        self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), set())
+        self.assertEqual(rhpw.polyfill(plane_poly, 1), [])
+        self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), [])
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -14,8 +14,9 @@ Keep adding tests!
 # Import standard modules
 import unittest
 
-# Import my modules
+# Import my modules and classes
 import rhealpixdggs.rhp_wrappers as rhpw
+import rhealpixdggs.dggs as gs
 
 # Import helper modules
 import numpy as np
@@ -118,6 +119,10 @@ class RhpWrappersTestCase(unittest.TestCase):
 
         # Invalid parent id
         child_id = rhpw.rhp_to_center_child("X")
+        self.assertIsNone(child_id)
+
+        # DGGS with even number of cells on a side
+        child_id = rhpw.rhp_to_center_child(parent_id, dggs=gs.WGS84_002)
         self.assertIsNone(child_id)
 
     def test_rhp_to_geo_boundary(self):

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -439,10 +439,18 @@ class RhpWrappersTestCase(unittest.TestCase):
     def test_polyfill(self):
         # Test data
         eq_poly_n = sh.Polygon(
-            shell=[(-10, -10), (50, -10), (50, 40), (-10, 40), (-10, -10)]
+            shell=[(-10, -10), (50, -10), (50, 40), (-10, 40), (-10, -10)],
+            holes=[
+                [(-5, 5), (25, 20), (45, 5), (-5, 5)],
+                [(-5, 25), (25, 30), (45, 25), (-5, 25)],
+            ],
         )
         eq_poly_s = sh.Polygon(
-            shell=[(-10, 10), (-10, -40), (50, -40), (50, 10), (-10, 10)]
+            shell=[(-10, 10), (-10, -40), (50, -40), (50, 10), (-10, 10)],
+            holes=[
+                [(-5, -5), (25, -20), (45, -5), (-5, -5)],
+                [(-5, -25), (25, -30), (45, -25), (-5, -25)],
+            ],
         )
         eq_poly_am = sh.Polygon(
             shell=[(170, 40), (170, -10), (-170, -10), (-170, 40), (170, 40)]
@@ -459,8 +467,8 @@ class RhpWrappersTestCase(unittest.TestCase):
 
         # TODO: polar caps
 
-        # TODO: polygon with hole (fold into equatorial and polar cap sections)
-        # TODO: multipolygon with holes (fold into equatorial and polar cap sections)
+        # TODO: polygon with hole (fold into polar cap section)
+        # TODO: multipolygon with holes (fold into polar cap section)
 
         # TODO: test cases for higher resolutions?
 

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -485,21 +485,17 @@ class RhpWrappersTestCase(unittest.TestCase):
             shell=[(30, -42), (0, -75), (90, -75), (60, -42), (30, -42)],
             holes=[[(10, -70), (20, -65), (10, -65), (10, -70)]],
         )
-        # eq_poly_am = sh.Polygon(
-        #     shell=[(130, 40), (130, -10), (-170, -10), (-170, 40), (130, 40)]
-        # )  # TODO: hole
 
         # Polygon tests - sphere
         self.assertEqual(rhpw.polyfill(eq_poly_n, 0, False), {"Q"})
         self.assertEqual(rhpw.polyfill(eq_poly_s, 0, False), {"Q"})
         self.assertEqual(rhpw.polyfill(po_poly_n, 1, False), {"N2"})
         self.assertEqual(rhpw.polyfill(po_poly_s, 1, False), {"S7"})
-        # self.assertEqual(rhpw.polyfill(eq_poly_am, 0, False), {"R"})
 
         # Multipolygon tests - sphere
         result = rhpw.polyfill(
             sh.MultiPolygon(polygons=[eq_poly_n, po_poly_n, po_poly_s]), 1, False
-        )  # TODO: add eq_poly_am, add "R*" to results list
+        )
         self.assertEqual(result, {"N2", "Q1", "Q3", "Q4", "S7"})
 
         # Test data - malformed

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -517,9 +517,7 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(rhpw.polyfill(no_area, 0))
         self.assertEqual(rhpw.polyfill(plane_poly, 1), set())
         self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), set())
-        self.assertRaises(
-            sh.errors.GEOSException, rhpw.polyfill, multi_overlap, 0, False
-        )
+        self.assertEqual(rhpw.polyfill(multi_overlap, 0, False), None)
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -438,31 +438,35 @@ class RhpWrappersTestCase(unittest.TestCase):
 
     def test_polyfill(self):
         # Test data
-        equatorial_poly_n = sh.Polygon(
+        eq_poly_n = sh.Polygon(
             shell=[(-10, -10), (50, -10), (50, 40), (-10, 40), (-10, -10)]
         )
-        equatorial_poly_s = sh.Polygon(
+        eq_poly_s = sh.Polygon(
             shell=[(-10, 10), (-10, -40), (50, -40), (50, 10), (-10, 10)]
         )
-        equatorial_poly_opp = sh.Polygon(
+        eq_poly_am = sh.Polygon(
             shell=[(130, 10), (130, -40), (-170, -40), (-170, 10), (130, 10)]
         )
-        # equatorial_multipoly = sh.MultiPolygon(
-        #     polygons=[equatorial_poly_n, equatorial_poly_opp]
-        # )
 
         # Equatorial polygons and multipolygons without holes
-        self.assertEqual(rhpw.polyfill(equatorial_poly_n, 0), ["Q"])
-        self.assertEqual(rhpw.polyfill(equatorial_poly_s, 0), ["Q"])
-        # self.assertEqual(rhpw.polyfill(equatorial_poly_opp, 0), ["R"])
-        # self.assertEqual(rhpw.polyfill(equatorial_multipoly, 0), ["Q"])
+        self.assertEqual(rhpw.polyfill(eq_poly_n, 0), ["Q"])
+        self.assertEqual(rhpw.polyfill(eq_poly_s, 0), ["Q"])
+        # self.assertEqual(rhpw.polyfill(eq_poly_am, 0), ["R"])
+        self.assertEqual(
+            rhpw.polyfill(sh.MultiPolygon(polygons=[eq_poly_n, eq_poly_s]), 0), ["Q"]
+        )
+        # self.assertEqual(
+        #     rhpw.polyfill(sh.MultiPolygon(polygons=[eq_poly_n, eq_poly_am]), 0)[
+        #         "Q", "R"
+        #     ]
+        # )
 
-        # TODO: polygon with hole
-        # TODO: multipolygon
-        # TODO: multipolygon with holes
+        # TODO: polar caps
 
-        # TODO: test cases for a set of test geometries and resolutions (equatorial
-        #       cases, cases involving the polar caps)
+        # TODO: polygon with hole (fold into equatorial and polar cap sections)
+        # TODO: multipolygon with holes (fold into equatorial and polar cap sections)
+
+        # TODO: test cases for higher resolutions?
 
         # Test data - malformed
         no_area = sh.Polygon(shell=((0, 0), (0, 0), (0, 0), (0, 0)))

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -446,7 +446,7 @@ class RhpWrappersTestCase(unittest.TestCase):
         result = rhpw.polyfill(plane_poly, 10)
         self.assertEqual(
             result,
-            [
+            {
                 "N2160556110",
                 "N2160556111",
                 "N2160556112",
@@ -456,11 +456,11 @@ class RhpWrappersTestCase(unittest.TestCase):
                 "N2160556116",
                 "N2160556117",
                 "N2160556118",
-            ],
+            },
         )
 
         # Compressed from polygon - plane
-        self.assertEqual(rhpw.polyfill(plane_poly, 10, compress=True), ["N216055611"])
+        self.assertEqual(rhpw.polyfill(plane_poly, 10, compress=True), {"N216055611"})
 
         # Test data - sphere
         eq_poly_n = sh.Polygon(
@@ -490,17 +490,17 @@ class RhpWrappersTestCase(unittest.TestCase):
         # )  # TODO: hole
 
         # Polygon tests - sphere
-        self.assertEqual(rhpw.polyfill(eq_poly_n, 0, False), ["Q"])
-        self.assertEqual(rhpw.polyfill(eq_poly_s, 0, False), ["Q"])
-        self.assertEqual(rhpw.polyfill(po_poly_n, 1, False), ["N2"])
-        self.assertEqual(rhpw.polyfill(po_poly_s, 1, False), ["S7"])
+        self.assertEqual(rhpw.polyfill(eq_poly_n, 0, False), {"Q"})
+        self.assertEqual(rhpw.polyfill(eq_poly_s, 0, False), {"Q"})
+        self.assertEqual(rhpw.polyfill(po_poly_n, 1, False), {"N2"})
+        self.assertEqual(rhpw.polyfill(po_poly_s, 1, False), {"S7"})
         # self.assertEqual(rhpw.polyfill(eq_poly_am, 0, False), ["R"])
 
         # Multipolygon tests - sphere
         result = rhpw.polyfill(
             sh.MultiPolygon(polygons=[eq_poly_n, po_poly_n, po_poly_s]), 1, False
         )  # TODO: add eq_poly_am, add "R*" to results list
-        self.assertEqual(result, ["N2", "Q1", "Q3", "Q4", "S7"])
+        self.assertEqual(result, {"N2", "Q1", "Q3", "Q4", "S7"})
 
         # Test data - malformed
         no_area = sh.Polygon(shell=((0, 0), (1, 0), (2, 0), (0, 0)))
@@ -515,8 +515,8 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(rhpw.polyfill(sh.MultiPolygon(), 0))
         self.assertIsNone(rhpw.polyfill(sh.Point(), 0))
         self.assertIsNone(rhpw.polyfill(no_area, 0))
-        self.assertEqual(rhpw.polyfill(plane_poly, 1), [])
-        self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), [])
+        self.assertEqual(rhpw.polyfill(plane_poly, 1), set())
+        self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), set())
         self.assertRaises(
             sh.errors.GEOSException, rhpw.polyfill, multi_overlap, 0, False
         )

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -453,7 +453,7 @@ class RhpWrappersTestCase(unittest.TestCase):
             ],
         )
         eq_poly_am = sh.Polygon(
-            shell=[(170, 40), (170, -10), (-170, -10), (-170, 40), (170, 40)]
+            shell=[(130, 40), (130, -10), (-170, -10), (-170, 40), (130, 40)]
         )
 
         # Equatorial polygons and multipolygons without holes

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -515,9 +515,9 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(rhpw.polyfill(sh.MultiPolygon(), 0))
         self.assertIsNone(rhpw.polyfill(sh.Point(), 0))
         self.assertIsNone(rhpw.polyfill(no_area, 0))
+        self.assertIsNone(rhpw.polyfill(multi_overlap, 0, False))
         self.assertEqual(rhpw.polyfill(plane_poly, 1), set())
         self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), set())
-        self.assertEqual(rhpw.polyfill(multi_overlap, 0, False), None)
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -437,7 +437,32 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(kring)
 
     def test_polyfill(self):
-        # Test data
+        # Test data - plane
+        idx = ("N", 2, 1, 6, 0, 5, 5, 6, 1, 1)
+        cell = rhpw.Cell(rdggs=rhpw.WGS84_003, suid=idx)
+        plane_poly = sh.Polygon(cell.vertices())
+
+        # Uncompressed from polygon - plane
+        result = rhpw.polyfill(plane_poly, 10)
+        self.assertEqual(
+            result,
+            [
+                "N2160556110",
+                "N2160556111",
+                "N2160556112",
+                "N2160556113",
+                "N2160556114",
+                "N2160556115",
+                "N2160556116",
+                "N2160556117",
+                "N2160556118",
+            ],
+        )
+
+        # Compressed from polygon - plane
+        self.assertEqual(rhpw.polyfill(plane_poly, 10, compress=True), ["N216055611"])
+
+        # Test data - sphere
         eq_poly_n = sh.Polygon(
             shell=[(-10, -10), (50, -10), (50, 40), (-10, 40), (-10, -10)],
             holes=[
@@ -448,35 +473,41 @@ class RhpWrappersTestCase(unittest.TestCase):
         eq_poly_s = sh.Polygon(
             shell=[(-10, 10), (-10, -40), (50, -40), (50, 10), (-10, 10)],
             holes=[
-                [(-5, -5), (25, -20), (45, -5), (-5, -5)],
-                [(-5, -25), (25, -30), (45, -25), (-5, -25)],
+                [(-5, -5), (45, -5), (25, -20), (-5, -5)],
+                [(-5, -25), (45, -25), (25, -30), (-5, -25)],
             ],
         )
-        eq_poly_am = sh.Polygon(
-            shell=[(130, 40), (130, -10), (-170, -10), (-170, 40), (130, 40)]
+        po_poly_n = sh.Polygon(
+            shell=[(0, 75), (-30, 42), (0, 42), (30, 42), (0, 75)],
+            holes=[[(0, 70), (5, 60), (-5, 60), (0, 70)]],
         )
+        po_poly_s = sh.Polygon(
+            shell=[(30, -42), (0, -75), (90, -75), (60, -42), (30, -42)],
+            holes=[[(10, -70), (20, -65), (10, -65), (10, -70)]],
+        )
+        # eq_poly_am = sh.Polygon(
+        #     shell=[(130, 40), (130, -10), (-170, -10), (-170, 40), (130, 40)]
+        # )  # TODO: hole
 
-        # Equatorial polygons and multipolygons without holes
+        # Polygon tests - sphere
         self.assertEqual(rhpw.polyfill(eq_poly_n, 0, False), ["Q"])
         self.assertEqual(rhpw.polyfill(eq_poly_s, 0, False), ["Q"])
+        self.assertEqual(rhpw.polyfill(po_poly_n, 1, False), ["N2"])
+        self.assertEqual(rhpw.polyfill(po_poly_s, 1, False), ["S7"])
         # self.assertEqual(rhpw.polyfill(eq_poly_am, 0, False), ["R"])
-        self.assertEqual(
-            rhpw.polyfill(sh.MultiPolygon(polygons=[eq_poly_n, eq_poly_s]), 0, False),
-            ["Q"],
-        )  # TODO: add eq_poly_am, add "R" to results list
 
-        # TODO: polar caps
-
-        # TODO: polygon with hole (fold into polar cap section)
-        # TODO: multipolygon with holes (fold into polar cap section)
-
-        # TODO: test cases for higher resolutions?
+        # Multipolygon tests - sphere
+        result = rhpw.polyfill(
+            sh.MultiPolygon(polygons=[eq_poly_n, po_poly_n, po_poly_s]), 1, False
+        )  # TODO: add eq_poly_am, add "R*" to results list
+        self.assertEqual(result, ["N2", "Q1", "Q3", "Q4", "S7"])
 
         # Test data - malformed
         no_area = sh.Polygon(shell=((0, 0), (1, 0), (2, 0), (0, 0)))
         geom_res_mismatch = sh.Polygon(
             shell=[(0, 0), (0, -40), (40, -40), (40, 0), (0, 0)]
         )
+        multi_overlap = sh.MultiPolygon(polygons=[eq_poly_n, eq_poly_s])
 
         # Malformed input geometries
         self.assertIsNone(rhpw.polyfill(None, 0))
@@ -484,7 +515,11 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(rhpw.polyfill(sh.MultiPolygon(), 0))
         self.assertIsNone(rhpw.polyfill(sh.Point(), 0))
         self.assertIsNone(rhpw.polyfill(no_area, 0))
+        self.assertEqual(rhpw.polyfill(plane_poly, 1), [])
         self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), [])
+        self.assertRaises(
+            sh.errors.GEOSException, rhpw.polyfill, multi_overlap, 0, False
+        )
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -446,7 +446,7 @@ class RhpWrappersTestCase(unittest.TestCase):
         result = rhpw.polyfill(plane_poly, 10)
         self.assertEqual(
             result,
-            [
+            {
                 "N2160556110",
                 "N2160556111",
                 "N2160556112",
@@ -456,11 +456,11 @@ class RhpWrappersTestCase(unittest.TestCase):
                 "N2160556116",
                 "N2160556117",
                 "N2160556118",
-            ],
+            },
         )
 
         # Compressed from polygon - plane
-        self.assertEqual(rhpw.polyfill(plane_poly, 10, compress=True), ["N216055611"])
+        self.assertEqual(rhpw.polyfill(plane_poly, 10, compress=True), {"N216055611"})
 
         # Test data - sphere
         eq_poly_n = sh.Polygon(
@@ -490,17 +490,17 @@ class RhpWrappersTestCase(unittest.TestCase):
         # )  # TODO: hole
 
         # Polygon tests - sphere
-        self.assertEqual(rhpw.polyfill(eq_poly_n, 0, False), ["Q"])
-        self.assertEqual(rhpw.polyfill(eq_poly_s, 0, False), ["Q"])
-        self.assertEqual(rhpw.polyfill(po_poly_n, 1, False), ["N2"])
-        self.assertEqual(rhpw.polyfill(po_poly_s, 1, False), ["S7"])
-        # self.assertEqual(rhpw.polyfill(eq_poly_am, 0, False), ["R"])
+        self.assertEqual(rhpw.polyfill(eq_poly_n, 0, False), {"Q"})
+        self.assertEqual(rhpw.polyfill(eq_poly_s, 0, False), {"Q"})
+        self.assertEqual(rhpw.polyfill(po_poly_n, 1, False), {"N2"})
+        self.assertEqual(rhpw.polyfill(po_poly_s, 1, False), {"S7"})
+        # self.assertEqual(rhpw.polyfill(eq_poly_am, 0, False), {"R"})
 
         # Multipolygon tests - sphere
         result = rhpw.polyfill(
             sh.MultiPolygon(polygons=[eq_poly_n, po_poly_n, po_poly_s]), 1, False
         )  # TODO: add eq_poly_am, add "R*" to results list
-        self.assertEqual(result, ["N2", "Q1", "Q3", "Q4", "S7"])
+        self.assertEqual(result, {"N2", "Q1", "Q3", "Q4", "S7"})
 
         # Test data - malformed
         no_area = sh.Polygon(shell=((0, 0), (1, 0), (2, 0), (0, 0)))
@@ -516,8 +516,8 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(rhpw.polyfill(sh.Point(), 0))
         self.assertIsNone(rhpw.polyfill(no_area, 0))
         self.assertIsNone(rhpw.polyfill(multi_overlap, 0, False))
-        self.assertEqual(rhpw.polyfill(plane_poly, 1), [])
-        self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), [])
+        self.assertEqual(rhpw.polyfill(plane_poly, 1), set())
+        self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), set())
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -445,21 +445,17 @@ class RhpWrappersTestCase(unittest.TestCase):
             shell=[(-10, 10), (-10, -40), (50, -40), (50, 10), (-10, 10)]
         )
         eq_poly_am = sh.Polygon(
-            shell=[(130, 10), (130, -40), (-170, -40), (-170, 10), (130, 10)]
+            shell=[(170, 40), (170, -10), (-170, -10), (-170, 40), (170, 40)]
         )
 
         # Equatorial polygons and multipolygons without holes
-        self.assertEqual(rhpw.polyfill(eq_poly_n, 0), ["Q"])
-        self.assertEqual(rhpw.polyfill(eq_poly_s, 0), ["Q"])
-        # self.assertEqual(rhpw.polyfill(eq_poly_am, 0), ["R"])
+        self.assertEqual(rhpw.polyfill(eq_poly_n, 0, False), ["Q"])
+        self.assertEqual(rhpw.polyfill(eq_poly_s, 0, False), ["Q"])
+        # self.assertEqual(rhpw.polyfill(eq_poly_am, 0, False), ["R"])
         self.assertEqual(
-            rhpw.polyfill(sh.MultiPolygon(polygons=[eq_poly_n, eq_poly_s]), 0), ["Q"]
-        )
-        # self.assertEqual(
-        #     rhpw.polyfill(sh.MultiPolygon(polygons=[eq_poly_n, eq_poly_am]), 0)[
-        #         "Q", "R"
-        #     ]
-        # )
+            rhpw.polyfill(sh.MultiPolygon(polygons=[eq_poly_n, eq_poly_s]), 0, False),
+            ["Q"],
+        )  # TODO: add eq_poly_am, add "R" to results list
 
         # TODO: polar caps
 
@@ -469,7 +465,7 @@ class RhpWrappersTestCase(unittest.TestCase):
         # TODO: test cases for higher resolutions?
 
         # Test data - malformed
-        no_area = sh.Polygon(shell=((0, 0), (0, 0), (0, 0), (0, 0)))
+        no_area = sh.Polygon(shell=((0, 0), (1, 0), (2, 0), (0, 0)))
         geom_res_mismatch = sh.Polygon(
             shell=[(0, 0), (0, -40), (40, -40), (40, 0), (0, 0)]
         )
@@ -480,7 +476,7 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(rhpw.polyfill(sh.MultiPolygon(), 0))
         self.assertIsNone(rhpw.polyfill(sh.Point(), 0))
         self.assertIsNone(rhpw.polyfill(no_area, 0))
-        self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0), [])
+        self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), [])
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This branch implements polyfill for shapely Polygon and MultiPolygon geometries as an addition to the wrapper API. Given an input geometry, it extracts the set of cells at the requested resolution where the cell centroid is inside the boundary of one of the polygons.

The wrapper function uses a boolean flag `compress` to call into existing functionality that groups cells that make up a parent cell as the parent if requested. It defaults to False for a single resolution consistent across all cells in the result set.

This update also turns the previously hardcoded dggs instance of WSG84_003 into a parameter defaulting to WGS84_003 in all implemented wrapper functions. The wrapper is now able to accept degrees in radians as a result, because degrees or radians is a setting in the dggs instance.

Prominent features:
- New function polyfill(geometry, res, plane, compress, verbose, dggs)
- Tests for the new function

Not included:
- Linefill
- Handling of the antimeridian in polyfill
- Correct handling of cap cells is not guaranteed as they have at least one documented issue in the backend (s. also https://github.com/manaakiwhenua/rhealpixdggs-py/issues/13)