### PR TITLE
demaion/linetrace

### DIFF
--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -1072,14 +1072,26 @@ class RHEALPixDGGS(object):
 
     def cells_from_line(
         self,
-        res: int,
+        resolution: int,
         lstart: tuple[float, float],
         lend: tuple[float, float],
         plane: bool = True,
     ) -> list[Cell]:
+        """
+        Return a list of the resolution `resolution` cells along an arbitrary line
+        given by two points on the sphere or plane.
+
+        EXAMPLES::
+
+            >>> rdggs = WGS84_003
+            >>> cells = rdggs.cells_from_line(3, (-89.669615, 86.549596), (-134, 86), False)
+            >>> print([str(cell) for cell in cells])
+            ['N448', 'N447']
+
+        """
         # Turn vertex pair into dggs cells
-        start = self.cell_from_point(res, lstart, plane)
-        end = self.cell_from_point(res, lend, plane)
+        start = self.cell_from_point(resolution, lstart, plane)
+        end = self.cell_from_point(resolution, lend, plane)
 
         # Collect cells along path
         line_cells = []

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -376,7 +376,7 @@ class RHEALPixDGGS(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
-    def healpix(self, u, v, inverse=False):
+    def healpix(self, u: float, v: float, inverse: bool = False) -> tuple[float, float]:
         """
         Return the HEALPix projection of point `(u, v)` (or its inverse if
         `inverse` = True) appropriate to this rHEALPix DGGS.
@@ -394,7 +394,9 @@ class RHEALPixDGGS(object):
         f = pw.Projection(ellipsoid=self.ellipsoid, proj="healpix")
         return f(u, v, inverse=inverse)
 
-    def rhealpix(self, u, v, inverse=False, region="none"):
+    def rhealpix(
+        self, u: float, v: float, inverse: bool = False, region: str = "none"
+    ) -> tuple[float, float]:
         """
         Return the rHEALPix projection of the point `(u, v)` (or its inverse if
         `inverse` = True) appropriate to this rHEALPix DGGS.
@@ -418,7 +420,9 @@ class RHEALPixDGGS(object):
         )
         return f(u, v, inverse=inverse)
 
-    def combine_triangles(self, u, v, inverse=False, region="none"):
+    def combine_triangles(
+        self, u: float, v: float, inverse: bool = False, region: str = "none"
+    ) -> tuple[float, float]:
         """
         Return the combine_triangles() transformation of the point `(u, v)`
         (or its inverse if `inverse` = True) appropriate to the underlying
@@ -448,7 +452,7 @@ class RHEALPixDGGS(object):
         # Scale up.
         return tuple(R_A * array((u, v)))
 
-    def triangle(self, x, y, inverse=True):
+    def triangle(self, x: float, y: float, inverse: bool = True) -> tuple[int, str]:
         """
         If `inverse` = False, then assume `(x,y)` lies in the image of the
         HEALPix projection that comes with this DGGS, and
@@ -498,7 +502,9 @@ class RHEALPixDGGS(object):
         # Get triangle.
         return pjr.triangle(x, y, inverse=inverse, north_square=ns, south_square=ss)
 
-    def xyz(self, u, v, lonlat=False):
+    def xyz(
+        self, u: float, v: float, lonlat: bool = False
+    ) -> tuple[float, float, float]:
         """
         Given a point `(u, v)` in the planar image of the rHEALPix projection,
         project it back to the ellipsoid and return its 3D rectangular
@@ -518,7 +524,9 @@ class RHEALPixDGGS(object):
             lam, phi = self.rhealpix(u, v, inverse=True)
         return self.ellipsoid.xyz(lam, phi)
 
-    def xyz_cube(self, u, v, lonlat=False):
+    def xyz_cube(
+        self, u: float, v: float, lonlat: bool = False
+    ) -> tuple[float, float, float]:
         """
         Given a point `(u, v)` in the planar version of this rHEALPix DGGS,
         fold the rHEALPix image into a cube centered at the origin,
@@ -602,7 +610,7 @@ class RHEALPixDGGS(object):
         """
         return Cell(self, suid, level_order_index, post_order_index)
 
-    def grid(self, resolution):
+    def grid(self, resolution: int):
         """
         Generator function for all the cells at resolution `resolution`.
 
@@ -622,7 +630,7 @@ class RHEALPixDGGS(object):
             yield cs
             cs = cs.successor(resolution)
 
-    def num_cells(self, res_1, res_2=None, subcells=False):
+    def num_cells(self, res_1: int, res_2: int = None, subcells: bool = False) -> int:
         """
         Return the number of cells of resolutions `res_1` to `res_2`
         (inclusive).
@@ -660,7 +668,7 @@ class RHEALPixDGGS(object):
             num = int(6 * (k ** (res_2 + 1) - k**res_1) / (k - 1))
         return num
 
-    def cell_width(self, resolution, plane=True):
+    def cell_width(self, resolution: int, plane: bool = True) -> float:
         """
         Return the width of a planar cell at the given resolution.
         If `plane` = False, then return None,
@@ -678,7 +686,7 @@ class RHEALPixDGGS(object):
         if plane:
             return self.ellipsoid.R_A * (pi / 2) * self.N_side ** (-resolution)
 
-    def cell_area(self, resolution, plane=True):
+    def cell_area(self, resolution: int, plane: bool = True) -> float:
         """
         Return the area of a planar or ellipsoidal cell at the given
         resolution.
@@ -726,7 +734,9 @@ class RHEALPixDGGS(object):
             yield cell
             cell = cell.successor(resolution)
 
-    def cell_from_point(self, resolution, p, plane=True):
+    def cell_from_point(
+        self, resolution: int, p: tuple[float, float], plane: bool = True
+    ) -> Cell:
         """
         Return the resolution `resolution` cell that contains the point `p`.
         If `plane` = True, then `p` and the output cell lie in the
@@ -820,7 +830,9 @@ class RHEALPixDGGS(object):
             suid.append(self.child_order[(int(suid_row[i], N), int(suid_col[i], N))])
         return Cell(self, suid)
 
-    def cell_from_region(self, ul, dr, plane=True):
+    def cell_from_region(
+        self, ul: tuple[float, float], dr: tuple[float, float], plane: bool = True
+    ) -> Cell:
         """
         Return the smallest planar or ellipsoidal cell wholly containing
         the region bounded by the axis-aligned rectangle with upper left
@@ -894,7 +906,14 @@ class RHEALPixDGGS(object):
         else:
             return self.cell(ul_suid[:least])
 
-    def cell_latitudes(self, resolution, phi_min, phi_max, nucleus=True, plane=True):
+    def cell_latitudes(
+        self,
+        resolution: int,
+        phi_min: float,
+        phi_max: float,
+        nucleus: bool = True,
+        plane: bool = True,
+    ) -> list[float]:
         """
         Return a list of every latitude phi whose parallel intersects
         a resolution `resolution` cell nucleus and satisfies
@@ -984,7 +1003,9 @@ class RHEALPixDGGS(object):
             result = [self.healpix(R * pi / 4, y, inverse=True)[1] for y in result]
         return result
 
-    def cells_from_meridian(self, resolution, lam, phi_min, phi_max):
+    def cells_from_meridian(
+        self, resolution: int, lam: float, phi_min: float, phi_max: float
+    ) -> list[Cell]:
         """
         Return a list of the resolution `resolution` cells that intersect
         the meridian segment of longitude `lam` whose least latitude is
@@ -1036,7 +1057,9 @@ class RHEALPixDGGS(object):
             result.append(end)
         return result
 
-    def cells_from_parallel(self, resolution, phi, lam_min, lam_max):
+    def cells_from_parallel(
+        self, resolution: int, phi: float, lam_min: float, lam_max: float
+    ) -> list[Cell]:
         """
         Return a list of the resolution `resolution` cells that intersect
         the parallel segment of latitude `phi` whose least longitude is
@@ -1080,6 +1103,15 @@ class RHEALPixDGGS(object):
         """
         Return a list of the resolution `resolution` cells along an arbitrary line
         given by two points on the sphere or plane.
+
+        NOTE:
+
+        Cannot handle cells along a line that crosses the antimeridian.
+
+        TODO:
+
+        Cap cells are not handled correctly. Lines intersecting one of those may not
+        return the correct sequence of cells.
 
         EXAMPLES::
 
@@ -1135,7 +1167,7 @@ class RHEALPixDGGS(object):
                             if line.intersects(edge_line) and nn not in line_cells:
                                 following = nn
 
-                    # Fail safe for strange cases
+                    # Fail safe for strange cases (to make sure the iteration ends)
                     if not following:
                         current = end
                     else:
@@ -1146,7 +1178,13 @@ class RHEALPixDGGS(object):
 
         return line_cells
 
-    def cells_from_region(self, resolution, ul, dr, plane=True):
+    def cells_from_region(
+        self,
+        resolution: int,
+        ul: tuple[float, float],
+        dr: tuple[float, float],
+        plane: bool = True,
+    ) -> list[list[Cell]]:
         """
         If `plane` = True, then return a list of lists of resolution
         `resolution` cells that cover the axis-aligned rectangle whose
@@ -1292,7 +1330,7 @@ class RHEALPixDGGS(object):
             result.append(cells)
         return result
 
-    def random_point(self, plane=True):
+    def random_point(self, plane: bool = True) -> tuple[float, float]:
         """
         Return a point in this DGGS sampled uniformly at
         random from the plane or from the ellipsoid.
@@ -1310,7 +1348,7 @@ class RHEALPixDGGS(object):
         # Pick a random point in that cell.
         return c.random_point(plane=plane)
 
-    def random_cell(self, resolution=None):
+    def random_cell(self, resolution: int = None) -> Cell:
         """
         Return a cell of the given resolution chosen uniformly at random
         from all cells at that resolution.
@@ -1331,7 +1369,9 @@ class RHEALPixDGGS(object):
             suid.append(randint(0, self.N_side**2 - 1))
         return Cell(self, suid)
 
-    def minimal_cover(self, resolution, points, plane=True):
+    def minimal_cover(
+        self, resolution: int, points: list[tuple[float, float]], plane: bool = True
+    ) -> list[Cell]:
         """
         Find the minimal set of resolution `resolution` cells that covers
         the list of points `points`.
@@ -1369,7 +1409,9 @@ class RHEALPixDGGS(object):
         # cover.sort(key=lambda x: (x[2], -x[1]), reverse=True)
         # return [t[0] for t in cover]
 
-    def antimeridian_check_and_flip(self, vertices, plane=True):
+    def antimeridian_check_and_flip(
+        self, vertices: list[tuple[float, float]], plane: bool = True
+    ) -> list[tuple[float, float]]:
         """
         Check for cell vertices on the antimeridian and make sure their sign is
         the same as that of the other vertices.

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from typing import Literal, Union
 from warnings import warn
 from shapely import (

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -747,11 +747,9 @@ def cells_from_line(
             # Wrap points in a shapely linestring
             line = LineString([lstart, lend])
 
-            iterations = 0  # TODO: DEBUG - To enforce end of loop during development
             current = start
             previous = None
-            while current != end and iterations < 100:  # TODO: DEBUG - iteration count
-                iterations = iterations + 1  # TODO: DEBUG
+            while current != end:
                 line_cells.append(current)
 
                 # Grab dictionary of nearest neighbours

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -1,6 +1,15 @@
+import numpy as np
+
 from typing import Literal, Union
 from warnings import warn
-from shapely import Point, Polygon, MultiPolygon, is_valid_reason
+from shapely import (
+    Point,
+    Polygon,
+    MultiPolygon,
+    LineString,
+    MultiLineString,
+    is_valid_reason,
+)
 
 from rhealpixdggs.dggs import RHEALPixDGGS
 from rhealpixdggs.cell import Cell
@@ -9,17 +18,29 @@ from rhealpixdggs.conversion import compress_order_cells
 # ======== Messages and constants ======== #
 
 
-# Pre-defined DGGS with WGS84 ellipsoid, coordinates in degrees and n == 3 to subdivide cell sides
+# Pre-defined DGGS with WGS84 ellipsoid, coordinates in degrees, n == 3 to subdivide
+# cell sides, and both N and S polar cube face attached to O equatorial cube face:
+# N
+# O P Q R
+# S
 from rhealpixdggs.dggs import WGS84_003
 
 # List of resolution 0 cell addresses (i.e. cube faces)
 from rhealpixdggs.cell import CELLS0
 
+# Cell neighbour directions and reverse directions (to detect steps across cube face boundaries)
+NEIGHBOURS = ["right", "down", "left", "up"]
+NEIGHBOUR_INVERSE = {"right": "left", "down": "up", "left": "right", "up": "down"}
+
+# Warnings
 PARENT_RESOLUTION_WARNING = "WARNING: You requested a parent resolution that is higher than the cell resolution. Returning the cell address itself."
 CHILD_RESOLUTION_WARNING = "WARNING: You requested a child resolution that is lower than the cell resolution. Returning the cell address itself."
 CELL_CENTRE_WARNING = "WARNING: You requested a centre cell for a DGGS that has an even number of cells on a side. Returning None."
 CELL_RING_WARNING = "WARNING: Implementation of cell rings is incomplete. Requesting a {0} ring that involves more than two resolution 0 cube faces will return unexpected results."
 POLYFILL_GEOMETRY_WARNING = "WARNING: Empty or missing geometry, unsupported geometry type (not Polygon or MultiPolygon), or geometry with no area. Returning None."
+LINETRACE_GEOMETRY_WARNING = "WARNING: Empty or missing line geometry, unsupported line type (not LineString or MultiLineString), or line with no length. Returning None."
+LINETRACE_WARNING = "WARNING: Implementation of linetrace is incomplete. Requesting linetrace across polar cap cells or the antimeridian may return incorrect results."
+
 
 # ======== Main API ======== #
 
@@ -308,25 +329,16 @@ def cell_ring(
         cell = _mirror_cell_on_cube(cell)
         return [str(cell)]
 
-    # Init the ring and directions
+    # Init the ring
     ring = []
-    directions = ["right", "down", "left", "up"]
 
     # Top-level cells (cube faces) are special
     if len(rhpindex) == 1:
-        for direction in directions:
+        for direction in NEIGHBOURS:
             ring.append(cell.neighbor(direction).suid[0])
 
     # Start in the upper left corner of the ring: it's k times left and k times up
     else:
-        # Mapping to detect direction changes
-        direction_inverse = {
-            "right": "left",
-            "down": "up",
-            "left": "right",
-            "up": "down",
-        }
-
         # Initialise iteration parameters
         k_eff, max_steps, cell = _cell_ring_setup(cell, half_circle / 2, k)
 
@@ -338,11 +350,11 @@ def cell_ring(
         else:
             # Set starting point
             cell, direction, n_steps = _find_cell_ring_start(
-                cell, k_eff, max_steps, directions, direction_inverse
+                cell, k_eff, max_steps, NEIGHBOURS, NEIGHBOUR_INVERSE
             )
 
             # Walk around the ring one side at a time and collect cell addresses
-            for _ in range(0, len(directions)):
+            for _ in range(0, len(NEIGHBOURS)):
                 step = 0
                 while step < n_steps:
                     # Add index to ring, take a step
@@ -350,8 +362,8 @@ def cell_ring(
                     next = cell.neighbor(direction)
 
                     # Looking back not being the same as looking ahead means we need to realign
-                    if next.neighbor(direction_inverse[direction]) != cell:
-                        direction = direction_inverse[_neighbor_direction(next, cell)]
+                    if next.neighbor(NEIGHBOUR_INVERSE[direction]) != cell:
+                        direction = NEIGHBOUR_INVERSE[_neighbor_direction(next, cell)]
 
                     # Take the step
                     cell = next
@@ -359,8 +371,8 @@ def cell_ring(
 
                 # Prepare walking direction for next ring side
                 if n_steps == 2 * k_eff:
-                    direction = directions[
-                        (directions.index(direction) + 1) % len(directions)
+                    direction = NEIGHBOURS[
+                        (NEIGHBOURS.index(direction) + 1) % len(NEIGHBOURS)
                     ]
 
                 # Reset number of steps along a side
@@ -405,7 +417,7 @@ def polyfill(
     dggs: RHEALPixDGGS = WGS84_003,
 ) -> set[str]:
     """
-    Turn the area contained in a shapely polygon or multipolygon into a set of cell
+    Turns the area contained in a shapely polygon or multipolygon into a set of cell
     indices at the requested resolution. A cell index is included if its centroid is
     inside the geometry defined by the boundaries and holes.
 
@@ -472,9 +484,101 @@ def polyfill(
 
 
 def linetrace(
-    geometry, res: int, plane: bool = True, dggs: RHEALPixDGGS = WGS84_003
+    geometry: Union[LineString, MultiLineString],
+    res: int,
+    geo_json: bool = True,
+    plane: bool = True,
+    verbose: bool = False,
+    dggs: RHEALPixDGGS = WGS84_003,
 ) -> list[str]:
-    raise NotImplementedError()
+    """
+    Returns the list of cell indices touched by a shapely linestring or multilinestring
+    at the requested resolution.
+
+    Returns None if the geom_type field in the input geometry is anything other than
+    'LineString' or 'MultiLineString'.
+
+    Returns None if the geometry is empty, or if it has no length.
+
+    Returns None if no cells match the geometry for some reason.
+
+    Returns None if the geometry is invalid in other ways, e.g. if a linestring contains
+    self intersecting segments.
+    """
+    if verbose:
+        warn(LINETRACE_WARNING)
+
+    # Stop early if the line geometry is malformed
+    if _malformed_lines(geometry):
+        if verbose:
+            message = is_valid_reason(geometry)
+            if not message or message == "Valid Geometry":
+                warn(LINETRACE_GEOMETRY_WARNING)
+            else:
+                warn(str.format("WARNING: {0}. Returning None.", message))
+
+        return None
+
+    # Extract list of linestrings from geometry: LineString needs to be wrapped in
+    # one, MultiLineString has it stashed in a property
+    if geometry.geom_type == "LineString":
+        lines = [geometry]
+    else:
+        lines = geometry.geoms
+
+    cells = []
+    for linestring in lines:
+        # Extract coordinate pairs along the line segments
+        coords = zip(linestring.coords, linestring.coords[1:])
+
+        # Walk along line segments
+        while (vertex_pair := next(coords, None)) is not None:
+            # Extract vertex pair defining line segment in (lng, lat) order
+            i, j = vertex_pair
+            if not geo_json:
+                i = i[::-1]
+                j = j[::-1]
+
+            # Turn vertex pair into dggs cells
+            start = dggs.cell_from_point(res, i, plane)
+            end = dggs.cell_from_point(res, j, plane)
+
+            # Collect cells along path
+            if start is not None and end is not None:
+
+                # Special case: resolution is coarse and path is short
+                if start == end:
+                    line_cells = [start]
+
+                # Work your way along the line one cell at a time
+                else:
+                    direction = np.subtract(j, i)
+                    line_cells = []
+
+                    current_cell = start
+                    # while current_cell != end:
+                    #     line_cells.append(current_cell)
+
+                    #     # Next cell is neighbour of current_cell along direction
+                    #     next = _resolve_neighbour_on_line(
+                    #         current_cell, plane, direction, NEIGHBOURS
+                    #     )
+
+                    #     # Fail safe for strange cases
+                    #     if not next:
+                    #         current_cell = end
+                    #     else:
+                    #         current_cell = current_cell.neighbors(plane)[next]
+
+                    line_cells.append(end)
+
+                # Convert cells to string ids and add to collection
+                cells = cells + [str(cell) for cell in line_cells]
+
+        # Remove duplicates along sequence
+        cells = _remove_sequential_duplicates(cells)
+
+    return cells
 
 
 # ======== Helper functions ======== #
@@ -619,6 +723,7 @@ def _malformed_geometry(geometry: Union[Polygon, MultiPolygon]) -> bool:
     if geometry.geom_type != "Polygon" and geometry.geom_type != "MultiPolygon":
         return True
 
+    # This catches e.g. self intersecting hulls and holes, or overlapping polygons
     if not geometry.is_valid:
         return True
 
@@ -627,3 +732,52 @@ def _malformed_geometry(geometry: Union[Polygon, MultiPolygon]) -> bool:
         return True
 
     return False
+
+
+def _malformed_lines(lines: Union[LineString, MultiLineString]) -> bool:
+    # There have to be lines
+    if lines is None or lines.is_empty:
+        return True
+
+    # Lines need to be of the correct type
+    if lines.geom_type != "LineString" and lines.geom_type != "MultiLineString":
+        return True
+
+    if not lines.is_valid:
+        return True
+
+    # Lines need to have a length, i.e. not be collapsed into points
+    if lines.length == 0:
+        return True
+
+    return False
+
+
+def _resolve_neighbour_on_line(
+    cell: Cell, plane: bool, direction: tuple[float, float], neighbour_names: list[str]
+) -> str:
+    # TODO: extract cell boundaries as...something.
+    #       Longitude lines are great circles, latitude lines are not.
+    #       Equatorial cells have longitude lines as 'up' and 'down'
+    #       boundaries and 'left' and 'right' boundaries. Cap cells
+    #       have all boundaries on a latitude line. Dart cells have
+    #       an interesting arrangement of boundaries...
+    verts = cell.vertices(plane)
+
+    # TODO: find edge where line exits the current cell, determine
+    #       value of 'next' - will be string "up", "right", "down"
+    #       or "left"?
+
+
+def _remove_sequential_duplicates(cells: list[str]) -> list[str]:
+    if not cells:
+        return []
+
+    trimmed_cells = []
+    prev = None
+    for cell in cells:
+        if cell != prev:
+            trimmed_cells.append(cell)
+            prev = cell
+
+    return trimmed_cells

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -39,7 +39,6 @@ CELL_CENTRE_WARNING = "WARNING: You requested a centre cell for a DGGS that has 
 CELL_RING_WARNING = "WARNING: Implementation of cell rings is incomplete. Requesting a {0} ring that involves more than two resolution 0 cube faces will return unexpected results."
 POLYFILL_GEOMETRY_WARNING = "WARNING: Empty or missing geometry, unsupported geometry type (not Polygon or MultiPolygon), or geometry with no area. Returning None."
 LINETRACE_GEOMETRY_WARNING = "WARNING: Empty or missing line geometry, unsupported line type (not LineString or MultiLineString), or line with no length. Returning None."
-LINETRACE_WARNING = "WARNING: Implementation of linetrace is incomplete. Requesting linetrace across polar cap cells or the antimeridian may return incorrect results."
 
 
 # ======== Main API ======== #
@@ -493,7 +492,8 @@ def linetrace(
 ) -> list[str]:
     """
     Returns the list of cell indices touched by a shapely linestring or multilinestring
-    at the requested resolution.
+    at the requested resolution. Removes internal sequences of duplicate cells before
+    returning result.
 
     Returns None if the geom_type field in the input geometry is anything other than
     'LineString' or 'MultiLineString'.
@@ -504,10 +504,9 @@ def linetrace(
 
     Returns None if the geometry is invalid in other ways, e.g. if a linestring contains
     self intersecting segments.
-    """
-    if verbose:
-        warn(LINETRACE_WARNING)
 
+    TODO: decide what to do with the antimeridian (if anything)
+    """
     # Stop early if the line geometry is malformed
     if _malformed_lines(geometry):
         if verbose:

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -37,6 +37,7 @@ CELL_CENTRE_WARNING = "WARNING: You requested a centre cell for a DGGS that has 
 CELL_RING_WARNING = "WARNING: Implementation of cell rings is incomplete. Requesting a {0} ring that involves more than two resolution 0 cube faces will return unexpected results."
 POLYFILL_GEOMETRY_WARNING = "WARNING: Empty or missing geometry, unsupported geometry type (not Polygon or MultiPolygon), or geometry with no area. Returning None."
 LINETRACE_GEOMETRY_WARNING = "WARNING: Empty or missing line geometry, unsupported line type (not LineString or MultiLineString), or line with no length. Returning None."
+LINETRACE_WARNING = "WARNING: Implementation of linetrace is incomplete. Lines crossing one of the cap cells may not be converted to the correct sequence of cells."
 
 
 # ======== Main API ======== #
@@ -505,6 +506,9 @@ def linetrace(
 
     TODO: decide what to do with the antimeridian (if anything)
     """
+    if verbose:
+        warn(LINETRACE_WARNING)
+
     # Stop early if the line geometry is malformed
     if _malformed_lines(geometry):
         if verbose:

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -553,19 +553,49 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertEqual(result, ["P874", "P877", "P876", "P873", "P874"])
 
         result = rhpw.linetrace(r_ls, 3, plane=False)
-        # self.assertEqual(result, ["R884", "R887", "R888", "R885", "R884"])
+        self.assertEqual(
+            result, ["R884", "R885", "R888", "R887", "R888", "R885", "R884"]
+        )
 
         # Equatorial faces - multiline string
         result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 3, plane=False)
-        # self.assertEqual(
-        #     result, ["P874", "P877", "P876", "P873", "P874", "R884", "R887", "R885", "R884"]
-        # )
+        self.assertEqual(
+            result,
+            [
+                "P874",
+                "P877",
+                "P876",
+                "P873",
+                "P874",
+                "R884",
+                "R885",
+                "R888",
+                "R887",
+                "R888",
+                "R885",
+                "R884",
+            ],
+        )
 
         # Cap faces - line string
         result = rhpw.linetrace(n_ls, 3, plane=False)
-        # self.assertEqual(result, ["N447", "N444", "N445", "N448", "N447"])
+        self.assertEqual(
+            result,
+            [
+                "N447",
+                "N446",
+                "N443",
+                "N444",
+                "N443",
+                "N446",
+                "N447",
+                "N448",
+                "N445",
+                "N448",
+                "N447",
+            ],
+        )
 
-        # TODO: polar cap standard case (include same cell being touched more than once)
         # TODO: lines crossing cube face boundaries
 
         # Resolution mismatch (coarse resolution, short line segments)

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -573,14 +573,6 @@ class RhpWrappersTestCase(unittest.TestCase):
             ],
         )
 
-        # Cap faces - line string
-        # TODO: this is still wrong - should be "N444", "N445" and not "N444", "N447", "N448", "N445"
-        result = rhpw.linetrace(n_ls, 3, plane=False)
-        self.assertEqual(
-            result,
-            ["N447", "N444", "N447", "N448", "N445", "N448", "N447"],
-        )
-
         # Lines crossing cube face boundaries (not involving cap cells)
         s = gs.WGS84_003.cell(("S", 7))
         e = gs.WGS84_003.cell(("P", 5))
@@ -601,7 +593,26 @@ class RhpWrappersTestCase(unittest.TestCase):
         # Malformed input geometries
         self.assertIsNone(rhpw.linetrace(sh.LineString(), 0))
         self.assertIsNone(rhpw.linetrace(sh.LineString([(1, 1), (1, 1)]), 0))
-        # TODO: invalid geometry (multilinestring with - what? Self intersecting segments?)
+
+    @unittest.expectedFailure
+    def test_linetrace_known_failure(self):
+        n_ls = sh.LineString(
+            [
+                (-134.998756, 86.549596),
+                (-179.141527, 88.504030),
+                (-44.874903, 86.549596),
+                (-89.669615, 86.549596),
+                (-134, 86),
+            ]
+        )
+
+        # Cap faces - line string
+        # TODO: this is still wrong - should be "N444", "N445" and not "N444", "N447", "N448", "N445"
+        result = rhpw.linetrace(n_ls, 3, plane=False)
+        self.assertEqual(
+            result,
+            ["N447", "N444", "N445", "N448", "N447"],
+        )
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -520,6 +520,53 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertEqual(rhpw.polyfill(plane_poly, 1), set())
         self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), set())
 
+    def test_linetrace(self):
+        # Test data
+        p_ls = sh.LineString(
+            [
+                (-14.793092, -37.005372),
+                (-15.621138, -40.323142),
+                (-18.333333, -36.483403),
+                (-14, -37),
+            ]
+        )
+        r_ls = sh.LineString(
+            [
+                (174.793092, -37.005372),
+                (175.621138, -40.323142),
+                (178.333333, -36.483403),
+                (174, -37),
+            ]
+        )
+
+        # Equatorial faces - line string
+        result = rhpw.linetrace(p_ls, 3, plane=False)
+        # self.assertEqual(result, ["P874", "P877", "P873", "P874"])
+
+        result = rhpw.linetrace(r_ls, 3, plane=False)
+        # self.assertEqual(result, ["R884", "R887", "R885", "R884"])
+
+        # Equatorial faces - multiline string
+        result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 3, plane=False)
+        # self.assertEqual(
+        #     result, ["P874", "P877", "P873", "P874", "R884", "R887", "R885", "R884"]
+        # )
+
+        # TODO: polar cap standard case (include same cell being touched more than once)
+        # TODO: lines crossing cube face boundaries
+
+        # Resolution mismatch (coarse resolution, short line segments)
+        result = rhpw.linetrace(p_ls, 2, plane=False)
+        self.assertEqual(result, ["P87"])
+
+        result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 2, plane=False)
+        self.assertEqual(result, ["P87", "R88"])
+
+        # Malformed input geometries
+        self.assertIsNone(rhpw.linetrace(sh.LineString(), 0))
+        self.assertIsNone(rhpw.linetrace(sh.LineString([(1, 1), (1, 1)]), 0))
+        # TODO: invalid geometry (multilinestring with - what? Self intersecting segments?)
+
 
 # ------------------------------------------------------------------------------
 if __name__ == "__main__":

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -574,6 +574,7 @@ class RhpWrappersTestCase(unittest.TestCase):
         )
 
         # Cap faces - line string
+        # TODO: this is still wrong - should be "N444", "N445" and not "N444", "N447", "N448", "N445"
         result = rhpw.linetrace(n_ls, 3, plane=False)
         self.assertEqual(
             result,

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -538,19 +538,32 @@ class RhpWrappersTestCase(unittest.TestCase):
                 (174, -37),
             ]
         )
+        n_ls = sh.LineString(
+            [
+                (-134.998756, 86.549596),
+                (-179.141527, 88.504030),
+                (-44.874903, 86.549596),
+                (-89.669615, 86.549596),
+                (-134, 86),
+            ]
+        )
 
         # Equatorial faces - line string
         result = rhpw.linetrace(p_ls, 3, plane=False)
-        # self.assertEqual(result, ["P874", "P877", "P873", "P874"])
+        self.assertEqual(result, ["P874", "P877", "P876", "P873", "P874"])
 
         result = rhpw.linetrace(r_ls, 3, plane=False)
-        # self.assertEqual(result, ["R884", "R887", "R885", "R884"])
+        # self.assertEqual(result, ["R884", "R887", "R888", "R885", "R884"])
 
         # Equatorial faces - multiline string
         result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 3, plane=False)
         # self.assertEqual(
-        #     result, ["P874", "P877", "P873", "P874", "R884", "R887", "R885", "R884"]
+        #     result, ["P874", "P877", "P876", "P873", "P874", "R884", "R887", "R885", "R884"]
         # )
+
+        # Cap faces - line string
+        result = rhpw.linetrace(n_ls, 3, plane=False)
+        # self.assertEqual(result, ["N447", "N444", "N445", "N448", "N447"])
 
         # TODO: polar cap standard case (include same cell being touched more than once)
         # TODO: lines crossing cube face boundaries
@@ -559,8 +572,10 @@ class RhpWrappersTestCase(unittest.TestCase):
         result = rhpw.linetrace(p_ls, 2, plane=False)
         self.assertEqual(result, ["P87"])
 
-        result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 2, plane=False)
-        self.assertEqual(result, ["P87", "R88"])
+        result = rhpw.linetrace(
+            sh.MultiLineString(lines=[p_ls, r_ls, n_ls]), 2, plane=False
+        )
+        self.assertEqual(result, ["P87", "R88", "N44"])
 
         # Malformed input geometries
         self.assertIsNone(rhpw.linetrace(sh.LineString(), 0))

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -553,25 +553,25 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertEqual(result, ["P874", "P877", "P876", "P873", "P874"])
 
         result = rhpw.linetrace(r_ls, 3, plane=False)
-        self.assertEqual(result, ["R884", "R887", "R888", "R885", "R884"])
+        self.assertEqual(result, ["R884", "R887", "R885", "R884"])
 
         # Equatorial faces - multiline string
-        result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 3, plane=False)
-        self.assertEqual(
-            result,
-            [
-                "P874",
-                "P877",
-                "P876",
-                "P873",
-                "P874",
-                "R884",
-                "R887",
-                "R888",
-                "R885",
-                "R884",
-            ],
-        )
+        # result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 3, plane=False)
+        # self.assertEqual(
+        #     result,
+        #     [
+        #         "P874",
+        #         "P877",
+        #         "P876",
+        #         "P873",
+        #         "P874",
+        #         "R884",
+        #         "R887",
+        #         "R888",
+        #         "R885",
+        #         "R884",
+        #     ],
+        # )
 
         # Cap faces - line string
         result = rhpw.linetrace(n_ls, 3, plane=False)
@@ -581,12 +581,12 @@ class RhpWrappersTestCase(unittest.TestCase):
         )
 
         # Lines crossing cube face boundaries
-        s = gs.WGS84_003.cell(("N", 5))
+        s = gs.WGS84_003.cell(("S", 4))
         e = gs.WGS84_003.cell(("P", 4))
         result = rhpw.linetrace(
             sh.LineString([s.centroid(False), e.centroid(False)]), 1, plane=False
         )
-        self.assertEqual(result, ["N5", "P1", "P4"])
+        self.assertEqual(result, ["S4", "S5", "P7", "P4"])
 
         # Resolution mismatch (coarse resolution, short line segments)
         result = rhpw.linetrace(p_ls, 2, plane=False)

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -553,40 +553,40 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertEqual(result, ["P874", "P877", "P876", "P873", "P874"])
 
         result = rhpw.linetrace(r_ls, 3, plane=False)
-        self.assertEqual(result, ["R884", "R887", "R885", "R884"])
+        self.assertEqual(result, ["R884", "R887", "R888", "R885", "R884"])
 
         # Equatorial faces - multiline string
-        # result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 3, plane=False)
-        # self.assertEqual(
-        #     result,
-        #     [
-        #         "P874",
-        #         "P877",
-        #         "P876",
-        #         "P873",
-        #         "P874",
-        #         "R884",
-        #         "R887",
-        #         "R888",
-        #         "R885",
-        #         "R884",
-        #     ],
-        # )
+        result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 3, plane=False)
+        self.assertEqual(
+            result,
+            [
+                "P874",
+                "P877",
+                "P876",
+                "P873",
+                "P874",
+                "R884",
+                "R887",
+                "R888",
+                "R885",
+                "R884",
+            ],
+        )
 
         # Cap faces - line string
         result = rhpw.linetrace(n_ls, 3, plane=False)
         self.assertEqual(
             result,
-            ["N447", "N444", "N445", "N448", "N447"],
+            ["N447", "N444", "N447", "N448", "N445", "N448", "N447"],
         )
 
-        # Lines crossing cube face boundaries
-        s = gs.WGS84_003.cell(("S", 4))
-        e = gs.WGS84_003.cell(("P", 4))
+        # Lines crossing cube face boundaries (not involving cap cells)
+        s = gs.WGS84_003.cell(("S", 7))
+        e = gs.WGS84_003.cell(("P", 5))
         result = rhpw.linetrace(
             sh.LineString([s.centroid(False), e.centroid(False)]), 1, plane=False
         )
-        self.assertEqual(result, ["S4", "S5", "P7", "P4"])
+        self.assertEqual(result, ["S7", "S8", "P8", "P5"])
 
         # Resolution mismatch (coarse resolution, short line segments)
         result = rhpw.linetrace(p_ls, 2, plane=False)

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -553,9 +553,7 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertEqual(result, ["P874", "P877", "P876", "P873", "P874"])
 
         result = rhpw.linetrace(r_ls, 3, plane=False)
-        self.assertEqual(
-            result, ["R884", "R885", "R888", "R887", "R888", "R885", "R884"]
-        )
+        self.assertEqual(result, ["R884", "R887", "R888", "R885", "R884"])
 
         # Equatorial faces - multiline string
         result = rhpw.linetrace(sh.MultiLineString(lines=[p_ls, r_ls]), 3, plane=False)
@@ -568,8 +566,6 @@ class RhpWrappersTestCase(unittest.TestCase):
                 "P873",
                 "P874",
                 "R884",
-                "R885",
-                "R888",
                 "R887",
                 "R888",
                 "R885",
@@ -581,22 +577,16 @@ class RhpWrappersTestCase(unittest.TestCase):
         result = rhpw.linetrace(n_ls, 3, plane=False)
         self.assertEqual(
             result,
-            [
-                "N447",
-                "N446",
-                "N443",
-                "N444",
-                "N443",
-                "N446",
-                "N447",
-                "N448",
-                "N445",
-                "N448",
-                "N447",
-            ],
+            ["N447", "N444", "N445", "N448", "N447"],
         )
 
-        # TODO: lines crossing cube face boundaries
+        # Lines crossing cube face boundaries
+        s = gs.WGS84_003.cell(("N", 5))
+        e = gs.WGS84_003.cell(("P", 4))
+        result = rhpw.linetrace(
+            sh.LineString([s.centroid(False), e.centroid(False)]), 1, plane=False
+        )
+        self.assertEqual(result, ["N5", "P1", "P4"])
 
         # Resolution mismatch (coarse resolution, short line segments)
         result = rhpw.linetrace(p_ls, 2, plane=False)


### PR DESCRIPTION
Added function `linetrace` to the wrapper API and function `cells_from_line` to class `RHEALPixDGGS`.

Function `cells_from_line` does the heavy lifting of collecting the cells (at the requested resolution) that lie along an arbitrary line defined by two end points. It resolves the cells corresponding to those end points first, then work its way along one neighbour cell at a time by examining which cell edge the line crosses next.

Function `linetrace` in the wrapper accepts `shapely` geometries `LineString` and `MultiLineString` for indexing at a requested resolution. It breaks them down into individual line segments and feeds each of those to `cells_from_line`, aggregating the results in a list of cell indices.

Not implemented:

Separate tests for function `cells_from_line`. All tests at present relate to `linetrace` from the wrapper API.

Known issues:

Implementation of `cells_from_line` is incomplete. It finds the correct path along cells and across cube faces, but only if there's no cap cell involved. Lines traversing or starting/ending in a cap cell _may_ find the correct neighbour cell to continue to, but there's no guarantee. It's best to avoid having a line intersect with a cap cell (e.g. by increasing the resolution) until those bugs have been fixed.

Just like with `polyfill`, the new features can't handle lines that cross the antimeridian. Cell vertices that touch it are resolved correctly in most cases when checking whether an edge intersects the line, however. (But see above under 'cap cells'...)