### PR TITLE
Refine packaging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,14 +36,14 @@ This package is available on PyPI, the Python Package Index from where it can be
 
 rHEALPixDGGS is also available for download from the github repository `<https://github.com/manaakiwhenua/rhealpixdggs-py>`_ from where the latest version can be cloned.
 
-You can install from source using setuptools in a virtual environment (MacOS and Linux):
+You can install from source using Poetry in a virtual environment (MacOS and Linux, assuming Poetry is already installed on your system):
 
 ::
 
     python3 -m venv rhealpixdggs
     source rhealpixdggs/bin/activate
-    python -m pip install --upgrade pip setuptools
-    python setup.py install
+    python install --upgrade pip
+    poetry install
 
 Or on Windows:
 
@@ -51,19 +51,16 @@ Or on Windows:
 
     python3 -m venv rhealpixdggs
     rhealpixdggs\Scripts\activate
-    python -m pip install --upgrade pip setuptools
-    python setup.py install
+    python install --upgrade pip
+    poetry install
 
 
 For development:
 
 ::
-    python setup.py develop
+    poetry shell
+    poetry install
 
-Or:
-
-::
-    pip install -e .
 
 Tests
 ------
@@ -110,19 +107,18 @@ For PyPI:
 
 ::
     # Build the distribution (.tar.gz and .whl)
-    pip install build twine
-    python -m build
+    poetry build
 
     # Upload to PyPI (test)
-    twine upload --repository testpypi dist/rhealpixdggs-{version}.*
+    poetry publish --repository testpypi
 
     # Test install from testpypi
     pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple rhealpixdggs
 
     # Upload to PyPI
-    twine upload dist/*
+    poetry publish
 
-A conda package `rhealpixdggs` is maintained at [conda-forge](https://github.com/conda-forge/rhealpixdggs-feedstock).
+A **conda package** `rhealpixdggs` is also maintained at [conda-forge](https://github.com/conda-forge/rhealpixdggs-feedstock).
 
 
 Contact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "rHEALPixDGGS"
-version = "0.5.10"
+version = "0.5.11"
 description = "An implementation of the rHEALPix discrete global grid system"
 authors = [
     { name = "Alexander Raichev", email = "alex@raichev.net" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61", "wheel"]
-build-backend = "setuptools.build_meta"
- 
+requires = ["poetry-core>=2.0.0,<3.0.0"]
+build-backend = "poetry.core.masonry.api"
+
 [project]
 name = "rHEALPixDGGS"
-version = "0.5.9"
+version = "0.5.10"
 description = "An implementation of the rHEALPix discrete global grid system"
 authors = [
     { name = "Alexander Raichev", email = "alex@raichev.net" }
@@ -55,9 +55,6 @@ dev = [
     "sphinx>=7.2"
 ]
 
-[tool.setuptools]
-packages = ["rhealpixdggs"]
+[tool.poetry]
+include = ["tests/","docs/"]
 
-## include tests in install data
-[tool.setuptools.package-data]
-'*' = ["tests/**/*"]


### PR DESCRIPTION
Hello Richard,

I've been attempting to refine the conda packaging.  Not an efficient process this time around, but maybe the next.

There are are new pull requests for you on the `rhealpixdggs` and `rhppandas` repos which switch the build backend from setuptools to poetry.  This shouldn't change any workflow but does make for a better defined pyproject.toml with respect to test data files (setuptools documentation is mind bending).  This also lead to an update of recipes at `ddgs-staged-recipes`.  

Building and testing python and conda packages after these change works locally, but new submissions of rehealpixdggs and rhppandas to PyPI are needed to build with the conda-forge bots.

I've added to the point version of rhealpixdggs and rhppandas in anticipation of a new deployment to PyPI.

Hopefully this does the trick.

 - Alan
