### PR TITLE
closes #35

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+0.5.14
+^^^^^^
+Added ``compact_cells`` to ``conversion``: takes a single-resolution iterable of
+cell IDs and returns a fully compacted ``set``, recursing until no further merges
+are possible. Added ``recursive`` keyword argument to ``compress_order_cells``
+(default ``False``) for the same behaviour with sorted-list output. Updated
+``polyfill`` to use ``compact_cells`` when ``compress=True``.
+
 0.5.13
 ^^^^^^
 Normalise floats and correct return types (rhp_wrappers).

--- a/rhealpixdggs/conversion.py
+++ b/rhealpixdggs/conversion.py
@@ -2,6 +2,7 @@ from shapely.geometry import Polygon, Point
 from rhealpixdggs.dggs import RHEALPixDGGS, WGS84_003
 from rhealpixdggs.cell import Cell
 from itertools import compress
+from collections.abc import Iterable
 
 
 def get_finest_containing_cell(
@@ -111,9 +112,14 @@ class CellZoneFromPoly:
             self.cells_list.append(cell)
 
 
-def compress_order_cells(cells: list[str]) -> list[str]:
+def compress_order_cells(cells: list[str], recursive: bool = False) -> list[str]:
     """
-    Compresses and sorts a set of cells
+    Compress and sort a collection of cells.
+
+    Each complete group of 9 siblings is replaced by their parent cell.
+    By default only one level of compression is performed. Pass
+    ``recursive=True`` to repeat until no further compression is possible.
+    The result is always deduplicated and sorted alphanumerically.
     """
     import re
 
@@ -122,14 +128,62 @@ def compress_order_cells(cells: list[str]) -> list[str]:
         alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
         return sorted(lst, key=alphanum_key)
 
-    cells = set(cells)
-    upper_cells = {}
-    for cell in cells:
-        upper_cells.setdefault(cell[:-1], []).append(cell)
-    compressed_cells = []
-    for k, v in upper_cells.items():
-        if len(v) == 9:
-            compressed_cells.append(k)
-        else:
-            compressed_cells.extend(v)
-    return alphanum_sort(compressed_cells)
+    def _compress_once(cell_set: set[str]) -> set[str]:
+        upper_cells: dict[str, list[str]] = {}
+        for cell in cell_set:
+            upper_cells.setdefault(cell[:-1], []).append(cell)
+        result: set[str] = set()
+        for k, v in upper_cells.items():
+            if len(v) == 9:
+                result.add(k)
+            else:
+                result.update(v)
+        return result
+
+    cell_set = set(cells)
+    if recursive:
+        while True:
+            next_set = _compress_once(cell_set)
+            if next_set == cell_set:
+                break
+            cell_set = next_set
+    else:
+        cell_set = _compress_once(cell_set)
+    return alphanum_sort(list(cell_set))
+
+
+def compact_cells(cells: Iterable[str]) -> set[str]:
+    """
+    Compact a set of rHEALPix DGGS cells by repeatedly merging complete groups
+    of 9 siblings into their parent until no further merging is possible.
+
+    All input cells must be at the same resolution (equal string length).
+    Raises ValueError if the input contains cells at mixed resolutions.
+    Returns a set; if the caller needs ordering, sort the result separately.
+    """
+    cell_set = set(cells)
+    if not cell_set:
+        return cell_set
+
+    lengths = {len(c) for c in cell_set}
+    if len(lengths) > 1:
+        raise ValueError(
+            f"All input cells must be at the same resolution; "
+            f"got cells with string lengths {sorted(lengths)}"
+        )
+
+    while True:
+        upper: dict[str, list[str]] = {}
+        for cell in cell_set:
+            upper.setdefault(cell[:-1], []).append(cell)
+
+        next_set: set[str] = set()
+        for parent, children in upper.items():
+            if len(children) == 9:
+                next_set.add(parent)
+            else:
+                next_set.update(children)
+
+        if next_set == cell_set:
+            return cell_set
+        cell_set = next_set

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -5,7 +5,7 @@ from shapely.geometry import Point, Polygon, MultiPolygon, LineString, MultiLine
 
 from rhealpixdggs.dggs import RHEALPixDGGS
 from rhealpixdggs.cell import Cell
-from rhealpixdggs.conversion import compress_order_cells
+from rhealpixdggs.conversion import compact_cells
 
 # ======== Messages and constants ======== #
 
@@ -547,6 +547,25 @@ def polyfill(
         ['Q33303', 'Q33304', 'Q33305', 'Q33306', 'Q33307', 'Q33308', 'Q33330', 'Q33331', 'Q33332']
         >>> sorted(polyfill(polygon, res=6, plane=False))
         ['Q333033', 'Q333034', 'Q333035', 'Q333036', 'Q333037', 'Q333038', 'Q333043', 'Q333044', 'Q333045', 'Q333046', 'Q333047', 'Q333048', 'Q333053', 'Q333054', 'Q333056', 'Q333057', 'Q333060', 'Q333061', 'Q333062', 'Q333063', 'Q333064', 'Q333065', 'Q333066', 'Q333067', 'Q333068', 'Q333070', 'Q333071', 'Q333072', 'Q333073', 'Q333074', 'Q333075', 'Q333076', 'Q333077', 'Q333078', 'Q333080', 'Q333081', 'Q333083', 'Q333084', 'Q333086', 'Q333087', 'Q333300', 'Q333301', 'Q333302', 'Q333303', 'Q333304', 'Q333305', 'Q333306', 'Q333307', 'Q333308', 'Q333310', 'Q333311', 'Q333312', 'Q333313', 'Q333314', 'Q333315', 'Q333316', 'Q333317', 'Q333318', 'Q333320', 'Q333321', 'Q333323', 'Q333324', 'Q333326', 'Q333327', 'Q333330', 'Q333331', 'Q333332', 'Q333333', 'Q333334', 'Q333335', 'Q333340', 'Q333341', 'Q333342', 'Q333343', 'Q333344', 'Q333345', 'Q333350', 'Q333351', 'Q333353', 'Q333354']
+
+        Four of those res-6 groups have all 9 siblings present (Q33306x, Q33307x,
+        Q33330x, Q33331x), so compress=True collapses them one level to res-5 parents.
+        The remaining partial groups stay at res-6, giving a mixed-resolution result:
+
+        >>> sorted(c for c in polyfill(polygon, res=6, plane=False, compress=True) if len(c) < 7)
+        ['Q33306', 'Q33307', 'Q33330', 'Q33331']
+
+        At res=7 the same four cells are again fully covered (all 81 of each cell's
+        res-7 grandchildren fall inside the polygon), so compaction runs two levels:
+        res-7 siblings collapse to res-6 parents, those in turn collapse to res-5:
+
+        >>> result7 = polyfill(polygon, res=7, plane=False, compress=True)
+        >>> 'Q33306' in result7  # res-5 cell present despite res=7 request
+        True
+        >>> 'Q333060' not in result7  # intermediate res-6 cell absorbed
+        True
+        >>> 'Q3330600' not in result7  # original res-7 cell absorbed
+        True
     """
     # Stop early if the geometry is malformed
     if _malformed_geometry(geometry):
@@ -590,7 +609,7 @@ def polyfill(
 
     # Merge cells inside polygon into larger ones where possible
     if compress:
-        cells = set(compress_order_cells(cells))
+        cells = compact_cells(cells)
 
     return cells
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -591,5 +591,58 @@ class ConversionUtilsTestCase(unittest.TestCase):
         assert compress_order_cells(equal_length_in) == equal_length_expected
 
 
+class TestCompactCells(unittest.TestCase):
+    def test_full_siblings_compact_to_parent(self):
+        cells = [f"R{n}" for n in range(9)]
+        assert compact_cells(cells) == {"R"}
+
+    def test_partial_siblings_stay(self):
+        cells = [f"R{n}" for n in range(8)]  # missing R8
+        assert compact_cells(cells) == set(cells)
+
+    def test_duplicate_input_treated_as_set(self):
+        cells = [f"R{n}" for n in range(9)] * 2
+        assert compact_cells(cells) == {"R"}
+
+    def test_multi_level_compaction(self):
+        # R0 through R8 at res-1 → R at res-0; then nothing further
+        cells = [f"R{n}" for n in range(9)]
+        assert compact_cells(cells) == {"R"}
+
+    def test_recursive_compaction(self):
+        # R00-R08 and R10-R18 are two complete sibling groups → compact to R0 and R1,
+        # but R0+R1 alone don't fill R (only 2 of 9 children present)
+        cells = [f"R0{n}" for n in range(9)] + [f"R1{n}" for n in range(9)]
+        assert compact_cells(cells) == {"R0", "R1"}
+
+        # Full 9 children of R0 at res-2: compact to R0 at res-1
+        cells_r0 = [f"R0{n}" for n in range(9)]
+        assert compact_cells(cells_r0) == {"R0"}
+
+    def test_multi_level_recursive_compaction(self):
+        # 81 res-2 cells that cover all of R0..R8 → should compact all the way to R
+        cells = [f"R{i}{j}" for i in range(9) for j in range(9)]
+        assert compact_cells(cells) == {"R"}
+
+    def test_mixed_resolution_raises(self):
+        with self.assertRaises(ValueError):
+            compact_cells(["R0", "R10"])
+
+    def test_empty_input(self):
+        assert compact_cells([]) == set()
+
+    def test_returns_set(self):
+        result = compact_cells([f"R{n}" for n in range(9)])
+        assert isinstance(result, set)
+
+    def test_partial_compaction_mixed_output(self):
+        # R00..R08 compact to R0; R10..R17 (8 cells) stay
+        cells = [f"R0{n}" for n in range(9)] + [f"R1{n}" for n in range(8)]
+        result = compact_cells(cells)
+        assert "R0" in result
+        assert all(f"R1{n}" in result for n in range(8))
+        assert "R1" not in result
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Addresses #35 while maintaining backwards compatibility. Changes are tested (both unit- and doc-tests).