### PR TITLE
Cache projection objects and ellipsoidal_shape to improve boundary() performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,9 @@ Performance improvements (issue #7): ``RHEALPixDGGS.healpix()`` and
 construction cost is paid only once per DGGS instance per region.
 ``Cell.ellipsoidal_shape`` is computed once per ``Cell`` instance and cached,
 eliminating repeated work in ``vertices()``, ``boundary()``, ``neighbors()``,
-and other hot paths.
+and other hot paths. ``Cell.boundary(plane=False)`` now short-circuits to
+``vertices()`` for quad and cap cells, whose edges are already well-represented
+by their four vertices on the ellipsoid.
 
 0.5.16
 ^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,16 @@
+0.6.0
+^^^^^
+**Breaking change:** ``Cell.ellipsoidal_shape`` is now a ``cached_property``
+instead of a method. Replace any calls to ``cell.ellipsoidal_shape()`` with
+``cell.ellipsoidal_shape``.
+
+Performance improvements (issue #7): ``RHEALPixDGGS.healpix()`` and
+``RHEALPixDGGS.rhealpix()`` now cache their ``Projection`` objects so the
+construction cost is paid only once per DGGS instance per region.
+``Cell.ellipsoidal_shape`` is computed once per ``Cell`` instance and cached,
+eliminating repeated work in ``vertices()``, ``boundary()``, ``neighbors()``,
+and other hot paths.
+
 0.5.16
 ^^^^^^
 Added ``RHEALPixDGGS.area_error_budget()``: returns the theoretical equal cell

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -274,7 +274,7 @@ Compute the ellipsoidal shape and ellipsoidal nuclei of these cells ::
     ...    ]]
     >>> for i, row in enumerate(cells):
     ...     for j, cell in enumerate(row):
-    ...         print(cell, cell.ellipsoidal_shape(), assert_allclose(cell.nucleus(plane=False), expected_results[i][j], rtol=1e-15, atol=0) == None)
+    ...         print(cell, cell.ellipsoidal_shape, assert_allclose(cell.nucleus(plane=False), expected_results[i][j], rtol=1e-15, atol=0) == None)
     N2 dart True
     N1 skew_quad True
     N0 dart True

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -5,7 +5,7 @@ from scipy import integrate
 from itertools import product
 from random import uniform
 from colorsys import hsv_to_rgb
-from functools import total_ordering
+from functools import total_ordering, cached_property
 
 # Level 0 cell IDs, which are anomalous.
 CELLS0 = ["N", "O", "P", "Q", "R", "S"]
@@ -586,7 +586,7 @@ class Cell(object):
 
         """
         v = self.vertices(plane=True)  # Planar vertices.
-        shape = self.ellipsoidal_shape()
+        shape = self.ellipsoidal_shape
         if shape == "quad" or shape == "cap":
             # Northwest vertex is the upper left vertex.
             result = v[0]
@@ -723,7 +723,7 @@ class Cell(object):
             result = [
                 self.rdggs.rhealpix(*p, inverse=True, region=region) for p in result
             ]
-            if trim_dart and self.ellipsoidal_shape() == "dart":
+            if trim_dart and self.ellipsoidal_shape == "dart":
                 # Remove non-vertex point.
                 if self.region() == "north_polar":
                     result.pop(2)
@@ -764,6 +764,12 @@ class Cell(object):
         If `n` = 2, then the output is the same as vertices().
         If `interior` = True, then push the boundary points slighly into the
         interior of the cell, which is convenient for some graphics methods.
+
+        When `plane` = False, the cost scales with `n` because each point
+        requires an inverse projection call. For quad and cap cells the cell
+        edges are already well-represented by their vertices, so callers can
+        use ``cell.ellipsoidal_shape`` to avoid the overhead and fall back
+        to ``vertices(plane=False)`` for those shapes.
 
         EXAMPLES::
 
@@ -922,7 +928,7 @@ class Cell(object):
             False
 
         """
-        if self.ellipsoidal_shape() == "cap":
+        if self.ellipsoidal_shape == "cap":
             return True
         # Not a cap cell.
         vertices = self.vertices(plane=False)
@@ -948,7 +954,7 @@ class Cell(object):
         vertices = self.vertices(plane=False)
         lat_min = min([v[1] for v in vertices])
         lat_max = max([v[1] for v in vertices])
-        if self.ellipsoidal_shape() == "cap":
+        if self.ellipsoidal_shape == "cap":
             if self.region() == "north_polar":
                 return phi >= lat_min
             else:
@@ -1005,6 +1011,7 @@ class Cell(object):
         else:
             return "equatorial"
 
+    @cached_property
     def ellipsoidal_shape(self):
         """
         Return the shape of this cell ('quad', 'cap', 'dart', or
@@ -1014,9 +1021,9 @@ class Cell(object):
 
             >>> from rhealpixdggs.dggs import RHEALPixDGGS
             >>> rdggs = RHEALPixDGGS()
-            >>> print(Cell(rdggs, ['P', 2]).ellipsoidal_shape())
+            >>> print(Cell(rdggs, ['P', 2]).ellipsoidal_shape)
             quad
-            >>> print(Cell(rdggs, ['N', 2]).ellipsoidal_shape())
+            >>> print(Cell(rdggs, ['N', 2]).ellipsoidal_shape)
             dart
 
         """
@@ -1081,7 +1088,7 @@ class Cell(object):
         # So we have to do some work.
         nucleus = self.nucleus(plane=False)
         vertices = self.vertices(plane=False)
-        shape = self.ellipsoidal_shape()
+        shape = self.ellipsoidal_shape
         if shape == "cap":
             return nucleus
         if shape == "quad":
@@ -1370,7 +1377,7 @@ class Cell(object):
             return plane_neighbors
         # Ellipsoid case.
         result = dict()
-        shape = self.ellipsoidal_shape()
+        shape = self.ellipsoidal_shape
         if shape == "quad":
             result["north"] = plane_neighbors["up"]
             result["south"] = plane_neighbors["down"]
@@ -1468,7 +1475,7 @@ class Cell(object):
         if plane:
             return uniform(u_min, u_max), uniform(v_min, v_max)
         else:
-            if self.ellipsoidal_shape() == "cap":
+            if self.ellipsoidal_shape == "cap":
                 # Need to adjust extremes.
                 PI = self.ellipsoid.pi()
                 u_max = PI

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -802,6 +802,11 @@ class Cell(object):
             (157.49999999999997, 58.41366190347208)
 
         """
+        # Quad and cap cells have straight or rotationally-symmetric edges on
+        # the ellipsoid, so extra boundary points add no accuracy. Fall back to
+        # vertices() and avoid the per-point projection cost entirely.
+        if not plane and self.ellipsoidal_shape in ("quad", "cap"):
+            return self.vertices(plane=False)
         ul = self.ul_vertex(plane=True)
         w = self.width(plane=True)
         if n < 2:

--- a/rhealpixdggs/conversion.py
+++ b/rhealpixdggs/conversion.py
@@ -16,7 +16,7 @@ def get_finest_containing_cell(
         # Cap cells span all longitudes at the pole, so their boundary cannot
         # be represented as a simple polygon in geographic coordinates.
         # Project both sides to the rHEALPix plane and test containment there.
-        if cell.ellipsoidal_shape() == "cap":
+        if cell.ellipsoidal_shape == "cap":
             plane_cell = Polygon(cell.vertices(plane=True))
             # MultiPolygon has no .exterior; check each part individually.
             parts = list(poly.geoms) if hasattr(poly, "geoms") else [poly]

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -234,6 +234,7 @@ class RHEALPixDGGS(object):
         )
 
         self.ellipsoid = ellipsoid
+        self._projection_cache: dict[str, object] = {}
 
         # Dictionary of the ordering (Morton order) of child cells of a cell
         # in terms of the row-column coordinates in the matrix of child cells.
@@ -391,8 +392,11 @@ class RHEALPixDGGS(object):
 
         Uses ``pj_healpix`` instead of the PROJ.4 version of HEALPix.
         """
-        f = pw.Projection(ellipsoid=self.ellipsoid, proj="healpix")
-        return f(u, v, inverse=inverse)
+        if "healpix" not in self._projection_cache:
+            self._projection_cache["healpix"] = pw.Projection(
+                ellipsoid=self.ellipsoid, proj="healpix"
+            )
+        return self._projection_cache["healpix"](u, v, inverse=inverse)
 
     def rhealpix(
         self, u: float, v: float, inverse: bool = False, region: str = "none"
@@ -411,14 +415,15 @@ class RHEALPixDGGS(object):
 
         Uses ``pj_rhealpix`` instead of the PROJ.4 version of rHEALPix.
         """
-        f = pw.Projection(
-            ellipsoid=self.ellipsoid,
-            proj="rhealpix",
-            north_square=self.north_square,
-            south_square=self.south_square,
-            region=region,
-        )
-        return f(u, v, inverse=inverse)
+        if region not in self._projection_cache:
+            self._projection_cache[region] = pw.Projection(
+                ellipsoid=self.ellipsoid,
+                proj="rhealpix",
+                north_square=self.north_square,
+                south_square=self.south_square,
+                region=region,
+            )
+        return self._projection_cache[region](u, v, inverse=inverse)
 
     def combine_triangles(
         self, u: float, v: float, inverse: bool = False, region: str = "none"
@@ -1098,7 +1103,7 @@ class RHEALPixDGGS(object):
         for phi in reversed(phis):
             c = self.cell_from_point(resolution, (lam, phi), plane=False)
             new_cells = [c]
-            if c.ellipsoidal_shape() in ["dart", "skew_quad"]:
+            if c.ellipsoidal_shape in ["dart", "skew_quad"]:
                 # Either the east or the west neighbor of c
                 # might also intersect the meridian.
                 # So include the neighbor too.
@@ -1139,7 +1144,7 @@ class RHEALPixDGGS(object):
         end = self.cell_from_point(resolution, (lam_max, phi), plane=False)
         PI = self.ellipsoid.pi()
         if start == end:
-            if start.ellipsoidal_shape() == "cap" or lam_max - lam_min < PI / 2:
+            if start.ellipsoidal_shape == "cap" or lam_max - lam_min < PI / 2:
                 return [start]
             else:
                 # Need to wrap all the way around globe.

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -512,25 +512,25 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         for rdggs in [WGS84_123, WGS84_123_RADIANS]:
             for s in CELLS0[1:5]:
                 X = rdggs.cell([s])
-                self.assertEqual(X.ellipsoidal_shape(), "quad")
+                self.assertEqual(X.ellipsoidal_shape, "quad")
             for s in [CELLS0[0], CELLS0[5]]:
                 for t in [[], [4], [4, 4]]:
                     u = [s] + t
                     X = rdggs.cell(u)
-                    self.assertEqual(X.ellipsoidal_shape(), "cap")
+                    self.assertEqual(X.ellipsoidal_shape, "cap")
                 for t in [[4, 0, 8], [0], [4, 4, 4, 4, 6], [2, 4]]:
                     u = [s] + t
                     X = rdggs.cell(u)
-                    self.assertEqual(X.ellipsoidal_shape(), "dart")
+                    self.assertEqual(X.ellipsoidal_shape, "dart")
                 for t in [[4, 1, 8], [1], [4, 6, 5], [2, 3]]:
                     u = [s] + t
                     X = rdggs.cell(u)
-                    self.assertEqual(X.ellipsoidal_shape(), "skew_quad")
+                    self.assertEqual(X.ellipsoidal_shape, "skew_quad")
         rdggs = WGS84_122
         cell_n = rdggs.cell((CELLS0[0],))
         cell_s = rdggs.cell((CELLS0[5],))
-        self.assertEqual(cell_n.ellipsoidal_shape(), "cap")
-        self.assertEqual(cell_s.ellipsoidal_shape(), "cap")
+        self.assertEqual(cell_n.ellipsoidal_shape, "cap")
+        self.assertEqual(cell_s.ellipsoidal_shape, "cap")
 
     def test_centroid(self):
         # Warning: This test is slow.
@@ -562,7 +562,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         #     lam_bar_err = sqrt(sample_var[0]/N) # Approximately
         #     phi_bar_err = sqrt(sample_var[1]/N) # Approximately
         #     PI = cell.rdggs.ellipsoid.pi()
-        #     if cell.ellipsoidal_shape() == 'dart':
+        #     if cell.ellipsoidal_shape == 'dart':
         #         lam_bar = lam_nucleus
         #     return lam_bar, phi_bar, abs(lam_bar_err), abs(phi_bar_err)
         #
@@ -602,7 +602,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         #         lam_bar_approx, phi_bar_approx, lam_bar_err, phi_bar_err = \
         #         monte_carlo_centroid(X)
         #         # print "Testing centroid(plane=False) for %s cell %s..."\
-        #         #  % (X.ellipsoidal_shape(), X)
+        #         #  % (X.ellipsoidal_shape, X)
         #         # print 'lam:', lam_bar, lam_bar_approx, lam_bar_err
         #         # print 'phi:', phi_bar, phi_bar_approx, phi_bar_err
         #         self.assertTrue(euclidean(lam_bar, lam_bar_approx) <\


### PR DESCRIPTION
This should assist in #7, but also many other cases.

In the case of #7, the Projection object overhead was significant. It constructed a new Projection object on every single call. At n=10 that's 36 object constructions per cell. The quick fix was to hoist the projection out of the list comprehension in `boundary()` so it's created once, then called 36 times.

We can make a similar caching improvement for `Cell.ellipsoidal_shape`.

An additional short-circuit for non-planar quad and cap cells is added when computing `Cell.boundary()` (just uses `Cell.vertices()` since the edges of these cells are adequately represented by their four vertices on the ellipsoid. This again avoids computation relevant to the performance issue noted in #7.