### PR TITLE
Fix boundary(plane=False) silently ignoring n for quad/cap cells

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,13 @@
 0.6.1
 ^^^^^
+Fixed ``Cell.boundary(plane=False)`` silently returning only 4 points for
+quad/cap cells regardless of ``n``, instead of the documented ``4*n - 4``
+(a regression from 0.6.0's short-circuit to ``vertices()``). The
+short-circuit now only applies at ``n=2``, where it's provably equivalent;
+``n>2`` on quad/cap cells falls through to the same per-point-projected
+algorithm used for other shapes, so it is correct again but not faster
+than before 0.6.0 for that case (issue #49).
+
 **Breaking change (harmless):** removed the ``RhealPolygon`` stub class
 (``__init__`` only, no other methods, no references or tests anywhere).
 Follow-up from a whole-repository code review; see ``CODE_REVIEW.md``.

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -766,10 +766,17 @@ class Cell(object):
         interior of the cell, which is convenient for some graphics methods.
 
         When `plane` = False, the cost scales with `n` because each point
-        requires an inverse projection call. For quad and cap cells the cell
-        edges are already well-represented by their vertices, so callers can
-        use ``cell.ellipsoidal_shape`` to avoid the overhead and fall back
-        to ``vertices(plane=False)`` for those shapes.
+        requires an inverse projection call. For quad and cap cells, `n` = 2
+        is short-circuited straight to ``vertices(plane=False)`` (skipping the
+        projection calls entirely), since that's what the general algorithm
+        below would compute anyway. For `n` > 2 on quad/cap cells the general,
+        per-point-projected algorithm still runs -- unlike dart/skew_quad
+        cells, quad/cap edges are known to be lines of constant longitude or
+        latitude on the ellipsoid, so in principle the extra points could be
+        computed directly without projecting each one, but doing that
+        correctly for cap cells requires careful antimeridian-wrapping
+        arithmetic (a cap cell's boundary is a single constant-latitude ring
+        split into 4 arcs by longitude) that hasn't been implemented yet.
 
         EXAMPLES::
 
@@ -802,15 +809,17 @@ class Cell(object):
             (157.49999999999997, 58.41366190347208)
 
         """
+        if n < 2:
+            n = 2
         # Quad and cap cells have straight or rotationally-symmetric edges on
-        # the ellipsoid, so extra boundary points add no accuracy. Fall back to
-        # vertices() and avoid the per-point projection cost entirely.
-        if not plane and self.ellipsoidal_shape in ("quad", "cap"):
+        # the ellipsoid, so at n=2 extra boundary points would add no accuracy.
+        # Fall back to vertices() and avoid the per-point projection cost
+        # entirely. For n>2 this cell falls through to the general algorithm
+        # below, same as any other shape (see the n>2 note in the docstring).
+        if not plane and n == 2 and self.ellipsoidal_shape in ("quad", "cap"):
             return self.vertices(plane=False)
         ul = self.ul_vertex(plane=True)
         w = self.width(plane=True)
-        if n < 2:
-            n = 2
         if interior:
             eps = w / 10000  # A smidgen.
         else:

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -377,6 +377,20 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         for n in (0, 1):
             self.assertEqual(a.boundary(n=n, plane=True), expect)
 
+    def test_boundary_quad_cap_n_contract(self):
+        # Regression test for the boundary(plane=False) short-circuit that
+        # silently returned only 4 points for quad/cap cells regardless of
+        # n, instead of the documented 4*n - 4. See issue #49.
+        rdggs = RHEALPixDGGS()
+        quad = Cell(rdggs, [P, 2])
+        cap = Cell(rdggs, [N])
+        for c in (quad, cap):
+            for n in (2, 3, 5):
+                b = c.boundary(n=n, plane=False)
+                self.assertEqual(len(b), max(4 * n - 4, 4))
+            # n=2 (the short-circuited case) must still agree with vertices().
+            self.assertEqual(c.boundary(n=2, plane=False), c.vertices(plane=False))
+
     def test_nucleus(self):
         for rdggs in [WGS84_123, WGS84_123_RADIANS]:
             # Nuclei of children should be in correct position


### PR DESCRIPTION
Fixes #49.

## What's happening

The 0.6.0 short-circuit (`0ea199e`) sent all `boundary(plane=False)` calls on quad/cap cells straight to `vertices()`, which always returns 4 points -- silently breaking the documented `4*n - 4` contract whenever `n > 2`. Confirmed by execution:

| `n` | documented `4n-4` | before this fix |
|---|---|---|
| 2 | 4 | 4 |
| 3 | 8 | **4** |
| 5 | 16 | **4** |

## The fix, and a trade-off worth your input on

I restricted the short-circuit to `n <= 2`, where it's provably equivalent to the general algorithm -- I verified this by simulating the pre-0.6.0 fallback path directly (i.e. the exact code that ran, unconditionally, for every shape before 0ea199e added the shortcut): it reduces to `vertices()` at `n=2` for both quad and cap cells, and produces the correct `4n-4` points in the right order for `n>2`. So for `n>2`, quad/cap cells now fall through to the same per-point-projected algorithm dart/skew_quad cells already use.

**This restores correctness but does not restore the `n>2` performance win for quad/cap cells that #7 was originally about.** A faster *and* correct fix is possible in principle: I confirmed by inspection that quad cell edges are lines of constant longitude/latitude on the ellipsoid, and a cap cell's entire boundary is a single constant-latitude ring split into 4 arcs by longitude -- so the extra points could be interpolated directly instead of projected one at a time. I didn't attempt that here, because getting the antimeridian-wrapping arithmetic right for the cap case needs real care (this codebase has existing antimeridian bugs tracked in #60), and landing a correct fix seemed more valuable than a fast-but-maybe-still-wrong one.

Happy to take a swing at the faster interpolation-based version as a follow-up if you'd rather have that than leave `n>2` slow again for quad/cap -- wanted to put the trade-off in front of you rather than pick silently.

## Testing

- Regression test added (`test_boundary_quad_cap_n_contract`): checks `4n-4` point counts for `n=2,3,5` on a quad and a cap cell, and that `n=2` still agrees with `vertices()`.
- Full suite: 80 unit tests pass (1 expected failure, pre-existing and unrelated), 392 doctests pass.