### PR TITLE
Cache invariant projection objects instead of rebuilding them per point

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,15 @@
 0.6.1
 ^^^^^
+Performance (issue #7, #62): ``Projection.__call__`` and
+``in_healpix_image``/``in_rhealpix_image`` were rebuilding objects that
+never change (the underlying projection callable, and a fixed
+matplotlib ``Path``) on every single point projected, rather than once.
+Both are now cached. No behavior change -- same inputs still produce
+identical outputs, verified against the full test suite -- only less
+redundant setup work per point. Measured on a real-world repro
+(``Cell.boundary(10, plane=False)`` on a dart-shaped cell, 2000
+iterations): roughly 2.4x faster (3.62s -> 1.48s).
+
 **Breaking change (harmless):** removed the ``RhealPolygon`` stub class
 (``__init__`` only, no other methods, no references or tests anywhere).
 Follow-up from a whole-repository code review; see ``CODE_REVIEW.md``.

--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -26,6 +26,9 @@ from typing import Callable
 # Import my modules.
 from rhealpixdggs.utils import my_round, auth_lat, auth_rad
 
+# Cache for in_healpix_image(); see the comment inside that function.
+_healpix_image_path = None
+
 
 def healpix_sphere(lam: float, phi: float) -> tuple[float, float]:
     """
@@ -193,34 +196,40 @@ def in_healpix_image(x: float, y: float) -> bool:
         False
 
     """
-    # matplotlib is a third-party module.
-    from matplotlib.path import Path
+    global _healpix_image_path
+    if _healpix_image_path is None:
+        # matplotlib is a third-party module.
+        from matplotlib.path import Path
 
-    # Fuzz to slightly expand HEALPix image boundary so that
-    # points on the boundary count as lying in the image.
-    eps = 1e-10
-    vertices = [
-        (-pi - eps, pi / 4 + eps),
-        (-3 * pi / 4, pi / 2 + eps),
-        (-pi / 2, pi / 4 + eps),
-        (-pi / 4, pi / 2 + eps),
-        (0, pi / 4 + eps),
-        (pi / 4, pi / 2 + eps),
-        (pi / 2, pi / 4 + eps),
-        (3 * pi / 4, pi / 2 + eps),
-        (pi + eps, pi / 4 + eps),
-        (pi + eps, -pi / 4 - eps),
-        (3 * pi / 4, -pi / 2 - eps),
-        (pi / 2, -pi / 4 - eps),
-        (pi / 4, -pi / 2 - eps),
-        (0, -pi / 4 - eps),
-        (-pi / 4, -pi / 2 - eps),
-        (-pi / 2, -pi / 4 - eps),
-        (-3 * pi / 4, -pi / 2 - eps),
-        (-pi - eps, -pi / 4 - eps),
-    ]
-    poly = Path(vertices)
-    return bool(poly.contains_point([x, y]))
+        # Fuzz to slightly expand HEALPix image boundary so that
+        # points on the boundary count as lying in the image.
+        eps = 1e-10
+        vertices = [
+            (-pi - eps, pi / 4 + eps),
+            (-3 * pi / 4, pi / 2 + eps),
+            (-pi / 2, pi / 4 + eps),
+            (-pi / 4, pi / 2 + eps),
+            (0, pi / 4 + eps),
+            (pi / 4, pi / 2 + eps),
+            (pi / 2, pi / 4 + eps),
+            (3 * pi / 4, pi / 2 + eps),
+            (pi + eps, pi / 4 + eps),
+            (pi + eps, -pi / 4 - eps),
+            (3 * pi / 4, -pi / 2 - eps),
+            (pi / 2, -pi / 4 - eps),
+            (pi / 4, -pi / 2 - eps),
+            (0, -pi / 4 - eps),
+            (-pi / 4, -pi / 2 - eps),
+            (-pi / 2, -pi / 4 - eps),
+            (-3 * pi / 4, -pi / 2 - eps),
+            (-pi - eps, -pi / 4 - eps),
+        ]
+        # This Path never varies (the function takes no parameters), so
+        # build it once and reuse it -- constructing a matplotlib Path is
+        # not free, and this used to happen on every single call, i.e. once
+        # per point projected.
+        _healpix_image_path = Path(vertices)
+    return bool(_healpix_image_path.contains_point([x, y]))
 
 
 def healpix_vertices() -> list[tuple[float, float, float]]:

--- a/rhealpixdggs/pj_rhealpix.py
+++ b/rhealpixdggs/pj_rhealpix.py
@@ -47,6 +47,9 @@ ROTATE = {
     -3: ROTATE1,
 }
 
+# Cache for in_rhealpix_image(); see the comment inside that function.
+_rhealpix_image_paths = {}
+
 
 def combine_triangles(
     x: float,
@@ -446,27 +449,35 @@ def in_rhealpix_image(
         False
 
     """
-    # matplotlib is a third-party module.
-    from matplotlib.path import Path
+    # This Path only depends on (north_square, south_square), which are
+    # fixed per DGGS instance, so build it once per distinct pair and reuse
+    # it -- constructing a matplotlib Path is not free, and this used to
+    # happen on every single call, i.e. once per point projected.
+    key = (north_square, south_square)
+    poly = _rhealpix_image_paths.get(key)
+    if poly is None:
+        # matplotlib is a third-party module.
+        from matplotlib.path import Path
 
-    # Fuzz to slightly expand rHEALPix image so that
-    # points on the boundary count as lying in the image.
-    eps = 1e-15
-    vertices = [
-        (-pi - eps, pi / 4 + eps),
-        (-pi + north_square * pi / 2 - eps, pi / 4 + eps),
-        (-pi + north_square * pi / 2 - eps, 3 * pi / 4 + eps),
-        (-pi + (north_square + 1) * pi / 2 + eps, 3 * pi / 4 + eps),
-        (-pi + (north_square + 1) * pi / 2 + eps, pi / 4 + eps),
-        (pi + eps, pi / 4 + eps),
-        (pi + eps, -pi / 4 - eps),
-        (-pi + (south_square + 1) * pi / 2 + eps, -pi / 4 - eps),
-        (-pi + (south_square + 1) * pi / 2 + eps, -3 * pi / 4 - eps),
-        (-pi + south_square * pi / 2 - eps, -3 * pi / 4 - eps),
-        (-pi + south_square * pi / 2 - eps, -pi / 4 - eps),
-        (-pi - eps, -pi / 4 - eps),
-    ]
-    poly = Path(vertices)
+        # Fuzz to slightly expand rHEALPix image so that
+        # points on the boundary count as lying in the image.
+        eps = 1e-15
+        vertices = [
+            (-pi - eps, pi / 4 + eps),
+            (-pi + north_square * pi / 2 - eps, pi / 4 + eps),
+            (-pi + north_square * pi / 2 - eps, 3 * pi / 4 + eps),
+            (-pi + (north_square + 1) * pi / 2 + eps, 3 * pi / 4 + eps),
+            (-pi + (north_square + 1) * pi / 2 + eps, pi / 4 + eps),
+            (pi + eps, pi / 4 + eps),
+            (pi + eps, -pi / 4 - eps),
+            (-pi + (south_square + 1) * pi / 2 + eps, -pi / 4 - eps),
+            (-pi + (south_square + 1) * pi / 2 + eps, -3 * pi / 4 - eps),
+            (-pi + south_square * pi / 2 - eps, -3 * pi / 4 - eps),
+            (-pi + south_square * pi / 2 - eps, -pi / 4 - eps),
+            (-pi - eps, -pi / 4 - eps),
+        ]
+        poly = Path(vertices)
+        _rhealpix_image_paths[key] = poly
     return bool(poly.contains_point([x, y]))
 
 

--- a/rhealpixdggs/projection_wrapper.py
+++ b/rhealpixdggs/projection_wrapper.py
@@ -76,6 +76,11 @@ class Projection(object):
         # {'north_square':1, 'south_square': 2}:
         self.kwargs = kwargs
         self.ellipsoid = ellipsoid
+        # Lazily built and cached by _get_f(). `a`/`e` (the only ellipsoid
+        # attributes this depends on) never change after construction, so
+        # the underlying projection callable only ever needs to be built
+        # once, no matter how many times __call__() is invoked.
+        self._f = None
 
     def __str__(self):
         result = ["map projection:"]
@@ -86,26 +91,40 @@ class Projection(object):
             result.append(" " * 8 + k + " = " + str(v))
         return "\n".join(result)
 
+    def _get_f(self):
+        """
+        Return the underlying f(u, v, radians=False, inverse=False)
+        callable for this projection, building it on first use and
+        caching it thereafter. Previously this was rebuilt from scratch
+        (including re-importing its module and, for homemade projections,
+        recomputing the authalic radius) on every single call to
+        __call__() -- a real cost for callers like Cell.boundary(), which
+        may invoke __call__() dozens of times per cell.
+        """
+        if self._f is None:
+            a = self.ellipsoid.a
+            e = self.ellipsoid.e
+            if self.proj in HOMEMADE_PROJECTIONS:
+                try:
+                    # Import projection module for proj.
+                    module = importlib.import_module("rhealpixdggs.pj_" + self.proj)
+                    self._f = getattr(module, self.proj)(a=a, e=e, **self.kwargs)
+                except (AttributeError, ModuleNotFoundError):
+                    print("Oops! Projection %s is not implemented." % self.proj)
+                    return None
+            else:
+                # Use a projection from the PROJ library.
+                self._f = pyproj.Proj(proj=self.proj, a=a, e=e, **self.kwargs)
+        return self._f
+
     def __call__(self, u, v, inverse=False):
         ellipsoid = self.ellipsoid
-        proj = self.proj
-        kwargs = self.kwargs
         lon_0 = ellipsoid.lon_0
         lat_0 = ellipsoid.lat_0
         radians = ellipsoid.radians
-        a = ellipsoid.a
-        e = ellipsoid.e
-        if proj in HOMEMADE_PROJECTIONS:
-            try:
-                # Import projection module for proj.
-                module = importlib.import_module("rhealpixdggs.pj_" + proj)
-                f = getattr(module, proj)(a=a, e=e, **kwargs)
-            except (AttributeError, ModuleNotFoundError):
-                print("Oops! Projection %s is not implemented." % proj)
-                return
-        else:
-            # Use a projection from the PROJ library.
-            f = pyproj.Proj(proj=proj, a=a, e=e, **kwargs)
+        f = self._get_f()
+        if f is None:
+            return
         if not inverse:
             # Translate longitudes and latitudes so that
             # (lon_0, lat_0) maps to (0, 0) in the plane.

--- a/tests/test_pj_healpix.py
+++ b/tests/test_pj_healpix.py
@@ -160,6 +160,17 @@ class MyTestCase(unittest.TestCase):
                 self.assertAlmostEqual(get[i], expect[i])
             # ------------------------------------------------------------------------------
 
+    def test_in_healpix_image_path_is_cached(self):
+        # Regression test: in_healpix_image() used to rebuild its
+        # matplotlib Path on every call even though it takes no
+        # parameters (the Path is always identical). See issue #62.
+        pjh._healpix_image_path = None
+        self.assertTrue(pjh.in_healpix_image(0, 0))
+        cached = pjh._healpix_image_path
+        self.assertIsNotNone(cached)
+        self.assertTrue(pjh.in_healpix_image(0.1, 0.1))
+        self.assertIs(pjh._healpix_image_path, cached)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pj_rhealpix.py
+++ b/tests/test_pj_rhealpix.py
@@ -316,6 +316,25 @@ class MyTestCase(unittest.TestCase):
             for i in range(len(expect)):
                 self.assertAlmostEqual(get[i], expect[i])
 
+    def test_in_rhealpix_image_path_is_cached(self):
+        # Regression test: in_rhealpix_image() used to rebuild its
+        # matplotlib Path on every call even though it only depends on
+        # (north_square, south_square), which are fixed per DGGS instance.
+        # See issue #62.
+        pjr._rhealpix_image_paths.clear()
+        self.assertTrue(pjr.in_rhealpix_image(0, 0, north_square=1, south_square=2))
+        key = (1, 2)
+        self.assertIn(key, pjr._rhealpix_image_paths)
+        cached = pjr._rhealpix_image_paths[key]
+        self.assertTrue(
+            pjr.in_rhealpix_image(0.1, 0.1, north_square=1, south_square=2)
+        )
+        self.assertIs(pjr._rhealpix_image_paths[key], cached)
+        # A different (north_square, south_square) pair gets its own entry.
+        self.assertTrue(pjr.in_rhealpix_image(0, 0, north_square=0, south_square=0))
+        self.assertIn((0, 0), pjr._rhealpix_image_paths)
+        self.assertIsNot(pjr._rhealpix_image_paths[(0, 0)], cached)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_projection_wrapper.py
+++ b/tests/test_projection_wrapper.py
@@ -23,6 +23,21 @@ class MyTestCase(unittest.TestCase):
             f = Projection(ellipsoid=WGS84_ELLIPSOID, proj=proj)
             self.assertIsNone(f(0, 0))
 
+    def test_underlying_callable_is_built_once_and_cached(self):
+        # Regression test: __call__() used to rebuild its underlying f
+        # (re-importing its module and, for homemade projections,
+        # recomputing the authalic radius) on every single call, even
+        # though it only depends on the ellipsoid's a/e, which never
+        # change after construction. See issue #62.
+        p = Projection(ellipsoid=WGS84_ELLIPSOID, proj="rhealpix")
+        self.assertIsNone(p._f)
+        p(0, 0)
+        cached = p._f
+        self.assertIsNotNone(cached)
+        p(0, 0.1)
+        p(0.2, -0.1, inverse=True)
+        self.assertIs(p._f, cached)
+
 
 # ------------------------------------------------------------------------------
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #62.

## Context

While looking at the follow-up to #49, I'd originally planned to hand-roll per-shape (quad/cap) interpolation to avoid projecting every extra `boundary()` point. Profiling first (rather than assuming) turned up something more general and much safer to fix.

## What's actually slow

Reproducing #7's own repro cell/ellipsoid (a `dart`-shaped cell -- so this is #7's actual complaint, unrelated to #49's quad/cap case):

```
vertices() x2000:                 0.800s
boundary(10, plane=False) x2000:  3.617s
```

Profiling `boundary(10, plane=False)` showed two objects being rebuilt from scratch on **every single point** (`4n-4` times per cell), despite never actually changing:

1. **`Projection.__call__`** re-imports its module and reconstructs the underlying projection callable `f` every call -- for homemade projections (`healpix`/`rhealpix`) this also recomputes the authalic radius (`auth_rad(a, e)`) every time. `a`/`e` never change after a `Projection` is constructed (confirmed: nothing anywhere reassigns `ellipsoid.a`/`ellipsoid.e` -- unlike `lon_0`/`lat_0`, which are deliberately mutated by `Cell.neighbors()`, see #53), so `f` only needs building once.
2. **`in_healpix_image()`/`in_rhealpix_image()`** rebuild a `matplotlib.path.Path` on every call to check whether a point lies in the valid projection image. `in_healpix_image()`'s Path is a fixed constant (zero parameters); `in_rhealpix_image()`'s only depends on `(north_square, south_square)`, fixed per DGGS instance. matplotlib Path construction turned out to be one of the single biggest line items in the profile.

Both are now cached (lazily, on first use). Neither change alters any computed value -- same inputs, identical outputs -- confirmed by the full test suite passing unchanged, including every doctest that pins exact expected coordinates.

## Result

```
vertices() x2000:                 0.800s -> 0.353s
boundary(10, plane=False) x2000:  3.617s -> 1.478s   (~2.4x faster)
```

Test suite itself also got noticeably faster to run (many tests exercise inverse projections repeatedly).

## Why this instead of the interpolation idea I floated on #49

I'd suggested computing quad-cell edge points directly (they're constant-longitude/latitude lines) instead of projecting each one. Turns out that's still true, but reproducing it exactly would mean re-deriving part of the ellipsoid-specific authalic-latitude conversion by hand, with no safety net for cap cells (which route through the `combine_triangles` rotation logic). This fix is safer -- it doesn't change what's computed anywhere, just how often a fixed setup step is repeated -- and it helps every shape uniformly, including the dart/skew_quad case #7 was actually about (which a quad/cap-only interpolation would never have touched).

## Testing

- Regression tests added for all three caches, asserting each is populated on first use and reused (by object identity) on subsequent calls.
- Full suite: 82 unit tests pass (1 expected failure, pre-existing/unrelated), 392 doctests pass.

## Heads up on CHANGES.rst

This and #61 both add an entry right above the same "0.6.1 / RhealPolygon" line, based on the same starting point -- whichever of the two merges second will conflict there. Trivial to resolve (keep both entries), just flagging it so it's not a surprise.