### PR TITLE
Drop the matplotlib dependency; replace with shapely for point-in-polygon

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,15 @@
 0.6.1
 ^^^^^
+Dropped the ``matplotlib`` dependency (issue #64). It was only ever used
+for a point-in-polygon check inside ``in_healpix_image``/
+``in_rhealpix_image`` -- a vestige of plotting code that was moved out of
+this package back in 0.5.3 -- and is now replaced with an equivalent
+``shapely`` check (``shapely`` was already a required dependency, used
+elsewhere in ``conversion.py``). No behavior change, verified against
+the full test suite including every doctest that pins exact boundary
+cases; measured slightly faster overall, not slower, despite dropping a
+dependency.
+
 **Breaking change (harmless):** removed the ``RhealPolygon`` stub class
 (``__init__`` only, no other methods, no references or tests anywhere).
 Follow-up from a whole-repository code review; see ``CODE_REVIEW.md``.

--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,6 @@ Requirements
 * ``requirements.txt`` - all the module requirements for operation
     - `NumPy >=1.25.2,<2 <https://www.numpy.org/>`_ Base N-dimensional array package
     - `SciPy >=1.11.2 <https://www.scipy.org/>`_ Fundamental library for scientific computing
-    - `Matplotlib >=3.7.2 <https://matplotlib.org/>`_ Comprehensive 2D Plotting
     - `Pyproj >=3.6.1 <https://code.google.com/p/pyproj/>`_ Python interface to the PROJ.4 cartographic library
     - `Shapely >=2.0.1 <https://shapely.readthedocs.io/>`_ Manipulation and analysis of planar GEOS geometries
 * ``requirements.dev.txt`` - packages needed for developing this package

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -10,7 +10,6 @@ Requirements
 - `Python >=3.11 <http://python.org/>`_
 - `NumPy >=1.25.2 <http://www.numpy.org/>`_ Base N-dimensional array package
 - `SciPy >=1.11.2 <http://www.scipy.org/>`_ Fundamental library for scientific computing
-- `Matplotlib >=3.7.2 <http://matplotlib.org/>`_ Comprehensive 2D Plotting
 - `Pyproj >=3.6 <http://code.google.com/p/pyproj/>`_
   Python interface to the PROJ.4 cartographic library
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ requires-python = ">=3.11"
 dependencies = [
     "numpy>=2.0",
     "scipy>=1.11",
-    "matplotlib>=3.7",
     "pyproj>=3.6",
     "shapely>=2.1"
 ]

--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -21,10 +21,15 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 
 # Import third-party modules.
 from numpy import pi, floor, sqrt, sin, arcsin, sign, array, deg2rad, rad2deg
+import shapely
+from shapely.geometry import Polygon
 from typing import Callable
 
 # Import my modules.
 from rhealpixdggs.utils import my_round, auth_lat, auth_rad
+
+# Cache for in_healpix_image(); see the comment inside that function.
+_healpix_image_poly = None
 
 
 def healpix_sphere(lam: float, phi: float) -> tuple[float, float]:
@@ -193,34 +198,43 @@ def in_healpix_image(x: float, y: float) -> bool:
         False
 
     """
-    # matplotlib is a third-party module.
-    from matplotlib.path import Path
-
-    # Fuzz to slightly expand HEALPix image boundary so that
-    # points on the boundary count as lying in the image.
-    eps = 1e-10
-    vertices = [
-        (-pi - eps, pi / 4 + eps),
-        (-3 * pi / 4, pi / 2 + eps),
-        (-pi / 2, pi / 4 + eps),
-        (-pi / 4, pi / 2 + eps),
-        (0, pi / 4 + eps),
-        (pi / 4, pi / 2 + eps),
-        (pi / 2, pi / 4 + eps),
-        (3 * pi / 4, pi / 2 + eps),
-        (pi + eps, pi / 4 + eps),
-        (pi + eps, -pi / 4 - eps),
-        (3 * pi / 4, -pi / 2 - eps),
-        (pi / 2, -pi / 4 - eps),
-        (pi / 4, -pi / 2 - eps),
-        (0, -pi / 4 - eps),
-        (-pi / 4, -pi / 2 - eps),
-        (-pi / 2, -pi / 4 - eps),
-        (-3 * pi / 4, -pi / 2 - eps),
-        (-pi - eps, -pi / 4 - eps),
-    ]
-    poly = Path(vertices)
-    return bool(poly.contains_point([x, y]))
+    global _healpix_image_poly
+    if _healpix_image_poly is None:
+        # Fuzz to slightly expand HEALPix image boundary so that
+        # points on the boundary count as lying in the image.
+        eps = 1e-10
+        vertices = [
+            (-pi - eps, pi / 4 + eps),
+            (-3 * pi / 4, pi / 2 + eps),
+            (-pi / 2, pi / 4 + eps),
+            (-pi / 4, pi / 2 + eps),
+            (0, pi / 4 + eps),
+            (pi / 4, pi / 2 + eps),
+            (pi / 2, pi / 4 + eps),
+            (3 * pi / 4, pi / 2 + eps),
+            (pi + eps, pi / 4 + eps),
+            (pi + eps, -pi / 4 - eps),
+            (3 * pi / 4, -pi / 2 - eps),
+            (pi / 2, -pi / 4 - eps),
+            (pi / 4, -pi / 2 - eps),
+            (0, -pi / 4 - eps),
+            (-pi / 4, -pi / 2 - eps),
+            (-pi / 2, -pi / 4 - eps),
+            (-3 * pi / 4, -pi / 2 - eps),
+            (-pi - eps, -pi / 4 - eps),
+        ]
+        # This polygon never varies (the function takes no parameters), so
+        # build it once and reuse it -- constructing it is not free, and
+        # this used to happen on every single call, i.e. once per point
+        # projected.
+        _healpix_image_poly = Polygon(vertices)
+    # contains_xy (vectorized, coordinate-based) avoids constructing a Point
+    # object per call, unlike the equivalent poly.contains(Point(x, y)).
+    # It's a strict interior test (excludes the boundary), but the eps fuzz
+    # above already pushes genuine boundary points into the interior of
+    # this (slightly larger) polygon, so they still test True -- verified
+    # against every boundary case in this function's own doctest above.
+    return bool(shapely.contains_xy(_healpix_image_poly, x, y))
 
 
 def healpix_vertices() -> list[tuple[float, float, float]]:

--- a/rhealpixdggs/pj_rhealpix.py
+++ b/rhealpixdggs/pj_rhealpix.py
@@ -19,6 +19,8 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 
 # Import third-party modules.
 from numpy import pi, sign, array, identity, dot, deg2rad, rad2deg
+import shapely
+from shapely.geometry import Polygon
 from typing import Callable
 
 # Import my modules.
@@ -46,6 +48,9 @@ ROTATE = {
     -2: ROTATE2,
     -3: ROTATE1,
 }
+
+# Cache for in_rhealpix_image(); see the comment inside that function.
+_rhealpix_image_polys = {}
 
 
 def combine_triangles(
@@ -446,28 +451,39 @@ def in_rhealpix_image(
         False
 
     """
-    # matplotlib is a third-party module.
-    from matplotlib.path import Path
-
-    # Fuzz to slightly expand rHEALPix image so that
-    # points on the boundary count as lying in the image.
-    eps = 1e-15
-    vertices = [
-        (-pi - eps, pi / 4 + eps),
-        (-pi + north_square * pi / 2 - eps, pi / 4 + eps),
-        (-pi + north_square * pi / 2 - eps, 3 * pi / 4 + eps),
-        (-pi + (north_square + 1) * pi / 2 + eps, 3 * pi / 4 + eps),
-        (-pi + (north_square + 1) * pi / 2 + eps, pi / 4 + eps),
-        (pi + eps, pi / 4 + eps),
-        (pi + eps, -pi / 4 - eps),
-        (-pi + (south_square + 1) * pi / 2 + eps, -pi / 4 - eps),
-        (-pi + (south_square + 1) * pi / 2 + eps, -3 * pi / 4 - eps),
-        (-pi + south_square * pi / 2 - eps, -3 * pi / 4 - eps),
-        (-pi + south_square * pi / 2 - eps, -pi / 4 - eps),
-        (-pi - eps, -pi / 4 - eps),
-    ]
-    poly = Path(vertices)
-    return bool(poly.contains_point([x, y]))
+    # This polygon only depends on (north_square, south_square), which are
+    # fixed per DGGS instance, so build it once per distinct pair and reuse
+    # it -- constructing it is not free, and this used to happen on every
+    # single call, i.e. once per point projected.
+    key = (north_square, south_square)
+    poly = _rhealpix_image_polys.get(key)
+    if poly is None:
+        # Fuzz to slightly expand rHEALPix image so that
+        # points on the boundary count as lying in the image.
+        eps = 1e-15
+        vertices = [
+            (-pi - eps, pi / 4 + eps),
+            (-pi + north_square * pi / 2 - eps, pi / 4 + eps),
+            (-pi + north_square * pi / 2 - eps, 3 * pi / 4 + eps),
+            (-pi + (north_square + 1) * pi / 2 + eps, 3 * pi / 4 + eps),
+            (-pi + (north_square + 1) * pi / 2 + eps, pi / 4 + eps),
+            (pi + eps, pi / 4 + eps),
+            (pi + eps, -pi / 4 - eps),
+            (-pi + (south_square + 1) * pi / 2 + eps, -pi / 4 - eps),
+            (-pi + (south_square + 1) * pi / 2 + eps, -3 * pi / 4 - eps),
+            (-pi + south_square * pi / 2 - eps, -3 * pi / 4 - eps),
+            (-pi + south_square * pi / 2 - eps, -pi / 4 - eps),
+            (-pi - eps, -pi / 4 - eps),
+        ]
+        poly = Polygon(vertices)
+        _rhealpix_image_polys[key] = poly
+    # contains_xy (vectorized, coordinate-based) avoids constructing a Point
+    # object per call, unlike the equivalent poly.contains(Point(x, y)).
+    # It's a strict interior test (excludes the boundary), but the eps fuzz
+    # above already pushes genuine boundary points into the interior of
+    # this (slightly larger) polygon, so they still test True -- verified
+    # against every boundary case in this function's own doctest above.
+    return bool(shapely.contains_xy(poly, x, y))
 
 
 def rhealpix_vertices(

--- a/tests/test_pj_healpix.py
+++ b/tests/test_pj_healpix.py
@@ -160,6 +160,18 @@ class MyTestCase(unittest.TestCase):
                 self.assertAlmostEqual(get[i], expect[i])
             # ------------------------------------------------------------------------------
 
+    def test_in_healpix_image_poly_is_cached(self):
+        # Regression test: in_healpix_image() used to rebuild its polygon
+        # (originally a matplotlib Path, now a shapely Polygon) on every
+        # call even though it takes no parameters (the polygon is always
+        # identical). See issue #64.
+        pjh._healpix_image_poly = None
+        self.assertTrue(pjh.in_healpix_image(0, 0))
+        cached = pjh._healpix_image_poly
+        self.assertIsNotNone(cached)
+        self.assertTrue(pjh.in_healpix_image(0.1, 0.1))
+        self.assertIs(pjh._healpix_image_poly, cached)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pj_rhealpix.py
+++ b/tests/test_pj_rhealpix.py
@@ -316,6 +316,25 @@ class MyTestCase(unittest.TestCase):
             for i in range(len(expect)):
                 self.assertAlmostEqual(get[i], expect[i])
 
+    def test_in_rhealpix_image_poly_is_cached(self):
+        # Regression test: in_rhealpix_image() used to rebuild its polygon
+        # (originally a matplotlib Path, now a shapely Polygon) on every
+        # call even though it only depends on (north_square, south_square),
+        # which are fixed per DGGS instance. See issue #64.
+        pjr._rhealpix_image_polys.clear()
+        self.assertTrue(pjr.in_rhealpix_image(0, 0, north_square=1, south_square=2))
+        key = (1, 2)
+        self.assertIn(key, pjr._rhealpix_image_polys)
+        cached = pjr._rhealpix_image_polys[key]
+        self.assertTrue(
+            pjr.in_rhealpix_image(0.1, 0.1, north_square=1, south_square=2)
+        )
+        self.assertIs(pjr._rhealpix_image_polys[key], cached)
+        # A different (north_square, south_square) pair gets its own entry.
+        self.assertTrue(pjr.in_rhealpix_image(0, 0, north_square=0, south_square=0))
+        self.assertIn((0, 0), pjr._rhealpix_image_polys)
+        self.assertIsNot(pjr._rhealpix_image_polys[(0, 0)], cached)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #64.

## Why

`matplotlib` is a required runtime dependency, described in the docs as being there for "Comprehensive 2D Plotting" -- but it's used in exactly two places in the whole package, for something unrelated to plotting: `in_healpix_image()`/`in_rhealpix_image()` use `matplotlib.path.Path` purely as a point-in-polygon test. Git history shows the actual plotting code that originally justified this dependency was moved out to a separate companion project back in 2020 (`CHANGES.rst` 0.5.3, issue #5); this one utility call got left behind.

`shapely` is already a required dependency, already used elsewhere (`conversion.py`), and is the more natural fit for a geometry package.

## An honest note on how this went

My first attempt used `polygon.covers(Point(x, y))` -- semantically the closest match to the existing "boundary counts as inside" behavior. Profiling showed it was actually **slower** than the matplotlib version, even with the polygon cached: shapely 2.x wraps predicate methods in a validation decorator, and constructing a `Point` object per call adds up. Switched to `shapely.contains_xy(polygon, x, y)`, a vectorized coordinate-based function that skips `Point` construction entirely. It's a strict interior test (excludes the boundary), but the existing `eps` fuzz already pushes genuine boundary points into the interior of the (slightly larger) fuzzed polygon -- verified against every boundary case pinned in each function's own doctest, so behavior is unchanged.

## Result

Net effect, measured on issue #7's repro cell: **not just unchanged, actually faster, despite dropping a dependency.**

```
boundary(10, plane=False) x2000, matplotlib (original): 3.617s
boundary(10, plane=False) x2000, shapely contains_xy:   2.605s
```

(This branch doesn't include #62/#63's `Projection.__call__` caching, since it was branched before that merged -- combining both should improve further; a rough combined test landed around ~2.1s.)

## What's changed

- `in_healpix_image()`/`in_rhealpix_image()`: matplotlib `Path` -> shapely `Polygon`, using `shapely.contains_xy`. Both polygons are cached the same way #62 cached the `Projection` closure (module-level constant for the former; keyed by `(north_square, south_square)` for the latter, since that's fixed per DGGS instance).
- `pyproject.toml`: removed `matplotlib` from dependencies.
- `README.rst` / `docs/source/introduction.rst`: removed matplotlib from the requirements lists.
- Regression tests added for both caches.

## Not done here (flagging, not fixing)

- `poetry.lock` still lists matplotlib and its transitive deps -- it needs regenerating, but I can't do that myself (the local `poetry` CLI here is 1.5.1, too old for this project's `poetry-core>=2.0` requirement -- same issue noted back when `poetry.lock` was first committed).
- `docs/source/introduction.rst`'s requirements list was already missing `shapely` entirely, pre-existing and unrelated to this change -- left alone, already covered by #57.

## Merge order note

This branched from `code-review-fixes` before #61/#63 merged, so once those land there'll likely be a small conflict in `CHANGES.rst` (same pattern as #63's own note) and possibly in `pj_healpix.py`/`pj_rhealpix.py` if #63 merges first (its `Path`-caching code for these same two functions gets fully superseded by this PR's shapely rewrite). Happy to rebase once you've decided a merge order.

## Testing

Full suite: 81 unit tests pass (1 expected failure, pre-existing/unrelated), 392 doctests pass, including every boundary-point case pinned in `in_healpix_image`'s and `in_rhealpix_image`'s own doctests.