### PR TITLE
Fix compact_cells/compress_order_cells hardcoding N_side=3 (9 siblings)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,14 @@
 0.6.1
 ^^^^^
+Fixed ``compact_cells``/``compress_order_cells`` (``conversion``) hardcoding
+9 as the size of "a complete group of siblings" -- correct only for the
+default ``N_side=3``. Under an ``N_side=2`` DGGS (e.g. ``WGS84_002``, 4
+children per cell), a genuinely complete sibling group silently never
+compressed at all. Both functions now take an ``N_side`` keyword argument
+(default 3, so existing callers are unaffected) and use ``N_side ** 2``.
+``polyfill()``'s ``compress=True`` path now passes its ``dggs``
+parameter's actual ``N_side`` through (issue #51).
+
 Fixed ``Cell.boundary(plane=False)`` silently returning only 4 points for
 quad/cap cells regardless of ``n``, instead of the documented ``4*n - 4``
 (a regression from 0.6.0's short-circuit to ``vertices()``). The

--- a/rhealpixdggs/conversion.py
+++ b/rhealpixdggs/conversion.py
@@ -126,11 +126,18 @@ class CellZoneFromPoly:
             self.cells_list.append(cell)
 
 
-def compress_order_cells(cells: list[str], recursive: bool = False) -> list[str]:
+def compress_order_cells(
+    cells: list[str], recursive: bool = False, N_side: int = 3
+) -> list[str]:
     """
     Compress and sort a collection of cells.
 
-    Each complete group of 9 siblings is replaced by their parent cell.
+    Each complete group of ``N_side ** 2`` siblings is replaced by their
+    parent cell. ``N_side`` defaults to 3 (the default for `RHEALPixDGGS`
+    and most presets, e.g. ``WGS84_003``); pass the ``N_side`` of the DGGS
+    the cells actually belong to if it's not 3 (e.g. 2 for ``WGS84_002``),
+    otherwise a complete sibling group will never be recognised as complete
+    and nothing will compress.
     By default only one level of compression is performed. Pass
     ``recursive=True`` to repeat until no further compression is possible.
     The result is always deduplicated and sorted alphanumerically.
@@ -148,7 +155,7 @@ def compress_order_cells(cells: list[str], recursive: bool = False) -> list[str]
             upper_cells.setdefault(cell[:-1], []).append(cell)
         result: set[str] = set()
         for k, v in upper_cells.items():
-            if len(v) == 9:
+            if len(v) == N_side**2:
                 result.add(k)
             else:
                 result.update(v)
@@ -166,10 +173,15 @@ def compress_order_cells(cells: list[str], recursive: bool = False) -> list[str]
     return alphanum_sort(list(cell_set))
 
 
-def compact_cells(cells: Iterable[str]) -> set[str]:
+def compact_cells(cells: Iterable[str], N_side: int = 3) -> set[str]:
     """
-    Compact a set of rHEALPix DGGS cells by repeatedly merging complete groups
-    of 9 siblings into their parent until no further merging is possible.
+    Compact a set of rHEALPix DGGS cells by repeatedly merging complete
+    groups of ``N_side ** 2`` siblings into their parent until no further
+    merging is possible. ``N_side`` defaults to 3 (the default for
+    `RHEALPixDGGS` and most presets, e.g. ``WGS84_003``); pass the
+    ``N_side`` of the DGGS the cells actually belong to if it's not 3
+    (e.g. 2 for ``WGS84_002``), otherwise a complete sibling group will
+    never be recognised as complete and nothing will compact.
 
     All input cells must be at the same resolution (equal string length).
     Raises ValueError if the input contains cells at mixed resolutions.
@@ -193,7 +205,7 @@ def compact_cells(cells: Iterable[str]) -> set[str]:
 
         next_set: set[str] = set()
         for parent, children in upper.items():
-            if len(children) == 9:
+            if len(children) == N_side**2:
                 next_set.add(parent)
             else:
                 next_set.update(children)

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -609,7 +609,7 @@ def polyfill(
 
     # Merge cells inside polygon into larger ones where possible
     if compress:
-        cells = compact_cells(cells)
+        cells = compact_cells(cells, N_side=dggs.N_side)
 
     return cells
 

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -663,6 +663,37 @@ class TestCompactCells(unittest.TestCase):
         assert all(f"R1{n}" in result for n in range(8))
         assert "R1" not in result
 
+    def test_N_side_2_full_siblings_compact_to_parent(self):
+        # An N_side=2 DGGS (e.g. WGS84_002) has 4 children per cell, not 9.
+        # Regression test for issue #51: compact_cells hardcoded 9 as "a
+        # complete sibling group", so a genuinely complete N_side=2 group
+        # never compacted at all unless N_side is passed through.
+        cells = [f"R{n}" for n in range(4)]
+        assert compact_cells(cells, N_side=2) == {"R"}
+
+    def test_default_N_side_does_not_compact_N_side_2_siblings(self):
+        # The same complete N_side=2 sibling group, without specifying
+        # N_side, is silently left uncompacted under the N_side=3 default
+        # (4 != 9) -- this is the bug itself, kept as a test so a future
+        # change to the default doesn't accidentally paper over it.
+        cells = [f"R{n}" for n in range(4)]
+        assert compact_cells(cells) == set(cells)
+
+    def test_N_side_2_partial_siblings_stay(self):
+        cells = [f"R{n}" for n in range(3)]  # missing R3
+        assert compact_cells(cells, N_side=2) == set(cells)
+
+
+class TestCompressOrderCellsNSide(unittest.TestCase):
+    def test_N_side_2_full_siblings_compress_to_parent(self):
+        # Same bug, same fix, for compress_order_cells. See issue #51.
+        cells = [f"R{n}" for n in range(4)]
+        assert compress_order_cells(cells, N_side=2) == ["R"]
+
+    def test_default_N_side_does_not_compress_N_side_2_siblings(self):
+        cells = [f"R{n}" for n in range(4)]
+        assert compress_order_cells(cells) == sorted(cells)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -467,6 +467,23 @@ class RhpWrappersTestCase(unittest.TestCase):
         # Compressed from polygon - plane
         self.assertEqual(rhpw.polyfill(plane_poly, 10, compress=True), {"N216055611"})
 
+        # Regression test for issue #51: compress_cells hardcoded 9 as "a
+        # complete sibling group" (correct only for N_side=3), so under an
+        # N_side=2 DGGS (WGS84_002, 4 children per cell) a complete group
+        # of siblings silently never compressed at all. polyfill() must
+        # pass the DGGS's actual N_side through to compact_cells().
+        n_side_2_idx = ("N", 2, 1, 3)
+        n_side_2_cell = rhpw.Cell(rdggs=gs.WGS84_002, suid=n_side_2_idx)
+        n_side_2_poly = sh.Polygon(n_side_2_cell.vertices())
+        self.assertEqual(
+            rhpw.polyfill(n_side_2_poly, 4, dggs=gs.WGS84_002),
+            {"N2130", "N2131", "N2132", "N2133"},
+        )
+        self.assertEqual(
+            rhpw.polyfill(n_side_2_poly, 4, dggs=gs.WGS84_002, compress=True),
+            {"N213"},
+        )
+
         # Test data - sphere
         eq_poly_n = sh.Polygon(
             shell=[(-10, -10), (50, -10), (50, 40), (-10, 40), (-10, -10)],


### PR DESCRIPTION
Fixes #51.

## What's happening

Both `compress_order_cells` and `compact_cells` (`conversion.py`) grouped cells by parent prefix and merged a group into its parent only when it had exactly 9 members:

```python
if len(v) == 9:            # compress_order_cells
...
if len(children) == 9:      # compact_cells
```

That's correct only for an `N_side=3` DGGS (9 children per cell, digits `0`-`8`). But `N_side` is a general, user-facing parameter, and the package ships a preset with `N_side=2`:

```python
# rhealpixdggs/dggs.py
WGS84_002 = RHEALPixDGGS(ellipsoid=WGS84_ELLIPSOID, north_square=0, south_square=0, N_side=2)
```

For `WGS84_002`, a cell has only 4 children (digits `0`-`3`), so a complete sibling group has at most 4 members -- `len(v) == 9` is never true, and compaction silently does nothing. No error, no warning.

## Fix

Added an `N_side` keyword argument (default `3`, so existing callers are unaffected) to both functions, using `N_side ** 2` instead of the hardcoded `9`.

Also fixed `polyfill()`'s `compress=True` path -- the one place these are called internally -- which was calling `compact_cells(cells)` with no `N_side` at all. Even with the function itself fixed, `polyfill(..., dggs=WGS84_002, compress=True)` would still have silently done nothing, since the default `N_side=3` doesn't match the DGGS actually being used. Now passes `N_side=dggs.N_side` through.

## Testing

- `compact_cells`/`compress_order_cells` with an explicit `N_side=2`: a complete 4-sibling group correctly compacts, a partial one correctly doesn't.
- The same input *without* `N_side` is kept as its own test, demonstrating the original bug (silently uncompacted) -- so if the default ever changes, this doesn't quietly stop testing the bug it's meant to guard against.
- End-to-end: `polyfill(plane_poly, res, dggs=WGS84_002, compress=True)` on a real `WGS84_002` cell, confirming 4 uncompressed children collapse to their parent.
- Full suite: 88 unit tests pass (1 expected failure, pre-existing/unrelated), 392 doctests pass.