### PR TITLE
Raise ValueError for out-of-bounds coordinates instead of print+sentinel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,18 @@
 0.6.1
 ^^^^^
+**Breaking change:** ``healpix_sphere_inverse``, ``healpix_ellipsoid_inverse``,
+``rhealpix_sphere_inverse``, and ``rhealpix_ellipsoid_inverse``
+(``pj_healpix``/``pj_rhealpix``) now raise ``ValueError`` for out-of-bounds
+input coordinates, instead of printing an error message and returning a
+sentinel: ``float("inf")`` for ``healpix_sphere_inverse``, or bare ``None``
+for the other three. The ``None`` case was already effectively a crash for
+any caller going through the public ``healpix()``/``rhealpix()`` projection
+factories -- their closures do ``array(...)`` then unpack the result, which
+raises a confusing, unrelated-looking ``TypeError: iteration over a 0-d
+array`` a few frames away from the actual problem. If you were catching
+these failures by checking for ``None``/``inf``, catch ``ValueError``
+instead (issue #52).
+
 Fixed ``compact_cells``/``compress_order_cells`` (``conversion``) hardcoding
 9 as the size of "a complete group of siblings" -- correct only for the
 default ``N_side=3``. Under an ``N_side=2`` DGGS (e.g. ``WGS84_002``, 4

--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -81,10 +81,11 @@ def healpix_sphere_inverse(x: float, y: float) -> tuple[float, float]:
         True
 
     """
-    # Throw error if input coordinates are out of bounds.
     if not in_healpix_image(x, y):
-        print("Error (hsi): input coordinates (%.20f,%.20f) are out of bounds" % (x, y))
-        return float("inf"), float("inf")
+        raise ValueError(
+            "(%.20f,%.20f) is not a point in the image of the HEALPix "
+            "projection of the unit sphere" % (x, y)
+        )
     y0 = pi / 4
     # Equatorial region.
     if abs(y) <= y0:
@@ -150,11 +151,8 @@ def healpix_ellipsoid_inverse(x: float, y: float, e: float = 0) -> tuple[float, 
         (0, 0.448798950512828)
 
     """
-    # Throw error if input coordinates are out of bounds.
-    if not in_healpix_image(x, y):
-        print("Error (hei): input coordinates (%.20f,%.20f) are out of bounds" % (x, y))
-        return
-
+    # healpix_sphere_inverse() raises ValueError for out-of-bounds (x, y);
+    # no need to duplicate that check here.
     lam, beta = healpix_sphere_inverse(x, y)
     phi = auth_lat(beta, e, radians=True, inverse=True)
     return lam, phi

--- a/rhealpixdggs/pj_rhealpix.py
+++ b/rhealpixdggs/pj_rhealpix.py
@@ -325,12 +325,14 @@ def rhealpix_sphere_inverse(
         (0, 0.785398163397448)
 
     """
-    # Throw error if input coordinates are out of bounds.
     if not in_rhealpix_image(
         x, y, south_square=south_square, north_square=north_square
     ):
-        print("Error (rsi): input coordinates (%.20f,%.20f) are out of bounds" % (x, y))
-        return
+        raise ValueError(
+            "(%.20f,%.20f) is not a point in the image of the "
+            "(%d, %d)-rHEALPix projection of the unit sphere"
+            % (x, y, north_square, south_square)
+        )
     if region != "equatorial":
         x, y = combine_triangles(
             x, y, north_square=north_square, south_square=south_square, inverse=True
@@ -401,12 +403,14 @@ def rhealpix_ellipsoid_inverse(
         (0, 0.785398163397448)
 
     """
-    # Throw error if input coordinates are out of bounds.
     if not in_rhealpix_image(
         x, y, south_square=south_square, north_square=north_square
     ):
-        print("Error (rei): input coordinates (%.20f,%.20f) are out of bounds" % (x, y))
-        return
+        raise ValueError(
+            "(%.20f,%.20f) is not a point in the image of the "
+            "(%d, %d)-rHEALPix projection of the unit sphere"
+            % (x, y, north_square, south_square)
+        )
 
     if region != "equatorial":
         x, y = combine_triangles(

--- a/tests/test_pj_healpix.py
+++ b/tests/test_pj_healpix.py
@@ -172,6 +172,23 @@ class MyTestCase(unittest.TestCase):
         self.assertTrue(pjh.in_healpix_image(0.1, 0.1))
         self.assertIs(pjh._healpix_image_poly, cached)
 
+    def test_out_of_bounds_raises_value_error(self):
+        # Regression test for issue #52: out-of-bounds coordinates used to
+        # print an error message and return a sentinel (float("inf"), or
+        # bare None for healpix_ellipsoid_inverse) instead of raising --
+        # the sentinel case silently propagated inf into any downstream
+        # arithmetic, and the None case crashed several frames away with a
+        # confusing numpy TypeError the moment healpix()'s closure tried
+        # to array()-and-unpack it.
+        with self.assertRaises(ValueError):
+            pjh.healpix_sphere_inverse(0, 100)
+        with self.assertRaises(ValueError):
+            pjh.healpix_ellipsoid_inverse(0, 100)
+        # Same via the public factory function.
+        f = pjh.healpix(a=1, e=0.5)
+        with self.assertRaises(ValueError):
+            f(0, 100, radians=True, inverse=True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_pj_rhealpix.py
+++ b/tests/test_pj_rhealpix.py
@@ -335,6 +335,20 @@ class MyTestCase(unittest.TestCase):
         self.assertIn((0, 0), pjr._rhealpix_image_polys)
         self.assertIsNot(pjr._rhealpix_image_polys[(0, 0)], cached)
 
+    def test_out_of_bounds_raises_value_error(self):
+        # Regression test for issue #52: out-of-bounds coordinates used to
+        # print an error message and return None instead of raising, which
+        # crashed several frames away with a confusing numpy TypeError the
+        # moment rhealpix()'s closure tried to array()-and-unpack it.
+        with self.assertRaises(ValueError):
+            pjr.rhealpix_sphere_inverse(0, 100)
+        with self.assertRaises(ValueError):
+            pjr.rhealpix_ellipsoid_inverse(0, 100)
+        # Same via the public factory function.
+        f = pjr.rhealpix(a=1, e=0.5, north_square=1, south_square=2)
+        with self.assertRaises(ValueError):
+            f(0, 100, radians=True, inverse=True)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #52.

## What's happening

`healpix_sphere_inverse`, `healpix_ellipsoid_inverse`, `rhealpix_sphere_inverse`, and `rhealpix_ellipsoid_inverse` each had a comment saying "throw error if input coordinates are out of bounds," but the code printed a message and returned a sentinel instead: `float("inf")` for `healpix_sphere_inverse`, bare `None` for the other three.

The `None` case was already effectively a crash, just a confusing one. The public `healpix()`/`rhealpix()` projection factories' inverse closures do `array(healpix_ellipsoid_inverse(...))` then unpack the result -- `array(None)` is a 0-d object array, and unpacking that raises `TypeError: iteration over a 0-d array`, several frames away from the actual problem, with the "Error (hei): ..." message already printed and easy to miss. Confirmed by reproducing it directly:

```pycon
>>> from rhealpixdggs.pj_healpix import healpix
>>> f = healpix(a=1, e=0.5)
>>> f(0, 100, radians=True, inverse=True)
Error (hei): input coordinates (0.00000000000000000000,104.71464775647537237546) are out of bounds
TypeError: iteration over a 0-d array
```

The `inf` case was worse in a different way: no crash at all, just a coordinate that looks valid but isn't, free to propagate into downstream area/containment arithmetic undetected.

## Fix

Replaced both with a raised `ValueError` at the point of detection, including the actual out-of-bounds coordinates in the message (and, for the rHEALPix variants, the `north_square`/`south_square` in use).

Also removed a fully redundant duplicate check: `healpix_ellipsoid_inverse` checked `in_healpix_image(x, y)` itself, then immediately called `healpix_sphere_inverse(x, y)`, which checks the exact same `(x, y)` again -- unlike the rHEALPix pair, where the two checks are on different coordinates (before/after `combine_triangles`) and both stayed. Now that `healpix_sphere_inverse` raises, the outer check in `healpix_ellipsoid_inverse` was pure dead weight.

## Breaking change

Noted in `CHANGES.rst`. Nothing in this codebase's own tests or doctests exercised the out-of-bounds path at all (confirmed by grep before making the change), so there was nothing to verify this against by running the existing suite -- but any external caller catching `None`/`inf` needs to catch `ValueError` instead.

## Testing

Regression tests added for all four functions plus both public factory closures (`healpix()`/`rhealpix()`), confirming each now raises `ValueError` instead of the old sentinel/crash behavior. Full suite: 90 unit tests pass (1 expected failure, pre-existing/unrelated), 392 doctests pass.