### PR TITLE
Replace bare assert input validation in Cell with explicit exceptions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,16 @@
 0.6.1
 ^^^^^
+**Breaking change:** ``Cell``'s constructor and ``Cell.overlaps()`` validated
+their arguments with bare ``assert`` statements, which ``python -O``/
+``PYTHONOPTIMIZE`` compiles out entirely (silently disabling the checks),
+and which raised ``AssertionError`` for what is really invalid input.
+Replaced with explicit ``TypeError``/``ValueError`` matching the kind of
+problem: ``TypeError`` if ``suid`` isn't a list or tuple, ``ValueError``
+for a bad length, an invalid first character, an out-of-range digit, or
+calling ``overlaps()`` on an empty cell. If you were catching
+``AssertionError`` from these, catch ``TypeError``/``ValueError`` instead
+(issue #54).
+
 Fixed ``Cell.neighbors(plane=False)`` for dart and skew_quad cells, which
 computed east/west (and, for darts, southeast/southwest/etc.) by
 temporarily reassigning ``self.rdggs.ellipsoid.lon_0`` -- a singleton

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -153,19 +153,21 @@ class Cell(object):
         self.resolution = None  # Level of self in grid hierarchy.
         if suid is not None:
             # A little error checking.
-            assert isinstance(suid, list) or isinstance(suid, tuple), (
-                "Cell suid must be a list or tuple. Got %s." % suid
-            )
-            assert (len(suid) > 0) and (
-                len(suid) <= rdggs.max_resolution + 1
-            ), "Need 0 < len(suid) <= %s. Got %s." % (rdggs.max_resolution + 1, suid)
-            assert suid[0] in CELLS0, "suid[0] must lie in %s. Got %s." % (
-                CELLS0,
-                suid[0],
-            )
+            if not isinstance(suid, (list, tuple)):
+                raise TypeError("Cell suid must be a list or tuple. Got %s." % suid)
+            if not (0 < len(suid) <= rdggs.max_resolution + 1):
+                raise ValueError(
+                    "Need 0 < len(suid) <= %s. Got %s."
+                    % (rdggs.max_resolution + 1, suid)
+                )
+            if suid[0] not in CELLS0:
+                raise ValueError(
+                    "suid[0] must lie in %s. Got %s." % (CELLS0, suid[0])
+                )
             digits = set(range(self.N_side**2))
             for x in suid[1:]:
-                assert x in digits, "Digits of suid must lie in %s" % digits
+                if x not in digits:
+                    raise ValueError("Digits of suid must lie in %s. Got %s." % (digits, x))
 
             self.suid = [suid[0]] + [int(n) for n in suid[1:]]
             self.suid = tuple(self.suid)
@@ -987,7 +989,8 @@ class Cell(object):
         :param cell_two: the second DGGS cell
         :return: True if overlaps
         """
-        assert self.suid is not tuple()  # cell cannot be empty
+        if not self.suid:
+            raise ValueError("Cannot test overlap for an empty cell.")
         for i, j in zip(self.suid, other_cell.suid):
             if i != j:
                 return False

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -90,7 +90,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
 
             # Should not create invalid cells.
             suid = (P, rdggs.N_side**2)
-            self.assertRaises(AssertionError, Cell, rdggs, suid)
+            self.assertRaises(ValueError, Cell, rdggs, suid)
 
             # Should create cell P1.
             expect = (P, 1)
@@ -106,6 +106,29 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             i = 2 * num(0) + 1 * num(1) + num(1) - 1
             get = Cell(rdggs, post_order_index=i).suid
             self.assertEqual(get, expect)
+
+    def test_Cell_init_invalid_suid_raises(self):
+        # Regression test for issue #54: these were all bare `assert`s,
+        # which python -O silently compiles out, and which raised
+        # AssertionError regardless of what actually went wrong. Each
+        # should now raise a specific, conventional exception.
+        rdggs = WGS84_123
+        # Wrong type entirely.
+        with self.assertRaises(TypeError):
+            Cell(rdggs, suid="N0")
+        with self.assertRaises(TypeError):
+            Cell(rdggs, suid={"N", 0})
+        # Right type (tuple/list), wrong length.
+        with self.assertRaises(ValueError):
+            Cell(rdggs, suid=())
+        with self.assertRaises(ValueError):
+            Cell(rdggs, suid=(N,) * (rdggs.max_resolution + 2))
+        # suid[0] not a valid level-0 cell name.
+        with self.assertRaises(ValueError):
+            Cell(rdggs, suid=("X", 0))
+        # A later digit out of range for this DGGS's N_side.
+        with self.assertRaises(ValueError):
+            Cell(rdggs, suid=(P, rdggs.N_side**2))
 
     def test_suid_rowcol(self):
         for rdggs in [WGS84_123, WGS84_123_RADIANS]:
@@ -597,6 +620,22 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             for i, future in enumerate(futures):
                 result = future.result()
                 self.assertEqual(result, expected[i % len(cells)])
+
+    def test_overlaps(self):
+        rdggs = WGS84_003
+        a = rdggs.cell((P, 0))
+        descendant = rdggs.cell((P, 0, 3))
+        sibling = rdggs.cell((P, 1))
+        self.assertTrue(a.overlaps(a))
+        self.assertTrue(a.overlaps(descendant))
+        self.assertTrue(descendant.overlaps(a))
+        self.assertFalse(a.overlaps(sibling))
+        # Regression test for issue #54: this was a bare `assert`, which
+        # python -O silently compiles out, and which raised
+        # AssertionError rather than a conventional exception.
+        empty = rdggs.cell()
+        with self.assertRaises(ValueError):
+            empty.overlaps(a)
 
     def test_region(self):
         for rdggs in [WGS84_003, WGS84_003_RADIANS]:


### PR DESCRIPTION
Fixes #54.

## What's happening

`Cell.__init__` and `Cell.overlaps()` validated their arguments with bare `assert` statements. Two problems: `assert` is compiled out entirely under `python -O`/`PYTHONOPTIMIZE`, silently disabling the checks; and they raise `AssertionError`, which is conventionally reserved for internal invariant violations, not API misuse by a caller.

## Fix

Replaced each with an explicit raise of the exception type matching the actual problem:

- `TypeError` when `suid` isn't a list or tuple at all
- `ValueError` for a bad length, an invalid first character, an out-of-range digit, or calling `overlaps()` on an empty cell

Also fixed `overlaps()`'s `assert self.suid is not tuple()`: an identity check (`is not`) against a freshly-constructed literal, which only works because CPython happens to intern the empty tuple -- an implementation detail, not a language guarantee, which matters given this project's own classifiers claim PyPy support. Now a plain truthiness check.

## Testing

Updated the one existing test that asserted `AssertionError` to expect `ValueError` instead, and added dedicated tests for all 5 sites (4 in the constructor, 1 in `overlaps()`) plus minimal correctness coverage for `overlaps()` itself, which previously had none at all.

Full suite: 95 unit tests pass (1 expected failure, pre-existing/unrelated), 392 doctests pass.

## Breaking change

Noted in `CHANGES.rst`: anyone catching `AssertionError` from these needs to catch `TypeError`/`ValueError` instead.
