### PR TITLE
Fix Cell.subcell()/__le__ comparing stringified suids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,18 @@
 0.6.1
 ^^^^^
+Fixed ``Cell.subcell()`` and ``Cell.__le__`` (and so ``<``/``<=``/``>``/``>=``,
+and anything built on them, such as ``RHEALPixDGGS.interval()``) comparing a
+comma-joined **string** rendering of a cell's suid rather than the suid
+tuple itself. This happened to work for the default ``N_side=3``, where
+every digit is a single character, but for ``N_side >= 4`` some digits are
+multi-character (e.g. 10-15 for ``N_side=4``), and the string comparison
+could misfire: e.g. ``('N', 15).subcell(('N', 1))`` incorrectly returned
+``True`` (``"N,15"`` starts with ``"N,1"`` as a string, even though digit 15
+isn't a descendant of digit 1), and same-resolution siblings like
+``('N', 9)``/``('N', 10)`` could compare in the wrong order (``"9" > "1"``
+as strings, despite 9 < 10 numerically). Both now compare the suid tuple
+directly (issue #71).
+
 **Breaking change:** ``Cell``'s constructor and ``Cell.overlaps()`` validated
 their arguments with bare ``assert`` statements, which ``python -O``/
 ``PYTHONOPTIMIZE`` compiles out entirely (silently disabling the checks),

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -209,12 +209,18 @@ class Cell(object):
         Return True if (`self.suid < other.suid` and
         `self.suid` is not a prefix of `other.suid`) or
         `self` is a subcell of `other`.
-        Here < is the lexicographic order.
+        Here < is the lexicographic order on the suid tuple itself (face
+        letter, then digits compared as the integers they are -- not on
+        any string rendering of it, which for `N_side >= 4` would compare
+        multi-character digits like 10-15 character-by-character rather
+        than numerically).
         Returns False otherwise.
         """
-        s = ",".join([str(x) for x in self.suid])
-        t = ",".join([str(x) for x in other.suid])
-        if (s <= t and not t.startswith(s)) or s.startswith(t):
+        s = self.suid
+        t = other.suid
+        t_starts_with_s = t[: len(s)] == s
+        s_starts_with_t = s[: len(t)] == t
+        if (s <= t and not t_starts_with_s) or s_starts_with_t:
             return True
         else:
             return False
@@ -453,9 +459,14 @@ class Cell(object):
             False
 
         """
-        s = ",".join([str(x) for x in self.suid])
-        t = ",".join([str(x) for x in other.suid])
-        return s.startswith(t)
+        # Compare the suid tuples directly (not a string rendering of
+        # them): for N_side >= 4, some digits are multi-character (e.g.
+        # 10-15), and comparing stringified, comma-joined suids with
+        # startswith() can misfire, e.g. treating ('N', 15) as a subcell
+        # of ('N', 1), since "N,15" starts with "N,1" as a string even
+        # though these are same-resolution siblings, not ancestor and
+        # descendant.
+        return self.suid[: len(other.suid)] == other.suid
 
     def subcells(self, resolution=None):
         """

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -184,6 +184,22 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             self.assertFalse(b <= a)
             self.assertFalse(c <= a)
 
+    def test_le_N_side_ge_4(self):
+        # Regression test for issue #71: __le__ used to lexicographically
+        # compare a string rendering of the suid (comma-joined), which
+        # breaks for N_side >= 4 once some digits become multi-character
+        # (e.g. 10-15 for N_side=4): "9" > "1" as strings, so same-
+        # resolution siblings (N, 9) and (N, 10) came out mis-ordered
+        # despite 9 < 10 numerically. Compare the suid tuple itself
+        # instead.
+        rdggs = RHEALPixDGGS(N_side=4)
+        c9 = Cell(rdggs, (N, 9))
+        c10 = Cell(rdggs, (N, 10))
+        self.assertTrue(c9 <= c10)
+        self.assertFalse(c10 <= c9)
+        self.assertTrue(c9 < c10)
+        self.assertFalse(c10 < c9)
+
     def test_gt(self):
         for rdggs in [WGS84_123, WGS84_123_RADIANS]:
             a = Cell(rdggs, (N, 7, 6, 8, 1))
@@ -340,6 +356,25 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             D = Cell(rdggs, (S, 1, 2, 0, 5))
             self.assertTrue(D.subcell(C))
             self.assertFalse(C.subcell(D))
+
+    def test_subcell_N_side_ge_4(self):
+        # Regression test for issue #71: subcell() used to compare a
+        # string rendering of the suid (comma-joined) with startswith(),
+        # which breaks for N_side >= 4 once some digits become
+        # multi-character (e.g. 10-15 for N_side=4): "N,15" starts with
+        # "N,1" as a string, incorrectly making (N, 15) look like a
+        # subcell of (N, 1) even though they're same-resolution siblings,
+        # not ancestor and descendant.
+        rdggs = RHEALPixDGGS(N_side=4)
+        a = Cell(rdggs, (N, 15))
+        b = Cell(rdggs, (N, 1))
+        self.assertFalse(a.subcell(b))
+        self.assertFalse(b.subcell(a))
+        # A genuine ancestor/descendant pair should still work.
+        parent = Cell(rdggs, (N, 1))
+        child = Cell(rdggs, (N, 1, 15))
+        self.assertTrue(child.subcell(parent))
+        self.assertFalse(parent.subcell(child))
 
     def test_subcells(self):
         for rdggs in [WGS84_123, WGS84_123_RADIANS]:

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -119,6 +119,29 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
                 count += 1
             self.assertEqual(count, correct_count)
 
+    def test_interval_N_side_ge_4(self):
+        # Regression test for issue #71: interval() walks cells via
+        # cell.successor() and terminates on `cell <= b`, and __le__ used
+        # to compare a string rendering of the suid, which breaks for
+        # N_side >= 4 (some digits, e.g. 10-15, are multi-character).
+        # Confirm interval() still produces the correct, fully-ordered
+        # sequence of cells in that case.
+        rdggs = RHEALPixDGGS(N_side=4)
+        A = rdggs.cell((N, 9))
+        B = rdggs.cell((N, 12))
+        start_index = A.index(order="level")
+        end_index = B.index(order="level")
+        correct_count = end_index - start_index + 1
+        count = 0
+        old_index = start_index - 1
+        for X in rdggs.interval(A, B):
+            new_index = X.index(order="level")
+            self.assertEqual(new_index, old_index + 1)
+            old_index = new_index
+            count += 1
+        self.assertEqual(count, correct_count)
+        self.assertEqual(old_index, end_index)
+
     def test_cell_from_point(self):
         # The nucleus of a cell should yield the cell.
         for plane in [True, False]:


### PR DESCRIPTION
Closes #71.

`Cell.subcell()` and `Cell.__le__` (which backs `<`/`<=`/`>`/`>=` via
`@total_ordering`, and anything built on those — e.g.
`RHEALPixDGGS.interval()`) compared a comma-joined **string** rendering of
a cell's suid, rather than the suid tuple itself.

That happened to work for the default `N_side=3`, where every digit is a
single character, so the comma delimiter always prevented false prefix
matches. For `N_side >= 4`, digits run 0..N_side**2-1, so some are
multi-character (e.g. 10-15 for `N_side=4`), and the comma no longer
saves it:

```python
>>> a = Cell(rdggs, ('N', 15))
>>> b = Cell(rdggs, ('N', 1))
>>> a.subcell(b)
True   # Wrong: same-resolution siblings, not ancestor/descendant.
```

`__le__` has the same class of bug for ordering: `('N', 9) <= ('N', 10)`
could come out `False`, since `"9" > "1"` as strings despite `9 < 10`
numerically.

Both now compare the suid tuple directly, which is what the existing
docstrings already claimed ("lexicographic order") — the fix brings the
implementation in line with the documented intent rather than changing
it.

## Testing

Added regression tests for `subcell()`, `__le__` (via `<`/`<=`), and
`RHEALPixDGGS.interval()` (a real consumer of `__le__`) at `N_side=4`.
Confirmed each of these new tests actually fails against the pre-fix code
(not just that it passes now) by temporarily reverting the `cell.py`
change and re-running them.

Full existing test suite and doctests still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
