### PR TITLE
fix: Cell.boundary() n<2 guard typo (==→=) prevents ZeroDivisionError

### DIFF
--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -810,7 +810,7 @@ class Cell(object):
         ul = self.ul_vertex(plane=True)
         w = self.width(plane=True)
         if n < 2:
-            n == 2
+            n = 2
         if interior:
             eps = w / 10000  # A smidgen.
         else:

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -620,3 +620,17 @@ class SCENZGridCELLTestCase(unittest.TestCase):
                 self.assertTrue(
                     c.contains(p, plane=plane)
                 )  # ------------------------------------------------------------------------------
+
+    def test_boundary_n_clamp(self):
+        # Regression test for issue #48: boundary(n<2) should clamp to n=2
+        # instead of crashing with ZeroDivisionError (n==2 comparison bug).
+        for plane in [True, False]:
+            c = Cell(WGS84_123, [S, 2])  # dart cell - hits the n<2 guard
+            # n=1 used to crash with ZeroDivisionError
+            result_1 = c.boundary(n=1, plane=plane)
+            self.assertIsInstance(result_1, list)
+            # n=0 used to return silently empty instead of clamped result
+            result_0 = c.boundary(n=0, plane=plane)
+            self.assertIsInstance(result_0, list)
+            # Both should match n=2 behavior after clamping
+            self.assertEqual(result_1, c.boundary(n=2, plane=plane))


### PR DESCRIPTION
## Summary

Fixes issue #48 — corrects a typo in `Cell.boundary()`'s low-`n` guard where a comparison operator (`==`) was used instead of an assignment (`=`).

## The Bug

**File:** `rhealpixdggs/cell.py` line 812-813

**Before:**
```python
if n < 2:
    n == 2  # ❌ comparison, always evaluates to False, does nothing
```

**After:**
```python
if n < 2:
    n = 2  # ✅ assignment, correctly clamps n to minimum of 2
```

## Impact

- `boundary(n=1)` on dart/skew-quad cells → **ZeroDivisionError** at line 818: `(w - 2*eps) / (n - 1)` where `n-1 = 0`
- `boundary(n=0)` on dart/skew-quad cells → **silently returns empty list** instead of clamped result
- Masked for quad/cap cells because those short-circuit to `vertices()` before reaching this code

## Regression Test

Added `test_boundary_n_clamp()` in `tests/test_cell.py` covering:
- `boundary(n=1)` on dart cell — previously crashed with ZeroDivisionError
- `boundary(n=0)` on dart cell — previously returned silently empty

## Verification

```python
>>> from rhealpixdggs.dggs import RHEALPixDGGS
>>> from rhealpixdggs.cell import Cell
>>> c = Cell(RHEALPixDGGS(), ['S', 2])
>>> c.boundary(n=1, plane=True)  # was: ZeroDivisionError; now: valid result
```

---

Fixes issue #48.