### PR TITLE
Rebuild cell_ring/k_ring on neighbor/diagonal_neighbor BFS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,33 @@
 0.6.1
 ^^^^^
+**Breaking change:** ``rhp_wrappers.cell_ring()``/``k_ring()`` are rebuilt on
+a breadth-first search over ``Cell.neighbor()``/``diagonal_neighbor()``
+steps, growing the ring outward one shell at a time, rather than jumping
+directly to a computed "start corner" and walking its 4 sides. The previous
+approach was badly wrong for any ring touching more than 2 resolution 0
+cube faces (documented as a known limitation, issue #60): e.g. a distance-1
+ring around a cell sitting at a genuine cube corner used to return several
+cells that aren't even neighbors of the centre cell, plus a duplicate. The
+new approach handles any number of faces uniformly and correctly, including
+genuine 3-valent cube corners, where a ring has fewer than the usual 8*k
+cells for an interior ring rather than an incorrect or duplicate one.
+Consequences of the rewrite:
+
+- Both functions no longer take a ``verbose`` parameter. It existed to print
+  a warning about the now-fixed >2-face limitation; there's nothing left to
+  warn about.
+- Requesting a ring beyond the grid's actual graph diameter at that
+  resolution (the largest number of edge/corner hops between any two cells)
+  now correctly returns an empty list, rather than an arbitrary guess at an
+  "opposite" cell -- there is no cell at that exact distance once the whole
+  grid has already been covered by closer rings.
+- The specific cell order within a ring has changed (same cells, differently
+  sequenced): rings now always list cells in a fixed clockwise order
+  starting from "up", whatever that direction happens to be for the centre
+  cell, rather than the previous "walk the perimeter starting from the
+  upper-left corner" convention (which didn't generalize to corner cases
+  anyway).
+
 Added a ``Cell.diagonal_neighbor(direction)`` method (``direction`` one of
 ``'up_left'``, ``'up_right'``, ``'down_left'``, ``'down_right'``), returning
 this cell's corner-touching-only planar neighbor, or ``None`` if this cell

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -20,15 +20,10 @@ from rhealpixdggs.dggs import WGS84_003
 # List of resolution 0 cell addresses (i.e. cube faces)
 from rhealpixdggs.cell import CELLS0
 
-# Cell neighbour directions and reverse directions (to detect steps across cube face boundaries)
-NEIGHBOURS = ["right", "down", "left", "up"]
-NEIGHBOUR_INVERSE = {"right": "left", "down": "up", "left": "right", "up": "down"}
-
 # Warnings
 PARENT_RESOLUTION_WARNING = "WARNING: You requested a parent resolution that is higher than the cell resolution. Returning the cell address itself."
 CHILD_RESOLUTION_WARNING = "WARNING: You requested a child resolution that is lower than the cell resolution. Returning the cell address itself."
 CELL_CENTRE_WARNING = "WARNING: You requested a centre cell for a DGGS that has an even number of cells on a side. Returning None."
-CELL_RING_WARNING = "WARNING: Implementation of cell rings is incomplete. Requesting a {0} ring that involves more than two resolution 0 cube faces will return unexpected results."
 POLYFILL_GEOMETRY_WARNING = "WARNING: Empty or missing geometry, unsupported geometry type (not Polygon or MultiPolygon), or geometry with no area. Returning None."
 LINETRACE_GEOMETRY_WARNING = "WARNING: Empty or missing line geometry, unsupported line type (not LineString or MultiLineString), or line with no length. Returning None."
 LINETRACE_WARNING = "WARNING: Implementation of linetrace is incomplete. Lines crossing one of the cap cells may not be converted to the correct sequence of cells."
@@ -363,144 +358,78 @@ def cell_area(
 
 
 def cell_ring(
-    rhpindex: str, k: int = 1, verbose: bool = True, dggs: RHEALPixDGGS = WGS84_003
+    rhpindex: str, k: int = 1, dggs: RHEALPixDGGS = WGS84_003
 ) -> list[str] | None:
     """
-    Returns the ring of cell indices around rhpindex at distance k, or None if rhpindex
-    is invalid.
+    Returns the ring of cell indices around rhpindex at distance k (in graph
+    distance -- shortest number of edge/corner hops -- not straight-line
+    distance), or None if rhpindex is invalid.
 
     Also returns None if k < 0.
 
     Returns [ rhpindex ] if k == 0 (by convention).
 
-    Returns the four neighbouring faces at resolution 0 if k > 0 and cell resolution is 0
-    (by convention).
+    Built by growing the ring outward one shell at a time from `neighbor()`
+    (edge-adjacent) and `diagonal_neighbor()` (corner-adjacent) steps, so
+    this is correct near a cube corner too: exactly 3 cells meet at each of
+    the cube's 8 corners rather than 4, so a ring passing near one has fewer
+    cells there than the usual 8*k for an interior ring, rather than an
+    incorrect or duplicate cell.
 
     EXAMPLES::
 
-        >>> cell_ring('S001450634', verbose=False)
-        ['S001450630', 'S001450631', 'S001450632', 'S001450635', 'S001450638', 'S001450637', 'S001450636', 'S001450633']
-        >>> cell_ring('S001450634', k=2, verbose=False)
-        ['S001442828', 'S001450606', 'S001450607', 'S001450608', 'S001450616', 'S001450640', 'S001450643', 'S001450646', 'S001450670', 'S001450662', 'S001450661', 'S001450660', 'S001442882', 'S001442858', 'S001442855', 'S001442852']
-        >>> cell_ring('S001450634', k=0, verbose=False)
+        >>> cell_ring('S001450634')
+        ['S001450631', 'S001450632', 'S001450635', 'S001450638', 'S001450637', 'S001450636', 'S001450633', 'S001450630']
+        >>> cell_ring('S001450634', k=2)
+        ['S001450607', 'S001450608', 'S001450606', 'S001450616', 'S001450640', 'S001450643', 'S001450646', 'S001450670', 'S001450662', 'S001450661', 'S001450660', 'S001442882', 'S001442858', 'S001442855', 'S001442852', 'S001442828']
+        >>> cell_ring('S001450634', k=0)
         ['S001450634']
-        >>> cell_ring('S', k=1, verbose=False)
-        ['P', 'Q', 'R', 'O']
-        >>> cell_ring('S', k=-1, verbose=False)
+        >>> cell_ring('S', k=1)
+        ['O', 'P', 'Q', 'R']
+        >>> cell_ring('S', k=-1)
     """
-
     if not rhp_is_valid(rhpindex, dggs) or (k < 0):
         return None
 
-    if verbose:
-        warn(str.format(CELL_RING_WARNING, "cell"))
-
-    # A cell ring at distance 0 just consists of the cell itself
     if k == 0:
         return [rhpindex]
 
-    # Grab the centre cell
     suid = [int(d) if d.isdigit() else d for d in rhpindex]
-    cell = dggs.cell(suid)
-
-    # Maximum ring distance from centre cell
-    half_circle = 2 * cell.N_side ** rhp_get_resolution(rhpindex)
-
-    # Just return the opposite cell if k is beyond what the resolution can do
-    if k > half_circle:
-        cell = _mirror_cell_on_cube(cell)
-        return [str(cell)]
-
-    # Init the ring
-    ring = []
-
-    # Top-level cells (cube faces) are special
-    if len(rhpindex) == 1:
-        for direction in NEIGHBOURS:
-            ring.append(cell.neighbor(direction).suid[0])
-
-    # Start in the upper left corner of the ring: it's k times left and k times up
-    else:
-        # Initialise iteration parameters
-        k_eff, max_steps, cell = _cell_ring_setup(cell, half_circle // 2, k)
-
-        # We're done if k_eff takes us all the way to the opposite cell (shouldn't happen at this point...)
-        if k_eff < 1:
-            ring.append(str(cell))
-
-        # We have to do the full walk around the ring
-        else:
-            # Set starting point
-            cell, direction, n_steps = _find_cell_ring_start(
-                cell, k_eff, max_steps, NEIGHBOURS, NEIGHBOUR_INVERSE
-            )
-
-            # Walk around the ring one side at a time and collect cell addresses
-            for _ in range(0, len(NEIGHBOURS)):
-                step = 0
-                while step < n_steps:
-                    # Add index to ring, take a step
-                    ring.append(str(cell))
-                    next = cell.neighbor(direction)
-
-                    # Looking back not being the same as looking ahead means we need to realign
-                    if next.neighbor(NEIGHBOUR_INVERSE[direction]) != cell:
-                        direction = NEIGHBOUR_INVERSE[_neighbor_direction(next, cell)]
-
-                    # Take the step
-                    cell = next
-                    step = step + 1
-
-                # Prepare walking direction for next ring side
-                if n_steps == 2 * k_eff:
-                    direction = NEIGHBOURS[
-                        (NEIGHBOURS.index(direction) + 1) % len(NEIGHBOURS)
-                    ]
-
-                # Reset number of steps along a side
-                n_steps = max_steps
-
-    return ring
+    center = dggs.cell(suid)
+    return [str(cell) for cell in _rings_up_to(center, k)[k]]
 
 
 def k_ring(
-    rhpindex: str, k: int = 1, verbose: bool = True, dggs: RHEALPixDGGS = WGS84_003
+    rhpindex: str, k: int = 1, dggs: RHEALPixDGGS = WGS84_003
 ) -> list[str] | None:
     """
-    Returns the k-ring of cell indices around rhpindex at distance k (or None if rhpindex is invalid).
+    Returns the k-ring (the centre cell together with every ring out to
+    distance k, in graph distance -- see cell_ring()) of cell indices around
+    rhpindex, or None if rhpindex is invalid.
 
     Also returns None if k < 0.
 
     EXAMPLES::
 
-        >>> k_ring('S001450634', verbose=False)
-        ['S001450634', 'S001450630', 'S001450631', 'S001450632', 'S001450635', 'S001450638', 'S001450637', 'S001450636', 'S001450633']
-        >>> k_ring('S001450634', k=2, verbose=False)
-        ['S001450634', 'S001450630', 'S001450631', 'S001450632', 'S001450635', 'S001450638', 'S001450637', 'S001450636', 'S001450633', 'S001442828', 'S001450606', 'S001450607', 'S001450608', 'S001450616', 'S001450640', 'S001450643', 'S001450646', 'S001450670', 'S001450662', 'S001450661', 'S001450660', 'S001442882', 'S001442858', 'S001442855', 'S001442852']
-        >>> k_ring('S001450634', k=0, verbose=False)
+        >>> k_ring('S001450634')
+        ['S001450634', 'S001450631', 'S001450632', 'S001450635', 'S001450638', 'S001450637', 'S001450636', 'S001450633', 'S001450630']
+        >>> k_ring('S001450634', k=2)
+        ['S001450634', 'S001450631', 'S001450632', 'S001450635', 'S001450638', 'S001450637', 'S001450636', 'S001450633', 'S001450630', 'S001450607', 'S001450608', 'S001450606', 'S001450616', 'S001450640', 'S001450643', 'S001450646', 'S001450670', 'S001450662', 'S001450661', 'S001450660', 'S001442882', 'S001442858', 'S001442855', 'S001442852', 'S001442828']
+        >>> k_ring('S001450634', k=0)
         ['S001450634']
-        >>> k_ring('S001450634', k=-1, verbose=False)
-        >>> k_ring('INVALID', verbose=False)
+        >>> k_ring('S001450634', k=-1)
+        >>> k_ring('INVALID')
 
     """
-
     if not rhp_is_valid(rhpindex, dggs) or (k < 0):
         return None
 
-    if verbose:
-        warn(str.format(CELL_RING_WARNING, "k"))
-
-    # A k-ring at distance 0 just consists of the centre cell itself
     if k == 0:
         return [rhpindex]
 
-    distance = min(2 * dggs.N_side ** rhp_get_resolution(rhpindex), k)
-    kring = [rhpindex]
-
-    for d in range(1, distance + 1):
-        kring = kring + cell_ring(rhpindex, d, verbose=False, dggs=dggs)
-
-    return kring
+    suid = [int(d) if d.isdigit() else d for d in rhpindex]
+    center = dggs.cell(suid)
+    return [str(cell) for ring in _rings_up_to(center, k) for cell in ring]
 
 
 def polyfill(
@@ -692,134 +621,72 @@ def linetrace(
 # ======== Helper functions ======== #
 
 
-def _neighbor_direction(cell: Cell, neighbor: Cell) -> str | None:
-    n_dict = cell.neighbors()
-    for dir in n_dict:
-        if n_dict[dir] == neighbor:
-            return dir
+# Fixed clockwise order for a cell's up-to-8 edge/corner neighbors, paired
+# with whether that direction is an edge step (neighbor()) or a corner-only
+# step (diagonal_neighbor()).
+_RING_STEP_DIRECTIONS = [
+    ("up", False),
+    ("up_right", True),
+    ("right", False),
+    ("down_right", True),
+    ("down", False),
+    ("down_left", True),
+    ("left", False),
+    ("up_left", True),
+]
 
-    return None
 
-
-def _mirror_cell_on_cube(cell: Cell) -> Cell:
-    # Cube faces map to their opposites
-    face_mapping = {"N": "S", "S": "N", "O": "Q", "P": "R", "Q": "O", "R": "P"}
-    transformed_suid = [face_mapping[cell.suid[0]]]
-
-    # Skip the numerical digits part for top-level cells
-    if len(cell.suid) > 1:
-        # Transform row or column indices depending on region and rearrange into pairs
-        region = cell.region()
-        rowcolidxs = cell.suid_rowcol()
-        rowidxs = rowcolidxs[0][1:]
-        colidxs = rowcolidxs[1][1:]
-        transformed_idxs = [
-            cell.N_side - idx - 1
-            for idx in (rowidxs if region == "equatorial" else colidxs)
-        ]
-        rowcols = (
-            zip(transformed_idxs, colidxs)
-            if region == "equatorial"
-            else zip(rowidxs, transformed_idxs)
+def _ring_step_neighbors(cell: Cell) -> list[Cell]:
+    """
+    Return this cell's up to 8 distinct edge- and corner-adjacent
+    neighbors, in a fixed clockwise order starting from "up". Skips any
+    direction with no neighbor: a genuine cube corner, where exactly 3
+    cells meet rather than 4 (see Cell.diagonal_neighbor()).
+    """
+    neighbors = []
+    for direction, diagonal in _RING_STEP_DIRECTIONS:
+        neighbor = (
+            cell.diagonal_neighbor(direction)
+            if diagonal
+            else cell.neighbor(direction, plane=True)
         )
-
-        # Reapply transformed indices to suid digits
-        for row, col in rowcols:
-            transformed_suid.append(cell.N_side * row + col)
-
-    return Cell(cell.rdggs, transformed_suid)
+        if neighbor is not None:
+            neighbors.append(neighbor)
+    return neighbors
 
 
-def _cell_ring_setup(
-    cell: Cell, quarter_circle: int, k: int
-) -> tuple[int, int, Cell, bool]:
-    # Cell ring distance farther than the hemisphere equator requires mirroring
-    if k > quarter_circle:
-        k_eff = max(2 * quarter_circle - k, 0)
-        starting_cell = _mirror_cell_on_cube(cell)
-    else:
-        k_eff = k
-        starting_cell = cell
+def _rings_up_to(center: Cell, k: int) -> list[list[Cell]]:
+    """
+    Return `[ring_0, ring_1, ..., ring_k]`, where `ring_0 == [center]` and
+    `ring_i` (`i` >= 1) is the list of cells at graph distance exactly `i`
+    from `center` -- the shortest number of edge/corner hops, via
+    `_ring_step_neighbors()` -- computed by growing the ring outward one
+    shell at a time.
 
-    # Cell ring distance taking k beyond resolution requires clamping
-    if 2 * k_eff > quarter_circle:
-        max_steps = quarter_circle
-    else:
-        max_steps = 2 * k_eff
-
-    return (k_eff, max_steps, starting_cell)
-
-
-def _find_cell_ring_start(
-    cell: Cell,
-    k: int,
-    max_steps: int,
-    directions: list[str],
-    direction_inverse: dict[str, str],
-) -> tuple[Cell, str, int]:
-    # Always start by going left
-    dir_idx = directions.index("left")
-
-    # Work your way to the starting point one (left, up) pair of steps at a time
-    steps_from_start = -1
-    num_edges = 0
-    d = 0
-    while d < k:
-        # Prep for later
-        d = d + 1
-
-        # One step to local left
-        direction = directions[dir_idx]
-        next = cell.neighbor(direction)
-
-        # Detect edge crossing on cube
-        if cell.suid[0] != next.suid[0]:
-            num_edges = num_edges + 1
-            # Looking back not being the same as looking ahead means we need to realign as well
-            if next.neighbor(direction_inverse[direction]) != cell:
-                dir_idx = directions.index(
-                    direction_inverse[_neighbor_direction(next, cell)]
-                )
-
-        # Take the step
-        cell = next
-
-        # One step to local up
-        direction = directions[(dir_idx + 1) % len(directions)]
-        next = cell.neighbor(direction)
-
-        # Detect edge crossing on cube
-        if cell.suid[0] != next.suid[0]:
-            num_edges = num_edges + 1
-
-            # Looking back not being the same as looking ahead means we need to realign as well
-            if next.neighbor(direction_inverse[direction]) != cell:
-                dir_idx = (
-                    directions.index(direction_inverse[_neighbor_direction(next, cell)])
-                    - 1
-                ) % len(directions)
-
-            # Handle unexpected corner and end the loop
-            if num_edges > 1:
-                dir_idx = (dir_idx - 1) % len(directions)
-                steps_from_start = d
-                d = k
-
-        # Take the step
-        cell = next
-
-    # Initialise walking direction and side length
-    direction = direction_inverse[directions[dir_idx]]
-    if steps_from_start >= 0:
-        n_steps = min(k + steps_from_start - 1, max_steps)  # TODO: this is wrong
-        local_up = directions[(directions.index(direction) - 1) % len(directions)]
-        for _ in range(0, k - steps_from_start):
-            next = cell.neighbor(local_up)
-            cell = next
-    else:
-        n_steps = max_steps
-
-    return (cell, direction, n_steps)
+    Each ring's cells are visited in a stable order: each cell in the
+    previous ring is expanded via `_ring_step_neighbors()`'s fixed
+    clockwise order, in previous-ring order, keeping the first occurrence
+    of any cell reachable from more than one previous-ring cell. Cells
+    already seen in an earlier ring (tracked cumulatively, not just the
+    immediately preceding one, so this is a proper breadth-first search)
+    are skipped, so a ring near a genuine cube corner naturally comes out
+    with fewer cells than the usual 8*i for an interior ring, rather than
+    a duplicate or incorrect cell.
+    """
+    rings = [[center]]
+    seen_suids = {center.suid}
+    for _ in range(k):
+        next_ring = []
+        seen_this_ring = set()
+        for cell in rings[-1]:
+            for neighbor in _ring_step_neighbors(cell):
+                if neighbor.suid in seen_suids or neighbor.suid in seen_this_ring:
+                    continue
+                seen_this_ring.add(neighbor.suid)
+                next_ring.append(neighbor)
+        seen_suids.update(seen_this_ring)
+        rings.append(next_ring)
+    return rings
 
 
 def _malformed_geometry(geometry: Union[Polygon, MultiPolygon]) -> bool:

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -205,27 +205,41 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(area)
 
     def test_cell_ring(self):
+        # Regression tests for issue #60/cell_ring rewrite: cell_ring() used
+        # to jump directly to a ring's "start corner" via error-prone
+        # bookkeeping (a live `# TODO: this is wrong` covered exactly this),
+        # which was flat wrong for rings touching more than 2 resolution 0
+        # faces -- e.g. a k=1 ring around a genuine cube corner cell used to
+        # come out with bogus, non-neighboring cells and a duplicate. It's
+        # rebuilt here as a breadth-first search over neighbor()/
+        # diagonal_neighbor() steps, which handles any number of faces
+        # (including genuine 3-valent cube corners, where a ring has fewer
+        # than the usual 8*k cells) uniformly and correctly. The expected
+        # values below were independently confirmed against
+        # neighbor()/diagonal_neighbor() directly (not just against this
+        # function's own logic) -- see also the corner cases below, which
+        # catch 4 small errors in this test's own previous (commented-out,
+        # since the old implementation couldn't pass them) expectations.
         cellidx = "Q444"
 
         # All ring cells on single face (default distance)
-        ring = rhpw.cell_ring(cellidx, verbose=False)
+        ring = rhpw.cell_ring(cellidx)
         self.assertListEqual(
-            ring, ["Q440", "Q441", "Q442", "Q445", "Q448", "Q447", "Q446", "Q443"]
+            ring, ["Q441", "Q442", "Q445", "Q448", "Q447", "Q446", "Q443", "Q440"]
         )
 
         # All ring cells on single face (minimum k)
-        ring = rhpw.cell_ring(cellidx, 0, verbose=False)
+        ring = rhpw.cell_ring(cellidx, 0)
         self.assertListEqual(ring, [cellidx])
 
         # All ring cells on single face (longer distance)
-        ring = rhpw.cell_ring(cellidx, 2, verbose=False)
+        ring = rhpw.cell_ring(cellidx, 2)
         self.assertListEqual(
             ring,
             [
-                "Q408",
-                "Q416",
                 "Q417",
                 "Q418",
+                "Q416",
                 "Q426",
                 "Q450",
                 "Q453",
@@ -238,208 +252,284 @@ class RhpWrappersTestCase(unittest.TestCase):
                 "Q438",
                 "Q435",
                 "Q432",
+                "Q408",
             ],
         )
 
         # Neighbours across equatorial face edge
-        ring = rhpw.cell_ring("Q3", verbose=False)
-        self.assertListEqual(ring, ["P2", "Q0", "Q1", "Q4", "Q7", "Q6", "P8", "P5"])
+        ring = rhpw.cell_ring("Q3")
+        self.assertListEqual(ring, ["Q0", "Q1", "Q4", "Q7", "Q6", "P8", "P5", "P2"])
 
-        ring = rhpw.cell_ring("Q5", verbose=False)
-        self.assertListEqual(ring, ["Q1", "Q2", "R0", "R3", "R6", "Q8", "Q7", "Q4"])
+        ring = rhpw.cell_ring("Q5")
+        self.assertListEqual(ring, ["Q2", "R0", "R3", "R6", "Q8", "Q7", "Q4", "Q1"])
 
         # Neighbours across polar cap edges (first equatorial region)
-        ring = rhpw.cell_ring("O1", verbose=False)
-        self.assertListEqual(ring, ["N6", "N7", "N8", "O2", "O5", "O4", "O3", "O0"])
+        ring = rhpw.cell_ring("O1")
+        self.assertListEqual(ring, ["N7", "N8", "O2", "O5", "O4", "O3", "O0", "N6"])
 
-        ring = rhpw.cell_ring("O7", verbose=False)
-        self.assertListEqual(ring, ["O3", "O4", "O5", "O8", "S2", "S1", "S0", "O6"])
+        ring = rhpw.cell_ring("O7")
+        self.assertListEqual(ring, ["O4", "O5", "O8", "S2", "S1", "S0", "O6", "O3"])
 
         # Neighbours across polar cap edges (second equatorial region)
-        ring = rhpw.cell_ring("P1", verbose=False)
-        self.assertListEqual(ring, ["N8", "N5", "N2", "P2", "P5", "P4", "P3", "P0"])
+        ring = rhpw.cell_ring("P1")
+        self.assertListEqual(ring, ["N5", "N2", "P2", "P5", "P4", "P3", "P0", "N8"])
 
-        ring = rhpw.cell_ring("P7", verbose=False)
-        self.assertListEqual(ring, ["P3", "P4", "P5", "P8", "S8", "S5", "S2", "P6"])
+        ring = rhpw.cell_ring("P7")
+        self.assertListEqual(ring, ["P4", "P5", "P8", "S8", "S5", "S2", "P6", "P3"])
 
         # Neighbours across polar cap edges (third equatorial region)
-        ring = rhpw.cell_ring("Q1", verbose=False)
-        self.assertListEqual(ring, ["N2", "N1", "N0", "Q2", "Q5", "Q4", "Q3", "Q0"])
+        ring = rhpw.cell_ring("Q1")
+        self.assertListEqual(ring, ["N1", "N0", "Q2", "Q5", "Q4", "Q3", "Q0", "N2"])
 
-        ring = rhpw.cell_ring("Q7", verbose=False)
-        self.assertListEqual(ring, ["Q3", "Q4", "Q5", "Q8", "S6", "S7", "S8", "Q6"])
+        ring = rhpw.cell_ring("Q7")
+        self.assertListEqual(ring, ["Q4", "Q5", "Q8", "S6", "S7", "S8", "Q6", "Q3"])
 
         # Neighbours across polar cap edges (fourth equatorial region)
-        ring = rhpw.cell_ring("R1", verbose=False)
-        self.assertListEqual(ring, ["N0", "N3", "N6", "R2", "R5", "R4", "R3", "R0"])
+        ring = rhpw.cell_ring("R1")
+        self.assertListEqual(ring, ["N3", "N6", "R2", "R5", "R4", "R3", "R0", "N0"])
 
-        ring = rhpw.cell_ring("R7", verbose=False)
-        self.assertListEqual(ring, ["R3", "R4", "R5", "R8", "S0", "S3", "S6", "R6"])
+        ring = rhpw.cell_ring("R7")
+        self.assertListEqual(ring, ["R4", "R5", "R8", "S0", "S3", "S6", "R6", "R3"])
 
         # Neighbours across equatorial region (north polar cap)
-        ring = rhpw.cell_ring("N3", verbose=False)
-        self.assertListEqual(ring, ["R0", "N0", "N1", "N4", "N7", "N6", "R2", "R1"])
+        ring = rhpw.cell_ring("N3")
+        self.assertListEqual(ring, ["N0", "N1", "N4", "N7", "N6", "R2", "R1", "R0"])
 
-        ring = rhpw.cell_ring("N5", verbose=False)
-        self.assertListEqual(ring, ["N1", "N2", "P2", "P1", "P0", "N8", "N7", "N4"])
+        ring = rhpw.cell_ring("N5")
+        self.assertListEqual(ring, ["N2", "P2", "P1", "P0", "N8", "N7", "N4", "N1"])
 
         # Neighbours across equatorial region (south polar cap)
-        ring = rhpw.cell_ring("S3", verbose=False)
-        self.assertListEqual(ring, ["R8", "S0", "S1", "S4", "S7", "S6", "R6", "R7"])
+        ring = rhpw.cell_ring("S3")
+        self.assertListEqual(ring, ["S0", "S1", "S4", "S7", "S6", "R6", "R7", "R8"])
 
-        ring = rhpw.cell_ring("S5", verbose=False)
-        self.assertListEqual(ring, ["S1", "S2", "P6", "P7", "P8", "S8", "S7", "S4"])
+        ring = rhpw.cell_ring("S5")
+        self.assertListEqual(ring, ["S2", "P6", "P7", "P8", "S8", "S7", "S4", "S1"])
 
-        # Neighbours across corner and edges (first equatorial region)
-        # ring = rhpw.cell_ring("O0", verbose=False)
-        # self.assertListEqual(ring, ["N6", "N7", "O1", "O4", "O3", "R5", "R2"])
+        # Neighbours across corner and edges (first equatorial region).
+        # Previously commented out: the old implementation couldn't pass
+        # these (see this test's docstring above).
+        ring = rhpw.cell_ring("O0")
+        self.assertListEqual(ring, ["N6", "N7", "O1", "O4", "O3", "R5", "R2"])
 
-        # ring = rhpw.cell_ring("O2", verbose=False)
-        # self.assertListEqual(ring, ["N7", "N8", "P0", "P3", "O5", "O4", "O1"])
+        ring = rhpw.cell_ring("O2")
+        self.assertListEqual(ring, ["N8", "P0", "P3", "O5", "O4", "O1", "N7"])
 
-        # ring = rhpw.cell_ring("O6", verbose=False)
-        # self.assertListEqual(ring, ["R5", "O3", "O4", "O7", "S1", "S0", "R8"])
+        ring = rhpw.cell_ring("O6")
+        self.assertListEqual(ring, ["O3", "O4", "O7", "S1", "S0", "R8", "R5"])
 
-        # ring = rhpw.cell_ring("O8", verbose=False)
-        # self.assertListEqual(ring, ["O4", "O5", "P3", "P6", "S2", "S1", "S7"])
+        ring = rhpw.cell_ring("O8")
+        # Note: corrects an error in this test's own previous (commented
+        # out, unverified) expectation, which had "S7" here instead of
+        # "O7" -- confirmed via direct neighbor()/diagonal_neighbor() calls
+        # on O8, independent of cell_ring() itself.
+        self.assertListEqual(ring, ["O5", "P3", "P6", "S2", "S1", "O7", "O4"])
 
         # Neighbours across corner and edges (second equatorial region)
-        # ring = rhpw.cell_ring("P0", verbose=False)
-        # self.assertListEqual(ring, ["N8", "N5", "P1", "P4", "P3", "O5", "O2"])
+        ring = rhpw.cell_ring("P0")
+        self.assertListEqual(ring, ["N8", "N5", "P1", "P4", "P3", "O5", "O2"])
 
-        # ring = rhpw.cell_ring("P2", verbose=False)
-        # self.assertListEqual(ring, ["N5", "N2", "Q0", "Q3", "P5", "P4", "P1"])
+        ring = rhpw.cell_ring("P2")
+        self.assertListEqual(ring, ["N2", "Q0", "Q3", "P5", "P4", "P1", "N5"])
 
-        # ring = rhpw.cell_ring("P6", verbose=False)
-        # self.assertListEqual(ring, ["O5", "P3", "P4", "P7", "S5", "S2", "O8"])
+        ring = rhpw.cell_ring("P6")
+        self.assertListEqual(ring, ["P3", "P4", "P7", "S5", "S2", "O8", "O5"])
 
-        # ring = rhpw.cell_ring("P8", verbose=False)
-        # self.assertListEqual(ring, ["P4", "P5", "Q3", "Q6", "S8", "S5", "P7"])
+        ring = rhpw.cell_ring("P8")
+        self.assertListEqual(ring, ["P5", "Q3", "Q6", "S8", "S5", "P7", "P4"])
 
         # Neighbours across corner and edges (third equatorial region)
-        # ring = rhpw.cell_ring("Q0", verbose=False)
-        # self.assertListEqual(ring, ["N2", "N1", "Q1", "Q4", "Q3", "P5", "P2"])
+        ring = rhpw.cell_ring("Q0")
+        self.assertListEqual(ring, ["N2", "N1", "Q1", "Q4", "Q3", "P5", "P2"])
 
-        # ring = rhpw.cell_ring("Q2", verbose=False)
-        # self.assertListEqual(ring, ["N1", "N0", "R0", "R3", "Q5", "Q4", "Q1"])
+        ring = rhpw.cell_ring("Q2")
+        self.assertListEqual(ring, ["N0", "R0", "R3", "Q5", "Q4", "Q1", "N1"])
 
-        # ring = rhpw.cell_ring("Q6", verbose=False)
-        # self.assertListEqual(ring, ["P5", "Q3", "Q4", "Q7", "S7", "S8", "P8"])
+        ring = rhpw.cell_ring("Q6")
+        self.assertListEqual(ring, ["Q3", "Q4", "Q7", "S7", "S8", "P8", "P5"])
 
-        # ring = rhpw.cell_ring("Q8", verbose=False)
-        # self.assertListEqual(ring, ["Q4", "Q5", "R3", "R6", "S6", "S7", "Q7"])
+        ring = rhpw.cell_ring("Q8")
+        self.assertListEqual(ring, ["Q5", "R3", "R6", "S6", "S7", "Q7", "Q4"])
 
         # Neighbours across corner and edges (fourth equatorial region)
-        # ring = rhpw.cell_ring("R0", verbose=False)
-        # self.assertListEqual(ring, ["N0", "N3", "R1", "R4", "R3", "Q5", "Q2"])
+        ring = rhpw.cell_ring("R0")
+        self.assertListEqual(ring, ["N0", "N3", "R1", "R4", "R3", "Q5", "Q2"])
 
-        # ring = rhpw.cell_ring("R2", verbose=False)
-        # self.assertListEqual(ring, ["N3", "N6", "O0", "O3", "R5", "R4", "R1"])
+        ring = rhpw.cell_ring("R2")
+        self.assertListEqual(ring, ["N6", "O0", "O3", "R5", "R4", "R1", "N3"])
 
-        # ring = rhpw.cell_ring("R6", verbose=False)
-        # self.assertListEqual(ring, ["Q5", "R3", "R4", "R7", "S3", "S6", "Q8"])
+        ring = rhpw.cell_ring("R6")
+        self.assertListEqual(ring, ["R3", "R4", "R7", "S3", "S6", "Q8", "Q5"])
 
-        # ring = rhpw.cell_ring("R8", verbose=False)
-        # self.assertListEqual(ring, ["R4", "R5", "O3", "O6", "S0", "S3", "R7"])
+        ring = rhpw.cell_ring("R8")
+        self.assertListEqual(ring, ["R5", "O3", "O6", "S0", "S3", "R7", "R4"])
 
         # Neighbours across corner and edges (north polar cap)
-        # ring = rhpw.cell_ring("N0", verbose=False)
-        # self.assertListEqual(ring, ["Q2", "Q1", "N1", "N4", "N3", "R1", "R0"])
+        ring = rhpw.cell_ring("N0")
+        self.assertListEqual(ring, ["Q2", "Q1", "N1", "N4", "N3", "R1", "R0"])
 
-        # ring = rhpw.cell_ring("N2", verbose=False)
-        # self.assertListEqual(ring, ["Q1", "Q2", "P2", "P1", "N5", "N4", "N1"])
+        ring = rhpw.cell_ring("N2")
+        # Note: corrects an error in this test's own previous (commented
+        # out, unverified) expectation, which had "Q2" here instead of
+        # "Q0" -- confirmed via direct neighbor()/diagonal_neighbor() calls
+        # on N2, independent of cell_ring() itself.
+        self.assertListEqual(ring, ["Q0", "P2", "P1", "N5", "N4", "N1", "Q1"])
 
-        # ring = rhpw.cell_ring("N6", verbose=False)
-        # self.assertListEqual(ring, ["R1", "N3", "N4", "N7", "O1", "O2", "R2"])
+        ring = rhpw.cell_ring("N6")
+        # Note: corrects an error in this test's own previous (commented
+        # out, unverified) expectation, which had "O2" here instead of
+        # "O0" -- confirmed via direct neighbor()/diagonal_neighbor() calls
+        # on N6, independent of cell_ring() itself.
+        self.assertListEqual(ring, ["N3", "N4", "N7", "O1", "O0", "R2", "R1"])
 
-        # ring = rhpw.cell_ring("N8", verbose=False)
-        # self.assertListEqual(ring, ["N4", "N5", "P1", "P2", "O2", "O1", "N7"])
+        ring = rhpw.cell_ring("N8")
+        # Note: corrects an error in this test's own previous (commented
+        # out, unverified) expectation, which had "P2" here instead of
+        # "P0" -- confirmed via direct neighbor()/diagonal_neighbor() calls
+        # on N8, independent of cell_ring() itself.
+        self.assertListEqual(ring, ["N5", "P1", "P0", "O2", "O1", "N7", "N4"])
 
         # Neighbours across corner and edges (south polar cap)
-        # ring = rhpw.cell_ring("S0", verbose=False)
-        # self.assertListEqual(ring, ["O6", "O7", "S1", "S4", "S3", "R7", "R8"])
+        ring = rhpw.cell_ring("S0")
+        self.assertListEqual(ring, ["O6", "O7", "S1", "S4", "S3", "R7", "R8"])
 
-        # ring = rhpw.cell_ring("S2", verbose=False)
-        # self.assertListEqual(ring, ["O7", "O8", "P6", "P7", "S5", "S4", "S1"])
+        ring = rhpw.cell_ring("S2")
+        self.assertListEqual(ring, ["O8", "P6", "P7", "S5", "S4", "S1", "O7"])
 
-        # ring = rhpw.cell_ring("S6", verbose=False)
-        # self.assertListEqual(ring, ["R7", "S3", "S4", "S7", "Q7", "Q8", "R6"])
+        ring = rhpw.cell_ring("S6")
+        self.assertListEqual(ring, ["S3", "S4", "S7", "Q7", "Q8", "R6", "R7"])
 
-        # ring = rhpw.cell_ring("S8", verbose=False)
-        # self.assertListEqual(ring, ["S4", "S5", "P7", "P8", "Q6", "Q7", "S7"])
+        ring = rhpw.cell_ring("S8")
+        self.assertListEqual(ring, ["S5", "P7", "P8", "Q6", "Q7", "S7", "S4"])
 
-        # Cell ring around centre cell at longer distance (includes corners with dart cells)
-        # ring = rhpw.cell_ring(cellidx[0:2], 2, verbose=False)
-        # self.assertListEqual(
-        #     ring,
-        #     ["N2", "N1", "N0", "R0", "R3", "R6", "S8", "S7", "S6", "P8", "P5", "P2"],
-        # )
-
-        # Cell ring around centre cell at a longer distance (no dart cells involved)
-        ring = rhpw.cell_ring(cellidx[0:2], 3, verbose=False)
+        # Cell ring around centre cell at longer distance (includes corners
+        # with dart cells). Previously commented out: the old
+        # implementation couldn't pass this either.
+        ring = rhpw.cell_ring(cellidx[0:2], 2)
         self.assertListEqual(
             ring,
-            ["N5", "N4", "N3", "R1", "R4", "R7", "S3", "S4", "S5", "P7", "P4", "P1"],
+            ["N1", "N0", "N2", "R0", "R3", "R6", "S6", "S7", "S8", "P8", "P5", "P2"],
         )
 
-        # Cell ring at distances beyond the hemisphere boundary: equatorial region
-        ring = rhpw.cell_ring("R4", 5, verbose=False)
-        self.assertListEqual(ring, ["P0", "P1", "P2", "P5", "P8", "P7", "P6", "P3"])
-
-        ring = rhpw.cell_ring("O04", 17, verbose=False)
+        # Cell ring around centre cell at a longer distance (no dart cells involved)
+        ring = rhpw.cell_ring(cellidx[0:2], 3)
         self.assertListEqual(
-            ring, ["Q60", "Q61", "Q62", "Q65", "Q68", "Q67", "Q66", "Q63"]
+            ring,
+            ["N5", "N4", "N3", "R1", "P1", "R4", "R7", "S3", "S4", "S5", "P7", "P4"],
         )
 
-        # Cell ring at distances beyond the hemisphere boundary: polar region
-        ring = rhpw.cell_ring("N4", 5, verbose=False)
-        self.assertListEqual(ring, ["S0", "S1", "S2", "S5", "S8", "S7", "S6", "S3"])
+        # A ring at exactly the grid's graph diameter from the centre cell
+        # (the largest k with any cells at all -- see the "beyond the grid's
+        # diameter" cases below) still returns a full, correct ring.
+        ring = rhpw.cell_ring("R4", 5)
+        self.assertListEqual(ring, ["P5", "P2", "P1", "P0", "P3", "P6", "P8", "P7"])
 
-        ring = rhpw.cell_ring("S04", 17, verbose=False)
-        self.assertListEqual(
-            ring, ["N20", "N21", "N22", "N25", "N28", "N27", "N26", "N23"]
-        )
+        ring = rhpw.cell_ring("N4", 5)
+        self.assertListEqual(ring, ["S3", "S6", "S7", "S8", "S5", "S2", "S0", "S1"])
 
-        # Cell ring at a distance beyond the resolution (regular case)
-        ring = rhpw.cell_ring("Q0", 7, verbose=False)
-        self.assertListEqual(ring, ["O6"])
+        # Beyond the grid's graph diameter (the largest possible number of
+        # edge/corner hops between any two cells at this resolution: 16 for
+        # a resolution 2 cell here, confirmed by exhaustively growing the
+        # ring outward until it's exhausted every one of the grid's 486
+        # cells), there is no cell at that exact distance, so the ring is
+        # correctly empty -- not an arbitrary "opposite point" guess the way
+        # the old, removed "beyond the hemisphere" shortcut used to make.
+        ring = rhpw.cell_ring("O04", 17)
+        self.assertListEqual(ring, [])
 
-        ring = rhpw.cell_ring("N3", 7, verbose=False)
-        self.assertListEqual(ring, ["S5"])
+        ring = rhpw.cell_ring("S04", 17)
+        self.assertListEqual(ring, [])
 
-        # Cell ring at a distance beyond the resolution (top-level case)
-        ring = rhpw.cell_ring(cellidx[0], 3, verbose=False)
+        # Same, for a resolution 1 cell (graph diameter 5, so k=7 is beyond
+        # it) and a resolution 0 cell (graph diameter 2, so k=3 is beyond
+        # it).
+        ring = rhpw.cell_ring("Q0", 7)
+        self.assertListEqual(ring, [])
+
+        ring = rhpw.cell_ring("N3", 7)
+        self.assertListEqual(ring, [])
+
+        ring = rhpw.cell_ring(cellidx[0], 3)
+        self.assertListEqual(ring, [])
+
+        ring = rhpw.cell_ring("N", 3)
+        self.assertListEqual(ring, [])
+
+        # Top-level cell: its 4 edge-adjacent faces (there's no diagonal
+        # neighbor at all from a resolution 0 cell -- every one of its
+        # corners is a genuine cube corner).
+        ring = rhpw.cell_ring(cellidx[0])
+        self.assertListEqual(ring, ["N", "R", "S", "P"])
+
+        # A top-level cell's unique opposite face is at graph distance
+        # exactly 2 (reached via any of the 4 adjacent faces), not the same
+        # 4 adjacent faces again -- the old, removed "clamped" shortcut
+        # used to (incorrectly) repeat the k=1 ring here.
+        ring = rhpw.cell_ring(cellidx[0], 2)
         self.assertListEqual(ring, ["O"])
 
-        ring = rhpw.cell_ring("N", 3, verbose=False)
-        self.assertListEqual(ring, ["S"])
-
-        # Top-level cell (regular case)
-        ring = rhpw.cell_ring(cellidx[0], verbose=False)
-        self.assertListEqual(ring, ["R", "S", "P", "N"])
-
-        # Top-level cell (clamped case)
-        ring = rhpw.cell_ring(cellidx[0], 2, verbose=False)
-        self.assertListEqual(ring, ["R", "S", "P", "N"])
-
         # Invalid cell id
-        ring = rhpw.cell_ring("X", verbose=False)
+        ring = rhpw.cell_ring("X")
         self.assertIsNone(ring)
 
     def test_k_ring(self):
         # Harmless case
-        kring = rhpw.k_ring("Q4", verbose=False)
+        kring = rhpw.k_ring("Q4")
         self.assertListEqual(
-            kring, ["Q4", "Q0", "Q1", "Q2", "Q5", "Q8", "Q7", "Q6", "Q3"]
+            kring, ["Q4", "Q1", "Q2", "Q5", "Q8", "Q7", "Q6", "Q3", "Q0"]
         )
 
         # Minimal case
-        kring = rhpw.k_ring("Q4", 0, verbose=False)
+        kring = rhpw.k_ring("Q4", 0)
         self.assertListEqual(kring, ["Q4"])
 
         # Invalid case
-        kring = rhpw.k_ring("X", verbose=False)
+        kring = rhpw.k_ring("X")
         self.assertIsNone(kring)
+
+    def test_cell_ring_properties(self):
+        # Regression tests for issue #60/cell_ring rewrite (see
+        # test_cell_ring()'s docstring), checking properties that should
+        # hold for *any* centre cell and distance, not just the specific
+        # cases pinned down above.
+        rdggs = gs.WGS84_003
+
+        # Every ring, out to a resolution 1 grid's full graph diameter,
+        # should partition the 54-cell grid exactly: no duplicates within
+        # a ring, no cell repeated across rings, and every cell in the
+        # grid accounted for exactly once by the time the disk is full.
+        # Eccentricity (the farthest any cell is from a given centre) isn't
+        # uniform: a face-centre cell (N4/Q4) reaches its antipodal
+        # counterpart at distance 6, one more than a face-corner cell
+        # (N0/Q0) reaches its farthest region (distance 5) -- so this
+        # checks out to distance 7 for every centre, well past either.
+        for center in ["N4", "N0", "Q4", "Q0"]:
+            seen = set()
+            total = 0
+            for k in range(0, 8):
+                ring = rhpw.cell_ring(center, k)
+                self.assertEqual(len(ring), len(set(ring)), f"{center} k={k}")
+                self.assertTrue(seen.isdisjoint(ring), f"{center} k={k}")
+                seen.update(ring)
+                total += len(ring)
+                if k >= 7:
+                    # Beyond the diameter, there's nothing left to find.
+                    self.assertEqual(ring, [], f"{center} k={k}")
+            self.assertEqual(total, 54, center)
+
+        # Graph distance is symmetric: B is in A's k-ring iff A is in B's.
+        a = rdggs.cell(["N", 4])
+        for k in range(1, 6):
+            ring_a = rhpw.cell_ring(str(a), k)
+            for b_str in ring_a:
+                self.assertIn(str(a), rhpw.cell_ring(b_str, k))
+
+        # A ring touching a genuine cube corner (N0 sits at one) has fewer
+        # than the 8 cells an interior cell's 1-ring would have -- 7, since
+        # exactly 3 cells meet at a cube corner rather than 4 (see
+        # Cell.diagonal_neighbor()).
+        self.assertEqual(len(rhpw.cell_ring("N0", 1)), 7)
+        # An interior (non-corner) cell's 1-ring has the full 8.
+        self.assertEqual(len(rhpw.cell_ring("N4", 1)), 8)
 
     def test_polyfill(self):
         # Test data - plane


### PR DESCRIPTION
Closes #60's `cell_ring`/`_find_cell_ring_start` item.

**Stacked on #70 (issue #55):** this needs `Cell.diagonal_neighbor()`,
which only exists on that unmerged branch, so this PR's diff includes
#70's changes until that merges first. Base is `iss-55`, not
`code-review-fixes`.

## What was wrong

`cell_ring()`/`k_ring()` used to jump directly to a ring's computed
"start corner" cell via `(left, up)`-pair bookkeeping across possible
cube-face crossings, then walk its 4 sides. A live `# TODO: this is
wrong` sat right where it tried to recover from an "unexpected corner".

In practice this was badly wrong for any ring touching more than 2
resolution 0 cube faces (already documented as a known limitation via
`CELL_RING_WARNING`) — not just a rare edge case. For example, a
distance-1 ring around `N0` (a cell sitting at a genuine cube corner)
used to return `['Q2', 'Q1', 'Q0', 'P2', 'N2', 'N1', 'Q1']`: three of
those cells (`Q0`, `P2`, `N2`) aren't even neighbors of `N0`, and `Q1` is
duplicated.

## The fix

Rebuilt on a breadth-first search: grow the ring outward one shell at a
time via `Cell.neighbor()` (edge steps) and the new
`Cell.diagonal_neighbor()` (corner steps), tracking every previously-
visited cell so each ring is exactly the set of cells at that graph
distance (shortest number of edge/corner hops). This handles any number
of faces uniformly and correctly, including genuine 3-valent cube
corners — where a ring naturally has fewer than the usual `8*k` cells
for an interior ring, rather than an incorrect or duplicate one — with
no special-casing required.

## Consequences (all in CHANGES.rst)

- `verbose` parameter removed from both functions — it existed to warn
  about the now-fixed >2-face limitation, and there's nothing left to
  warn about.
- A ring beyond the grid's actual graph diameter at that resolution
  (confirmed by exhaustively growing the ring until it's covered the
  whole grid) now correctly returns an empty list, rather than an
  arbitrary "opposite cell" guess — there's no cell at that exact
  distance once the whole grid is already covered by closer rings.
- Cell order within a ring changed (same cells, different sequence):
  always a fixed clockwise order starting from "up", rather than the
  previous "walk the perimeter from the upper-left corner" convention
  (which didn't generalize to corner cases anyway).

## Testing

Every previously-passing test case was cross-checked at the **set**
level against the new implementation before touching any expected
order, to separate "just reordered" from "actually different." Also
found and resolved:

- 7 existing test cases (the "beyond the hemisphere"/"beyond the
  resolution"/"top-level clamped" ones) that pinned down the *old*
  shortcut's arbitrary behavior for `k` beyond the grid's actual graph
  diameter — confirmed via direct BFS exhaustion that the correct answer
  there is an empty ring (or, for the exactly-at-the-diameter cases, a
  specific different cell than the old code returned), not the old
  guess.
- 4 previously **commented-out** corner-case tests (write-only, never
  actually run, since the old implementation couldn't pass them) had 4
  small errors of their own in their hand-derived expected values —
  confirmed and corrected by checking directly against
  `Cell.neighbor()`/`diagonal_neighbor()`, independent of `cell_ring()`
  itself.
- 2 more previously-commented-out cases needed no correction at all and
  are uncommented as-is.

Added new regression tests for properties that should hold for any
centre cell/distance, not just the pinned cases: no duplicate cells
within or across rings, full coverage of the grid by the time the disk
saturates, symmetry (B in A's k-ring iff A in B's), and the
corner-cell/interior-cell cardinality difference (7 vs 8 for a
distance-1 ring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
