### PR TITLE
Close test-coverage gaps from the code review

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,31 @@
 0.6.1
 ^^^^^
+Test-coverage additions (issue #56), no library behavior changes:
+``utils.auth_lat()``'s large-flattening branch (``f > 1/150``, unreachable
+by any predefined ellipsoid) is now validated against the numerically
+integrated defining integral of authalic latitude, alongside the power
+series branch; ``projection_wrapper`` gained functional tests
+(forward/inverse round trips for homemade and PROJ-backed projections,
+``lon_0``/``lat_0`` recentring, projection keyword pass-through);
+``Cell.area()``, ``Cell.color()``, ``Cell.region_overlaps()``, and
+``RHEALPixDGGS.area_error_budget()`` gained their first tests (including
+checking that every resolution's cells sum to the authalic sphere's
+surface area); and ``Cell.centroid()`` gained its first active test (the
+previous one was a disabled stub), validating the dart/skew_quad
+integration against an independent fixed-seed Monte Carlo estimate --
+which flagged that quad cells' centroid latitudes are computed
+incorrectly, now tracked separately as issue #75. Also renamed
+``tests/test_PJ_healpix.c.py`` (whose embedded extra ``.c`` suffix made
+``unittest`` discovery silently skip its 4 pyproj/PROJ cross-checks) to
+``tests/test_pj_healpix_c_reference.py``, and repaired it: it had rotted
+unrunnable (removed ``scipy`` re-exports of numpy functions, a missing
+``itertools.product`` import, scalar inputs to
+``scipy.spatial.distance.euclidean``), and its ellipsoidal inverse
+round-trip tolerances are now geographic (pole/antimeridian aware) and
+two-tier -- a precision check at WGS84 eccentricity, a documented
+smoke-test bound at the file's deliberately extreme ``e = 0.8``, where
+PROJ's own low-order inverse authalic series is only good to ~2 degrees.
+
 **Breaking change:** ``rhp_wrappers.cell_ring()``/``k_ring()`` are rebuilt on
 a breadth-first search over ``Cell.neighbor()``/``diagonal_neighbor()``
 steps, growing the ring outward one shell at a time, rather than jumping

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -4,6 +4,7 @@ from scipy.spatial.distance import euclidean, norm
 # Import standard modules
 import unittest
 from itertools import product
+from math import pi
 
 # Import my modules.
 from rhealpixdggs.cell import Cell, CELLS0
@@ -786,6 +787,55 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         # Same-face siblings far enough apart to neither touch nor nest.
         self.assertTrue(rdggs.cell((P, 0)).disjoint(rdggs.cell((P, 8))))
 
+    def test_area(self):
+        rdggs = WGS84_003
+        for resolution in (0, 1, 3):
+            c = rdggs.cell((P,) + (0,) * resolution)
+            # Planar cells are squares of side width().
+            self.assertEqual(c.area(plane=True), c.width() ** 2)
+            # Must agree with the DGGS-level formula it delegates to.
+            self.assertEqual(
+                c.area(plane=False), rdggs.cell_area(resolution, plane=False)
+            )
+            # Independent check: the grid is an equal-area partition of the
+            # ellipsoid, so the 6 * N_side**(2r) ellipsoidal cells at any
+            # resolution must sum to the surface area of the ellipsoid's
+            # authalic sphere, 4*pi*R_A**2.
+            total = 6 * rdggs.N_side ** (2 * resolution) * c.area(plane=False)
+            sphere = 4 * pi * rdggs.ellipsoid.R_A**2
+            self.assertAlmostEqual(total / sphere, 1, places=12)
+
+    def test_color(self):
+        rdggs = WGS84_003
+        cells = list(rdggs.grid(1))
+        colors = [c.color() for c in cells]
+        # Deterministic, in-range RGB.
+        for c, rgb in zip(cells, colors):
+            self.assertEqual(len(rgb), 3)
+            for component in rgb:
+                self.assertGreaterEqual(component, 0)
+                self.assertLessEqual(component, 1)
+            self.assertEqual(c.color(), rgb)
+        # Documented as "a unique RGB color tuple for this cell": distinct
+        # cells at the same resolution get distinct colors.
+        self.assertEqual(len(set(colors)), len(cells))
+        # The saturation parameter is honored.
+        self.assertNotEqual(cells[7].color(saturation=0.2), cells[7].color(0.9))
+
+    def test_region_overlaps(self):
+        rdggs = WGS84_003
+        a = rdggs.cell((P, 0))
+        descendant = rdggs.cell((P, 0, 3))
+        sibling = rdggs.cell((P, 1))
+        far = rdggs.cell((S, 8))
+        self.assertTrue(a.region_overlaps([far, descendant]))
+        self.assertTrue(a.region_overlaps([a]))
+        self.assertFalse(a.region_overlaps([sibling, far]))
+        self.assertFalse(a.region_overlaps([]))
+        empty = rdggs.cell()
+        with self.assertRaises(ValueError):
+            empty.region_overlaps([a])
+
     def test_region(self):
         for rdggs in [WGS84_003, WGS84_003_RADIANS]:
             c = rdggs.cell((P, 0))
@@ -819,83 +869,82 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         self.assertEqual(cell_n.ellipsoidal_shape, "cap")
         self.assertEqual(cell_s.ellipsoidal_shape, "cap")
 
+    @staticmethod
+    def monte_carlo_mean_lon_lat(cell, n=4000, seed=20260811):
+        """
+        Estimate the mean longitude-latitude of ellipsoidal cell `cell` --
+        i.e. its centroid, by the definition centroid() implements -- by
+        sampling `n` points uniformly at random from the planar cell and
+        projecting them onto the ellipsoid. The projection is equal-area,
+        so planar-uniform samples are uniform on the ellipsoidal cell, and
+        their sample mean estimates the centroid with standard error
+        (sample standard deviation)/sqrt(n), independently of the
+        integration centroid() itself performs. The seed is fixed so the
+        estimate (and hence the test outcome) is deterministic.
+
+        Longitudes are handled relative to the cell's nucleus meridian and
+        wrapped, so a cell straddling the +-180 degree antimeridian
+        doesn't produce a meaningless raw average. Returns
+        (mean_lon, mean_lat, standard_error_lon, standard_error_lat).
+        """
+        from random import Random
+        from statistics import fmean, stdev
+
+        from rhealpixdggs.utils import wrap_longitude
+
+        rng = Random(seed)
+        rdggs = cell.rdggs
+        nucleus_lon = cell.nucleus(plane=False)[0]
+        ul = cell.ul_vertex()
+        w = cell.width()
+        lons, lats = [], []
+        for _ in range(n):
+            x = rng.uniform(ul[0], ul[0] + w)
+            y = rng.uniform(ul[1] - w, ul[1])
+            lon, lat = rdggs.rhealpix(x, y, inverse=True)
+            lons.append(wrap_longitude(lon - nucleus_lon, radians=False))
+            lats.append(lat)
+        mean_lon = wrap_longitude(fmean(lons) + nucleus_lon, radians=False)
+        return (
+            mean_lon,
+            fmean(lats),
+            stdev(lons) / n**0.5,
+            stdev(lats) / n**0.5,
+        )
+
     def test_centroid(self):
-        # Warning: This test is slow.
-        # Uncomment below if you want to test it and wait.
-        pass
-        # print
-        # print 'Testing centroid() method now. Takes about 2 minutes.'
-        #
-        # # For non-cap ellipsoidal cells, test centroid() against a Monte Carlo
-        # # approximation of the centroid.
-        # def monte_carlo_centroid(cell):
-        #     nv = cell.nucleus_and_vertices()
-        #     rdggs = cell.rdggs
-        #     lam_nucleus = rdggs.rhealpix(*nv[0], inverse=True)[0]
-        #     vertices = nv[1:]
-        #     x1, x2 = vertices[0][0], vertices[3][0]
-        #     y1, y2 = vertices[1][1], vertices[0][1]
-        #     N = 10000
-        #     sample_points = []
-        #     for i in range(N):
-        #         x, y = uniform(x1, x2), uniform(y1, y2)
-        #         lam, phi = rdggs.rhealpix(x, y, inverse=True)
-        #         sample_points.append(array((lam, phi)))
-        #     lam_bar, phi_bar = sum(sample_points)/N
-        #     sample_var = sum([array((
-        #                              (p[0] - lam_bar)**2,
-        #                              (p[1] - phi_bar)**2))
-        #                       for p in sample_points])/(N - 1)
-        #     lam_bar_err = sqrt(sample_var[0]/N) # Approximately
-        #     phi_bar_err = sqrt(sample_var[1]/N) # Approximately
-        #     PI = cell.rdggs.ellipsoid.pi()
-        #     if cell.ellipsoidal_shape == 'dart':
-        #         lam_bar = lam_nucleus
-        #     return lam_bar, phi_bar, abs(lam_bar_err), abs(phi_bar_err)
-        #
-        # for rdggs in [WGS84_003, WGS84_003_RADIANS]:
-        #     # The centroid of a planar cell is its nucleus.
-        #     for suid in [(Q, 7), (S, 2, 2)]:
-        #         X = rdggs.cell(suid)
-        #         centroid = X.centroid()
-        #         nucleus = X.nucleus_and_vertices()[0]
-        #         self.assertEqual(centroid, nucleus)
-        #
-        #     # The centroid of a ellipsoidal cap cell is also its nucleus.
-        #     for suid in [(N, 4, 4, 4), [S]]:
-        #         X = rdggs.cell(suid)
-        #         centroid = X.centroid(plane=False)
-        #         nucleus = X.nucleus_and_vertices(plane=False)[0]
-        #         self.assertEqual(centroid, nucleus)
-        #
-        #     for suid in [
-        #       (Q, 7), # quad
-        #       (O, 5, 8), # quad
-        #       (N, 6), # dart
-        #       (N, 6, 2), # dart
-        #       #(N, 6, 2, 4), # dart
-        #       (N, 7), # skew quad
-        #       (N, 7, 3), # skew quad
-        #       #(N, 7, 3, 5), # skew quad
-        #       (S, 2), # dart
-        #       (S, 2, 4), # dart
-        #       #(S, 2, 4, 4), # dart
-        #       (S, 1), # skew quad
-        #       (S, 1, 1), # skew quad
-        #       #(S, 1, 1, 1), # skew quad
-        #       ]:
-        #         X = rdggs.cell(suid)
-        #         lam_bar, phi_bar = X.centroid(plane=False)
-        #         lam_bar_approx, phi_bar_approx, lam_bar_err, phi_bar_err = \
-        #         monte_carlo_centroid(X)
-        #         # print "Testing centroid(plane=False) for %s cell %s..."\
-        #         #  % (X.ellipsoidal_shape, X)
-        #         # print 'lam:', lam_bar, lam_bar_approx, lam_bar_err
-        #         # print 'phi:', phi_bar, phi_bar_approx, phi_bar_err
-        #         self.assertTrue(euclidean(lam_bar, lam_bar_approx) <\
-        #                                                   10*lam_bar_err)
-        #         self.assertTrue(euclidean(phi_bar, phi_bar_approx) <\
-        #                                                   10*phi_bar_err)
+        rdggs = WGS84_003
+        # The centroid of a planar cell is its nucleus, whatever the
+        # cell's ellipsoidal shape.
+        for suid in [(Q, 7), (S, 2, 2), (N,), (N, 6), (N, 7)]:
+            X = rdggs.cell(suid)
+            self.assertEqual(X.centroid(plane=True), X.nucleus(plane=True))
+
+        # The centroid of an ellipsoidal cap cell is its nucleus (the
+        # pole), by symmetry.
+        for suid in [(N, 4), (S,)]:
+            X = rdggs.cell(suid)
+            self.assertEqual(X.centroid(plane=False), X.nucleus(plane=False))
+
+        # For the ellipsoidal shapes whose centroid is computed by
+        # numerical integration -- dart and skew_quad -- check both
+        # coordinates against an independent fixed-seed Monte Carlo
+        # estimate, within 6 standard errors (a bound the estimate has
+        # essentially no chance of missing unless the integration itself
+        # is wrong). The dart cell at longitude -180 also exercises the
+        # antimeridian-straddling case. Quad cells are absent here
+        # deliberately: their latitude takes a separate, non-integrated
+        # code path that fails this same Monte Carlo check (issue #75).
+        from rhealpixdggs.utils import wrap_longitude
+
+        for suid in [(N, 6), (S, 2, 4), (N, 7), (N, 7, 3)]:
+            X = rdggs.cell(suid)
+            self.assertIn(X.ellipsoidal_shape, ("dart", "skew_quad"))
+            lon, lat = X.centroid(plane=False)
+            mc_lon, mc_lat, se_lon, se_lat = self.monte_carlo_mean_lon_lat(X)
+            lon_gap = abs(wrap_longitude(lon - mc_lon, radians=False))
+            self.assertLess(lon_gap, 6 * se_lon, msg=str(suid))
+            self.assertLess(abs(lat - mc_lat), 6 * se_lat, msg=str(suid))
 
     def test_random_point(self):
         # Output should lie in the cell at least.

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -81,6 +81,32 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
             c = a.successor()
             self.assertEqual(str(b), str(c))
 
+    def test_area_error_budget(self):
+        import sys
+
+        rdggs = WGS84_003
+        budget = rdggs.area_error_budget()
+        # One entry per resolution, none missing, none extra.
+        self.assertEqual(
+            sorted(budget.keys()), list(range(rdggs.max_resolution + 1))
+        )
+        rel_tol = 10 * sys.float_info.epsilon
+        previous_area = None
+        for r in range(rdggs.max_resolution + 1):
+            entry = budget[r]
+            # The budgeted area is exactly the ellipsoidal cell area at
+            # that resolution.
+            self.assertEqual(entry["cell_area_m2"], rdggs.cell_area(r, plane=False))
+            # Documented invariants: the relative tolerance is 10 machine
+            # epsilons at every resolution, and the absolute tolerance is
+            # the area scaled by it.
+            self.assertEqual(entry["rel_tolerance"], rel_tol)
+            self.assertEqual(entry["abs_tolerance"], entry["cell_area_m2"] * rel_tol)
+            # Areas strictly decrease with resolution.
+            if previous_area is not None:
+                self.assertLess(entry["cell_area_m2"], previous_area)
+            previous_area = entry["cell_area_m2"]
+
     def test_interval(self):
         for rdggs in [WGS84_123, WGS84_123_RADIANS]:
             # Should produce the correct number of cells

--- a/tests/test_pj_healpix_c_reference.py
+++ b/tests/test_pj_healpix_c_reference.py
@@ -1,6 +1,9 @@
 """
-This Python 3.11 code tests the ``PJ_healpix.c`` code of the third party
-pyproj module.
+This Python 3.11 code cross-checks the ``PJ_healpix.c`` implementation of
+the healpix and rhealpix projections that ships in the PROJ library (as
+exposed by the third-party pyproj module) against reference values derived
+from the defining formulas -- a canary for a broken or mispatched PROJ
+healpix at install time.
 Beware, these tests cover only some functions and only some scenarios.
 Keep adding tests!
 
@@ -14,25 +17,44 @@ Keep adding tests!
 # *****************************************************************************
 
 # Import third-party modules.
-from scipy.spatial.distance import euclidean, norm
-from scipy import array, sin, arcsin, pi, sqrt, rad2deg, deg2rad
+from numpy import array, atleast_1d, sin, arcsin, pi, sqrt, rad2deg, deg2rad
+from numpy.linalg import norm
 from pyproj import Proj
 
 # Import standard modules.
 import unittest
+from itertools import product
 
 # Import my modules.
 from rhealpixdggs.utils import auth_lat, auth_rad
 
 
-# Relative error function.
+# Relative error function. Accepts scalars or point tuples.
 def rel_err(get, expect):
-    a = euclidean(get, expect)
+    get = atleast_1d(array(get))
+    expect = atleast_1d(array(expect))
+    a = norm(get - expect)
     b = norm(expect)
     if b == 0:
         return a
     else:
         return a / b
+
+
+def geo_gap_deg(p, q):
+    """
+    Angular separation, in degrees, between lon-lat points `p` and `q`
+    (in degrees) treated as positions on the unit sphere. Unlike a
+    componentwise comparison, this correctly treats (-180, phi) and
+    (180, phi) as the same point, and any two longitudes at a pole as
+    the same point.
+    """
+    from numpy import cos, sin, deg2rad, clip, arccos
+
+    lam1, phi1 = deg2rad(array(p, dtype=float))
+    lam2, phi2 = deg2rad(array(q, dtype=float))
+    cos_gap = sin(phi1) * sin(phi2) + cos(phi1) * cos(phi2) * cos(lam1 - lam2)
+    return rad2deg(arccos(clip(cos_gap, -1, 1)))
 
 
 # Define lon-lat input points to test.
@@ -92,25 +114,14 @@ class PJHEALPixTestCase(unittest.TestCase):
         expect = healpix_sphere_outputs
         # Fuzz to allow for rounding errors:
         error = 1e-12
-        print()
-        print("=" * 80)
-        print("HEALPix forward projection, sphere with radius R = %s" % R)
-        print("input (radians) / expected output (meters) / received output")
-        print("=" * 80)
         for i in range(len(get)):
-            print(given[i], expect[i], get[i])
             self.assertTrue(rel_err(get[i], expect[i]) < error)
 
         # Inverse of projection of a point p should yield p.
         given = get
         get = [f(*q, radians=RADIANS, inverse=True) for q in given]
         expect = inputs
-        print("=" * 80)
-        print("HEALPix inverse projection, sphere with radius R = %s" % R)
-        print("input (meters) / expected output (radians) / received output")
-        print("=" * 80)
         for i in range(len(get)):
-            print(given[i], expect[i], get[i])
             self.assertTrue(rel_err(get[i], expect[i]) < error)
 
         # Inverse projection of p below should return longitude of -pi.
@@ -146,66 +157,51 @@ class PJHEALPixTestCase(unittest.TestCase):
         expect = healpix_ellipsoid_outputs
         # Fuzz to allow for rounding errors:
         error = 1e-12
-        print("=" * 80)
-        print(
-            "HEALPix forward projection, ellipsoid with major radius a = %s and eccentricity e = %s"
-            % (a, e)
-        )
-        print("input (radians) / expected output (meters) / received output")
-        print("=" * 80)
         for i in range(len(get)):
-            print(given[i], expect[i], get[i])
             self.assertTrue(rel_err(get[i], expect[i]) < error)
 
-        # Inverse of projection of a point p should yield p.
+        # Inverse of projection of a point p should yield p, geographically
+        # (comparing angular separation on the sphere, so that the
+        # antimeridian's two longitude representations and the poles'
+        # indeterminate longitude don't register as spurious mismatches).
+        #
+        # PROJ inverts the authalic latitude with a low-order series whose
+        # truncation error grows steeply with eccentricity, so the
+        # achievable tolerance depends on e. At this test's deliberately
+        # extreme e = 0.8 the observed round-trip error is ~2.2 degrees of
+        # latitude: assert within 3 degrees, purely as a smoke test that
+        # the inverse lands in the right neighborhood (a sign flip, wrong
+        # polar square, or wrong quadrant would miss by far more).
         given = get
         get = [f(*q, radians=RADIANS, inverse=True) for q in given]
         expect = inputs
-        # Fuzz for rounding errors based on the error of the approximation to
-        # the inverse authalic latitude function:
-        alpha = PI / 4
-        alpha_ = auth_lat(
-            auth_lat(alpha, e, radians=RADIANS), e, radians=RADIANS, inverse=True
-        )
-        error = 10 * rel_err(alpha_, alpha)
-        print("=" * 80)
-        print(
-            "HEALPix inverse projection, ellipsoid with major radius a = %s and eccentricity e = %s"
-            % (a, e)
-        )
-        print("input (meters) / expected output (radians) / received output")
-        print("=" * 80)
         for i in range(len(get)):
-            print(given[i], expect[i], get[i])
-            self.assertTrue(rel_err(get[i], expect[i]) < error)
+            self.assertLess(geo_gap_deg(get[i], expect[i]), 3)
+
+        # At a realistic eccentricity (WGS84's), that same series is
+        # accurate to about a millionth of a degree, so there the
+        # round trip is a genuine precision check.
+        f = Proj(proj="healpix", a=a, e=0.0818191908426215)
+        for p in inputs:
+            q = f(*p, radians=RADIANS)
+            back = f(*q, radians=RADIANS, inverse=True)
+            self.assertLess(geo_gap_deg(back, p), 1e-5)
 
     def test_rhealpix_sphere(self):
-        from random import uniform
-
         # Sphere parameters.
         R = 5
         # Fuzz to allow for rounding errors:
         error = 1e-12
-        # Forward projection of random equatorial points should yield the same
+        # Forward projection of equatorial points should yield the same
         # output as healpix_sphere().
-        print("=" * 80)
-        print("rHEALPix forward projection, sphere of radius R = %s" % R)
-        print("input (radians) / expected output (meters) / received output")
-        print("=" * 80)
         eps = 1e-3
         given = [(-PI, PI / 6), (-PI, -PI / 7), (0, 0), (PI / 3, phi_0 - eps)]
-        # for i in range(10):
-        #     p = (uniform(-pi + eps, pi - eps),
-        #          uniform(-phi_0 + eps, phi_0 - eps))
-        #     given.append(p)
         h = Proj(proj="healpix", R=R)
         expect = [h(*p, radians=RADIANS) for p in given]
         for ns, ss in product(list(range(4)), repeat=2):
-            print("_____ north_square = %s, south_square = %s" % (ns, ss))
             rh = Proj(proj="rhealpix", R=R, north_square=ns, south_square=ss)
             get = [rh(*p, radians=RADIANS) for p in given]
             for i in range(len(get)):
-                print(given[i], expect[i], get[i])
                 self.assertEqual(get[i], expect[i])
 
         # Forward projection of polar points should be correct.
@@ -225,7 +221,6 @@ class PJHEALPixTestCase(unittest.TestCase):
             h(*p, radians=RADIANS, inverse=True) for p in south_healpix_output
         ]
         for ns, ss in product(list(range(4)), repeat=2):
-            print("_____ north_square = %s, south_square = %s" % (ns, ss))
             rh = Proj(proj="rhealpix", R=R, north_square=ns, south_square=ss)
             # Corners of north square.
             ndl = (-pi + ns * pi / 2, pi / 4)
@@ -258,27 +253,19 @@ class PJHEALPixTestCase(unittest.TestCase):
             for i, p in enumerate(north_given):
                 get = rh(*p, radians=RADIANS)
                 expect = north_expect[(i - ns) % 4]
-                print(p, expect, get)
                 self.assertTrue(rel_err(get, expect) < error)
             for i, p in enumerate(south_given):
                 get = rh(*p, radians=RADIANS)
                 expect = south_expect[(i - ss) % 4]
-                print(p, expect, get)
                 self.assertTrue(rel_err(get, expect) < error)
 
         # The inverse of the projection of a point p should yield p.
-        print("=" * 80)
-        print("rHEALPix inverse projection, sphere of radius R = %s" % R)
-        print("input (meters) / expected output (radians) / received output:")
-        print("=" * 80)
         for ns, ss in product(list(range(4)), repeat=2):
-            print("_____ north_square = %s, south_square = %s" % (ns, ss))
             f = Proj(proj="rhealpix", R=R, north_square=ns, south_square=ss)
             for p in inputs:
                 expect = p
                 q = f(*p, radians=RADIANS)
                 get = f(*q, radians=RADIANS, inverse=True)
-                print(q, expect, get)
                 self.assertTrue(rel_err(get, expect) < error)
 
     def test_rhealpix_ellipsoid(self):
@@ -287,18 +274,10 @@ class PJHEALPixTestCase(unittest.TestCase):
         e = 0.8
         R_A = auth_rad(a, e=e)
         # Forward projection should be correct on test points.
-        print("=" * 80)
-        print(
-            "rHEALPix forward projection, ellipsoid with major radius a = %s and eccentricity e = %s"
-            % (a, e)
-        )
-        print("input (radians) / expected output (meters) / received output")
-        print("=" * 80)
         given = inputs
         # Fuzz to allow for rounding errors:
         error = 1e-12
         for ns, ss in product(list(range(4)), repeat=2):
-            print("_____ north_square = %s, south_square = %s" % (ns, ss))
             expect = []
             g = Proj(proj="rhealpix", R=R_A, north_square=ns, south_square=ss)
             for p in given:
@@ -309,34 +288,28 @@ class PJHEALPixTestCase(unittest.TestCase):
             f = Proj(proj="rhealpix", a=a, e=e, north_square=ns, south_square=ss)
             get = [f(*p, radians=RADIANS) for p in given]
             for i in range(len(given)):
-                print(given[i], expect[i], get[i])
                 self.assertTrue(rel_err(get[i], expect[i]) < error)
 
-        # Inverse of projection of point a p should yield p.
-        # Fuzz for rounding errors based on the error of the approximation to
-        # the inverse authalic latitude function:
-        alpha = PI / 4
-        alpha_ = auth_lat(
-            auth_lat(alpha, e, radians=RADIANS), e, radians=RADIANS, inverse=True
-        )
-        error = 10 * rel_err(alpha_, alpha)
-        print("=" * 80)
-        print(
-            "HEALPix inverse projection, ellipsoid with major radius a = %s and eccentricity e = %s"
-            % (a, e)
-        )
-        print("input (meters) / expected output (radians) / received output")
-        print("=" * 80)
-        # The inverse of the projection of a point p should yield p.
+        # The inverse of the projection of a point p should yield p,
+        # geographically. Same two-tier tolerances as in
+        # test_healpix_ellipsoid, and for the same reason: PROJ inverts
+        # the authalic latitude with a low-order series, so at the
+        # deliberately extreme e = 0.8 this is a within-3-degrees smoke
+        # test, while at WGS84's eccentricity it's a genuine precision
+        # check.
         for ns, ss in product(list(range(4)), repeat=2):
-            print("_____ north_square = %s, south_square = %s" % (ns, ss))
             f = Proj(proj="rhealpix", a=a, e=e, north_square=ns, south_square=ss)
             for p in inputs:
-                expect = p
                 q = f(*p, radians=RADIANS)
                 get = f(*q, radians=RADIANS, inverse=True)
-                print(q, expect, get)
-                self.assertTrue(rel_err(get, expect) < error)
+                self.assertLess(geo_gap_deg(get, p), 3)
+        f = Proj(
+            proj="rhealpix", a=a, e=0.0818191908426215, north_square=1, south_square=2
+        )
+        for p in inputs:
+            q = f(*p, radians=RADIANS)
+            back = f(*q, radians=RADIANS, inverse=True)
+            self.assertLess(geo_gap_deg(back, p), 1e-5)
 
 
 # ------------------------------------------------------------------------------

--- a/tests/test_projection_wrapper.py
+++ b/tests/test_projection_wrapper.py
@@ -9,10 +9,83 @@ import unittest
 
 # Import my modules.
 from rhealpixdggs.projection_wrapper import Projection
-from rhealpixdggs.ellipsoids import WGS84_ELLIPSOID
+from rhealpixdggs.ellipsoids import (
+    Ellipsoid,
+    WGS84_ELLIPSOID,
+    WGS84_ELLIPSOID_RADIANS,
+)
 
 
 class MyTestCase(unittest.TestCase):
+    def test_homemade_projection_round_trip(self):
+        # The homemade healpix/rhealpix projections, called through the
+        # wrapper, should invert cleanly: f(p) followed by the inverse
+        # should recover p. Exercised in degrees mode (the wrapper reads
+        # angle units off the ellipsoid).
+        points = [(0, 0), (30, 45), (-120, -60), (170, 80)]
+        for proj, kwargs in [
+            ("healpix", {}),
+            ("rhealpix", {"north_square": 1, "south_square": 2}),
+        ]:
+            f = Projection(ellipsoid=WGS84_ELLIPSOID, proj=proj, **kwargs)
+            for p in points:
+                q = f(*p)
+                back = f(*q, inverse=True)
+                self.assertAlmostEqual(back[0], p[0], places=9, msg=proj)
+                self.assertAlmostEqual(back[1], p[1], places=9, msg=proj)
+
+    def test_homemade_projection_round_trip_radians(self):
+        # Same as above in radians mode.
+        f = Projection(
+            ellipsoid=WGS84_ELLIPSOID_RADIANS,
+            proj="rhealpix",
+            north_square=0,
+            south_square=0,
+        )
+        for p in [(0.5, 0.7), (-2.0, -1.0), (3.0, 1.4)]:
+            q = f(*p)
+            back = f(*q, inverse=True)
+            self.assertAlmostEqual(back[0], p[0], places=12)
+            self.assertAlmostEqual(back[1], p[1], places=12)
+
+    def test_pyproj_backed_projection_round_trip(self):
+        # A projection not in HOMEMADE_PROJECTIONS dispatches to pyproj.
+        # 'cea' (cylindrical equal area) is a stable, universally available
+        # PROJ projection. pyproj's own round-trip precision is coarser
+        # than the homemade projections' (observed ~5e-9 degrees), hence
+        # the looser tolerance.
+        f = Projection(ellipsoid=WGS84_ELLIPSOID, proj="cea")
+        for p in [(0, 0), (30, 45), (-120, -60)]:
+            q = f(*p)
+            if p != (0, 0):
+                # A real projection to meters happened (not a pass-through).
+                self.assertNotEqual(q, p)
+            back = f(*q, inverse=True)
+            self.assertAlmostEqual(back[0], p[0], delta=1e-6)
+            self.assertAlmostEqual(back[1], p[1], delta=1e-6)
+
+    def test_ellipsoid_origin_translation(self):
+        # The wrapper recentres on the ellipsoid's (lon_0, lat_0): that
+        # point must project to the planar origin, and the planar origin
+        # must invert back to it.
+        E = Ellipsoid(a=WGS84_ELLIPSOID.a, f=WGS84_ELLIPSOID.f, lon_0=50, lat_0=0)
+        f = Projection(ellipsoid=E, proj="rhealpix", north_square=0, south_square=0)
+        self.assertEqual(f(50, 0), (0.0, 0.0))
+        self.assertEqual(f(0, 0, inverse=True), (50.0, 0.0))
+
+    def test_projection_kwargs_are_passed_through(self):
+        # rhealpix's north_square/south_square kwargs reposition the polar
+        # squares, so they must change where a polar point lands while
+        # leaving equatorial points untouched.
+        f0 = Projection(
+            ellipsoid=WGS84_ELLIPSOID, proj="rhealpix", north_square=0, south_square=0
+        )
+        f1 = Projection(
+            ellipsoid=WGS84_ELLIPSOID, proj="rhealpix", north_square=1, south_square=0
+        )
+        self.assertNotEqual(f0(10, 80), f1(10, 80))
+        self.assertEqual(f0(10, 20), f1(10, 20))
+
     def test_unimplemented_homemade_projection_degrades_gracefully(self):
         # 'isea', 'csea', and 'qsc' are listed in HOMEMADE_PROJECTIONS but have
         # no backing rhealpixdggs.pj_* module. Calling them should hit the

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,12 +14,38 @@ Keep adding tests!
 # *****************************************************************************
 
 # Import standard modules.
-from math import pi
+from math import asin, pi, sin, sqrt
 import unittest
+
+# Import third-party modules.
+from scipy.integrate import quad
 
 # Import my modules.
 from rhealpixdggs.ellipsoids import WGS84_E
 import rhealpixdggs.utils as ut
+
+
+def auth_lat_by_defining_integral(phi: float, e: float) -> float:
+    """
+    Authalic latitude of geodetic latitude `phi` (radians) on an ellipsoid
+    of eccentricity `e`, computed by numerically integrating its defining
+    integral: beta = arcsin(q(phi)/q(pi/2)), where (after substituting
+    u = sin(t) to keep the integrand a smooth rational function)
+    q(phi) = (1 - e^2) * integral of du/(1 - e^2 u^2)^2 from 0 to sin(phi).
+
+    This is deliberately independent of auth_lat()'s own closed-form
+    formula and power series, so it can serve as ground truth for both.
+    """
+
+    def integrand(u):
+        return (1 - e**2) / (1 - (e * u) ** 2) ** 2
+
+    # epsabs/epsrel = 1e-13 keeps quad comfortably clear of its internal
+    # roundoff limits while remaining orders of magnitude tighter than the
+    # assertion tolerances used below.
+    q, _ = quad(integrand, 0, sin(phi), epsabs=1e-13, epsrel=1e-13)
+    q_pole, _ = quad(integrand, 0, 1, epsabs=1e-13, epsrel=1e-13)
+    return asin(q / q_pole)
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -115,6 +141,88 @@ class UtilsTestCase(unittest.TestCase):
         expect = lat
         for i in range(len(expect)):
             self.assertAlmostEqual(auth_lat_inverse[i], expect[i])
+
+    def test_auth_lat_matches_defining_integral(self):
+        # auth_lat() switches implementation on flattening: a closed-form
+        # direct formula for f > 1/150, a power series for f <= 1/150. No
+        # predefined Ellipsoid has a flattening anywhere near 1/150 (WGS84's
+        # f ~ 1/298 uses the series; the sphere presets short-circuit via
+        # e == 0), so the direct-formula branch is only reachable through
+        # user-constructed high-flattening ellipsoids. Validate BOTH
+        # branches against the same independent ground truth -- the
+        # numerically-integrated defining integral of authalic latitude --
+        # which also confirms the two branches agree with each other across
+        # the f = 1/150 switch point.
+        cases = [
+            # (eccentricity, which branch it exercises)
+            (0.8, "direct formula, extreme flattening (f = 0.4)"),
+            (0.1155, "direct formula, just above the f = 1/150 threshold"),
+            (WGS84_E, "power series, well below the threshold"),
+        ]
+        lat_degs = [-89, -80, -60, -45, -30, -10, 0, 10, 30, 45, 60, 80, 89]
+        for e, label in cases:
+            for deg in lat_degs:
+                phi = deg * pi / 180
+                expected = auth_lat_by_defining_integral(phi, e)
+                got_rad = ut.auth_lat(phi, e, radians=True)
+                self.assertAlmostEqual(got_rad, expected, places=12, msg=label)
+                # Degrees mode must agree with radians mode.
+                got_deg = ut.auth_lat(deg, e, radians=False)
+                self.assertAlmostEqual(
+                    got_deg, expected * 180 / pi, places=10, msg=label
+                )
+
+    def test_auth_lat_large_flattening_basic_properties(self):
+        # Structural properties of the direct-formula branch (f > 1/150):
+        # authalic latitude is an odd function of geodetic latitude, fixes
+        # the equator and the poles, pulls every other latitude strictly
+        # toward the equator on an oblate ellipsoid, and is strictly
+        # increasing.
+        e = 0.8
+        self.assertEqual(ut.auth_lat(0, e, radians=True), 0)
+        self.assertAlmostEqual(ut.auth_lat(pi / 2, e, radians=True), pi / 2, places=12)
+        self.assertAlmostEqual(
+            ut.auth_lat(-pi / 2, e, radians=True), -pi / 2, places=12
+        )
+        previous = None
+        for deg in range(-89, 90, 2):
+            phi = deg * pi / 180
+            beta = ut.auth_lat(phi, e, radians=True)
+            self.assertAlmostEqual(
+                beta, -ut.auth_lat(-phi, e, radians=True), places=12
+            )
+            if deg != 0:
+                self.assertLess(abs(beta), abs(phi))
+            if previous is not None:
+                self.assertGreater(beta, previous)
+            previous = beta
+
+    def test_auth_lat_large_flattening_inverse_round_trip(self):
+        # The inverse always uses the power series in the third flattening
+        # n, truncated at n^6, whatever the flattening -- so for a large
+        # flattening the round trip is only approximate: for e = 0.8,
+        # n = 0.25 and the truncation error is of order n^7 ~ 6e-5. Assert
+        # the round trip lands within 1e-3 radians (~0.06 degrees), which
+        # the observed worst case (~5e-4 rad) clears with headroom to spare
+        # while still catching any gross regression in either direction of
+        # the conversion.
+        e = 0.8
+        for deg in range(-89, 90, 7):
+            phi = deg * pi / 180
+            round_trip = ut.auth_lat(
+                ut.auth_lat(phi, e, radians=True), e, radians=True, inverse=True
+            )
+            self.assertAlmostEqual(round_trip, phi, delta=1e-3)
+        # For a flattening just above the direct-formula threshold
+        # (f ~ 1/149, n ~ 1/298), the same n^7 truncation bound puts the
+        # round trip within double-precision noise.
+        e = 0.1155
+        for deg in range(-89, 90, 7):
+            phi = deg * pi / 180
+            round_trip = ut.auth_lat(
+                ut.auth_lat(phi, e, radians=True), e, radians=True, inverse=True
+            )
+            self.assertAlmostEqual(round_trip, phi, places=12)
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes #56.

Works through the issue's checklist. No library behavior changes — every
edit is in `tests/` (plus the CHANGES.rst note).

## auth_lat()'s large-flattening branch

The direct-formula branch (`f > 1/150`) had zero coverage and is
unreachable by any predefined `Ellipsoid`. Rather than re-deriving the
same closed-form formula in the test (which would prove nothing), both
branches are validated against the **numerically integrated defining
integral** of authalic latitude (`scipy.integrate.quad` over
`(1-e²)/(1-e²u²)²` after the `u = sin t` substitution). Using one
independent ground truth for both branches also implicitly proves they
agree with each other across the `f = 1/150` switch point. Observed
agreement: ≤ 1.5e-14 rad across e ∈ {0.8, just-above-threshold, WGS84}.
Also added: structural-property tests (odd symmetry, fixed points at
equator/poles, strict monotonicity, equatorward pull) and inverse
round-trips with tolerances derived from the inverse series' truncation
order (the inverse is a 6th-order series in the third flattening n, so at
e = 0.8 / n = 0.25 the round trip is only good to ~5e-4 rad — asserted at
1e-3 with the reasoning documented).

## projection_wrapper functional coverage

The file gained its first functional tests (it previously had only the
2 regression tests from #50/#62): forward/inverse round trips for
homemade projections (healpix, rhealpix; degrees and radians modes) and a
PROJ-backed one (cea), `lon_0`/`lat_0` recentring (the ellipsoid's origin
must project to the planar origin and back), and projection kwargs
pass-through (`north_square` must move polar output and leave equatorial
output alone).

## Cell.area(), color(), region_overlaps(), area_error_budget()

First tests for each. `area()` is checked against an independent
invariant — the grid is an equal-area partition, so all `6·N_side^(2r)`
ellipsoidal cells at any resolution must sum to the authalic sphere's
surface area `4πR_A²` — as well as the formulas it delegates to.
`color()`: range, determinism, distinctness across all 54 resolution-1
cells, saturation parameter honored. `region_overlaps()`: semantics,
empty region list, empty cell raises. `area_error_budget()`: all
documented invariants (keys, exact agreement with `cell_area()`,
constant relative tolerance of 10 machine epsilons, monotone areas).

## Cell.centroid() (the issue-comment addendum)

`test_centroid` was a disabled stub — a bare `pass` above ~75 lines of
commented-out Python-2-era Monte Carlo code. Replaced with an active
test: planar centroid == nucleus for every shape, cap centroid ==
nucleus, and the dart/skew_quad integration paths validated against an
independent **fixed-seed** (hence deterministic) Monte Carlo estimate,
exploiting the projection's equal-area property (uniform planar samples
are uniform on the ellipsoidal cell), with antimeridian-aware longitude
averaging. Runs in ~0.9 s.

**This validation immediately surfaced a real bug**: quad cells' centroid
latitude is computed as the midpoint of the two edge latitudes, where the
definition requires the area-weighted mean — off by up to 0.63° at
resolution 1. The defect traces back to the founding paper's §7 summary
table contradicting the paper's own integral definition. Filed as #75
with full numeric evidence; quads are deliberately excluded from the
Monte Carlo check here (with a comment pointing at #75) so this PR stays
green and behavior-neutral. A fix PR will follow.

## test_PJ_healpix.c.py → test_pj_healpix_c_reference.py

The embedded extra `.c` suffix broke `unittest`'s dotted-module-name
resolution, so `unittest discover` silently never ran this file's 4
pyproj/PROJ cross-checks. The audit found it worse than undiscovered —
run directly, 3 of its 4 tests **error**: `from scipy import array, sin,
...` (numpy re-exports long removed from scipy), a missing
`itertools.product` import, and scalar inputs to
`scipy.spatial.distance.euclidean` (now requires 1-D vectors). Renamed
via `git mv` (history preserved) and repaired all of the above, removed
the per-point stdout noise, and reworked the ellipsoidal inverse
round-trip tolerances on two axes:

- **Geographic comparison** — points are compared by angular separation
  on the sphere, so `(-180, φ)` vs `(180, φ)` and differing longitudes at
  a pole no longer register as failures (both occur in practice).
- **Two-tier tolerance** — at WGS84 eccentricity the round trip is a
  genuine precision check (< 1e-5°); at the file's deliberately extreme
  `e = 0.8` it's a documented 3° smoke bound, because PROJ's own
  low-order inverse authalic series is only accurate to ~2.2° there. (The
  old tolerance was derived from *our* `auth_lat`'s round-trip error,
  which stopped tracking PROJ's error when our series was upgraded to
  6th order.) Forward projections remain checked at 1e-12 even at
  e = 0.8.

## boundary() short-circuit (checklist item 4)

Already covered: `test_boundary_quad_cap_n_contract` (added with the #49
fix in #61) tests both the 4n−4 point-count contract and the n=2
short-circuit's equivalence with `vertices()`. Nothing further added.

## Result

`unittest discover tests`: 104 → 120 tests, all passing (1 pre-existing
expected failure). Doctests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
