### PR TITLE
Fix quad-cell centroid latitude: mean, not edge midpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,27 @@
 0.6.1
 ^^^^^
+Fixed ``Cell.centroid(plane=False)`` for quad cells, whose centroid
+latitude was computed as the midpoint of the cell's two edge latitudes
+rather than the area-weighted mean latitude the centroid is defined as
+(the average value of latitude over the cell). Latitude is a nonlinear
+function of planar y, so the two differ -- by up to ~0.63 degrees for
+resolution 1 quad cells, shrinking quadratically with cell size, and
+vanishing for cells symmetric about the equator. The defect traces back
+to the founding paper's section 7 summary table, whose quad-cell entry
+contradicts the paper's own integral definition of the centroid directly
+above it; dart and skew_quad cells always used the integral and were
+unaffected, as were all centroid longitudes and everything planar. Quad
+centroid latitudes are now computed by (effectively exact) fixed-order
+Gauss-Legendre quadrature of the mean-latitude integral, validated
+against adaptive quadrature at a different meridian and an independent
+equal-area Monte Carlo estimate. Affects anything consuming ellipsoidal
+quad centroids, notably ``rhp_wrappers.rhp_to_geo(..., plane=False)``
+and ``rhp_wrappers.polyfill(..., plane=False)`` membership decisions for
+quad cells whose true and previously-reported centroids straddle the
+polygon boundary. One observable side effect: an exactly-symmetric
+cell's centroid latitude may now come out as floating-point dust (e.g.
+6e-16) rather than exactly 0 (issue #75).
+
 Test-coverage additions (issue #56), no library behavior changes:
 ``utils.auth_lat()``'s large-flattening branch (``f > 1/150``, unreachable
 by any predefined ellipsoid) is now validated against the numerically

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -1,6 +1,7 @@
 # from rhealpixdggs.dggs import WGS84_003
 
 from numpy import array, base_repr, pi  # pi is just for the doctests
+from numpy import vectorize as numpy_vectorize
 from scipy import integrate
 from itertools import product
 from random import uniform
@@ -1117,14 +1118,9 @@ class Cell(object):
         # This cell is ellipsoidal.
         # So we have to do some work.
         nucleus = self.nucleus(plane=False)
-        vertices = self.vertices(plane=False)
         shape = self.ellipsoidal_shape
         if shape == "cap":
             return nucleus
-        if shape == "quad":
-            lam_bar = nucleus[0]
-            phi_bar = sum([v[1] for v in vertices]) / 4
-            return lam_bar, phi_bar
         planar_vertices = self.vertices(plane=True)
         x1 = min([v[0] for v in planar_vertices])
         x2 = max([v[0] for v in planar_vertices])
@@ -1138,6 +1134,32 @@ class Cell(object):
         def phi(x, y):
             return self.rdggs.rhealpix(x, y, inverse=True)[1]
 
+        if shape == "quad":
+            # A quad cell is symmetric about its nucleus meridian, and its
+            # meridians are equally spaced in planar x, so the mean
+            # longitude is the nucleus longitude. Latitude is independent
+            # of planar x on a quad cell, so the area-weighted mean
+            # latitude reduces to a single integral over y. Note it is
+            # NOT the midpoint of the two edge latitudes: latitude is a
+            # nonlinear function of planar y, so the mean sits closer to
+            # the equator than the midpoint (by up to ~0.6 degrees for
+            # resolution 1 cells).
+            lam_bar = nucleus[0]
+            # Integrate along the nucleus meridian's planar x, which is
+            # safely interior to the cell (any x in the cell would do,
+            # since latitude doesn't depend on it). Fixed-order
+            # Gauss-Legendre quadrature is effectively exact here -- the
+            # integrand is smooth, and n=20 agrees with adaptive
+            # quadrature to machine precision -- while avoiding adaptive
+            # quadrature's error estimation, whose requested tolerances
+            # collide with the projection stack's floating-point noise
+            # floor and trigger spurious IntegrationWarnings.
+            x_mid = self.nucleus(plane=True)[0]
+            phi_of_y = numpy_vectorize(lambda y: phi(x_mid, y))
+            phi_bar = (1 / (y2 - y1)) * integrate.fixed_quad(
+                phi_of_y, y1, y2, n=20
+            )[0]
+            return lam_bar, phi_bar
         if shape == "dart":
             lam_bar = nucleus[0]
             phi_bar = (1 / area) * integrate.dblquad(

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -932,9 +932,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         # estimate, within 6 standard errors (a bound the estimate has
         # essentially no chance of missing unless the integration itself
         # is wrong). The dart cell at longitude -180 also exercises the
-        # antimeridian-straddling case. Quad cells are absent here
-        # deliberately: their latitude takes a separate, non-integrated
-        # code path that fails this same Monte Carlo check (issue #75).
+        # antimeridian-straddling case.
         from rhealpixdggs.utils import wrap_longitude
 
         for suid in [(N, 6), (S, 2, 4), (N, 7), (N, 7, 3)]:
@@ -945,6 +943,64 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             lon_gap = abs(wrap_longitude(lon - mc_lon, radians=False))
             self.assertLess(lon_gap, 6 * se_lon, msg=str(suid))
             self.assertLess(abs(lat - mc_lat), 6 * se_lat, msg=str(suid))
+
+    def test_centroid_quad(self):
+        # Regression test for issue #75: the centroid latitude of an
+        # ellipsoidal quad cell is the area-weighted mean latitude over
+        # the cell, NOT the midpoint of its two edge latitudes -- latitude
+        # is a nonlinear function of planar y, so the two differ, by up to
+        # ~0.63 degrees for resolution 1 quads (the midpoint is what
+        # centroid() used to return, following an erratum in the founding
+        # paper's summary table that contradicts the paper's own integral
+        # definition of the centroid).
+        from scipy import integrate
+
+        from rhealpixdggs.utils import wrap_longitude
+
+        rdggs = WGS84_003
+        for suid in [(Q, 7), (O, 0), (P, 3, 1), (Q, 4)]:
+            X = rdggs.cell(suid)
+            self.assertEqual(X.ellipsoidal_shape, "quad")
+            lon, lat = X.centroid(plane=False)
+
+            # The centroid longitude is the nucleus longitude (meridians
+            # are equally spaced in planar x, so mean == midpoint there).
+            self.assertEqual(lon, X.nucleus(plane=False)[0])
+
+            # Deterministic ground truth for the latitude: adaptive
+            # quadrature of the mean-latitude integral, evaluated along
+            # the cell's left edge x (latitude is independent of x on a
+            # quad, and adaptive quadrature at a different abscissa is an
+            # implementation-independent path from centroid()'s own
+            # fixed-order rule at the nucleus meridian).
+            pv = X.vertices(plane=True)
+            x1 = min(v[0] for v in pv)
+            y1 = min(v[1] for v in pv)
+            y2 = max(v[1] for v in pv)
+
+            def phi(y):
+                return rdggs.rhealpix(x1, y, inverse=True)[1]
+
+            expected_lat = (
+                integrate.quad(phi, y1, y2, epsabs=1e-5, epsrel=1e-10)[0]
+            ) / (y2 - y1)
+            self.assertAlmostEqual(lat, expected_lat, places=9, msg=str(suid))
+
+            # And explicitly: NOT the edge-latitude midpoint, except for
+            # cells symmetric about the equator, where the two coincide.
+            midpoint = (phi(y1) + phi(y2)) / 2
+            if abs(midpoint) > 1e-12:
+                self.assertNotAlmostEqual(lat, midpoint, places=3, msg=str(suid))
+
+        # Fully independent statistical check for the deepest-affected
+        # case: a fixed-seed Monte Carlo mean with enough samples that its
+        # 6-standard-error bound (~0.35 degrees) is tighter than the
+        # ~0.63 degree error this test guards against.
+        X = rdggs.cell((Q, 7))
+        lon, lat = X.centroid(plane=False)
+        mc_lon, mc_lat, se_lon, se_lat = self.monte_carlo_mean_lon_lat(X, n=20000)
+        self.assertLess(abs(wrap_longitude(lon - mc_lon, radians=False)), 6 * se_lon)
+        self.assertLess(abs(lat - mc_lat), 6 * se_lat)
 
     def test_random_point(self):
         # Output should lie in the cell at least.

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -67,13 +67,19 @@ class RhpWrappersTestCase(unittest.TestCase):
         centroid = rhpw.rhp_to_geo("N0", plane=False)
         self.assertEqual(centroid, (90.0, 53.00810765458496))
 
-        # Equatorial cell without geojson
+        # Equatorial cell without geojson. Q is symmetric about the
+        # equator, so its centroid latitude is 0 -- up to the floating-
+        # point noise floor of the quadrature that computes quad-cell
+        # centroid latitudes (Cell.centroid()), hence the tolerance-based
+        # comparison.
         centroid = rhpw.rhp_to_geo("Q", geo_json=False, plane=False)
-        self.assertEqual(centroid, (0, 45))
+        self.assertAlmostEqual(centroid[0], 0, places=12)
+        self.assertEqual(centroid[1], 45)
 
         # Equatorial cell with geojson
         centroid = rhpw.rhp_to_geo("Q", plane=False)
-        self.assertEqual(centroid, (45, 0))
+        self.assertEqual(centroid[0], 45)
+        self.assertAlmostEqual(centroid[1], 0, places=12)
 
     def test_rhp_to_parent(self):
         child_id = "N12345"


### PR DESCRIPTION
Closes #75.

**Stacked on #76 (issue #56):** the regression test extends the
`test_centroid` machinery introduced there, so this PR's diff includes
#76's changes until that merges first. Base is `iss-56`, not
`code-review-fixes`.

## The bug

`Cell.centroid(plane=False)` computed a quad cell's centroid latitude as
the midpoint of its two edge latitudes. The centroid is defined (founding
paper, §7) as the *average value* of latitude over the cell, and latitude
is a nonlinear function of planar y, so the midpoint is wrong — by up to
~0.63° for resolution 1 quads (e.g. Q7: −27.417° reported vs −26.790°
true), shrinking quadratically with cell size, and masked entirely for
cells symmetric about the equator (which is why the resolution 0
equatorial faces never showed it).

The implementation faithfully matched the paper's §7 summary table — but
that table's quad entry contradicts the paper's own integral definition
of the centroid directly above it, so this appears to be an inherited
paper erratum rather than a transcription error. Dart and skew_quad cells
always used the integral and were correct; all centroid longitudes and
all planar centroids were also correct.

## The fix

Quad centroid latitudes are now computed by fixed-order (n=20)
Gauss–Legendre quadrature of the mean-latitude integral along the nucleus
meridian (latitude is independent of planar x on a quad, so the double
integral the definition calls for reduces to one dimension). Fixed-order
quadrature is effectively exact here — it agrees with adaptive quadrature
to machine precision (7e-15) across all 728 quad cells at resolutions 0–2
in both angle modes — while avoiding adaptive quadrature's error
estimation, whose tolerances collide with the projection stack's
floating-point noise floor and raise spurious `IntegrationWarning`s.

## Downstream effects

- `rhp_to_geo(..., plane=False)` now returns the true centroid for quad
  cells.
- `polyfill(..., plane=False)` membership decisions change for quad cells
  whose true and previously-reported centroids straddle the polygon
  boundary (its default `plane=True` path is unaffected — the planar
  centroid is the nucleus).
- One observable side effect (covered in CHANGES.rst): an
  exactly-equator-symmetric cell's centroid latitude may now come out as
  floating-point dust (~6e-16) instead of exactly 0, because the
  quadrature's summands cancel only to machine precision. The two
  affected assertions in `test_rhp_to_geo` now compare with tolerance.

## Validation

`test_centroid_quad` checks the fix three independent ways:

1. **Adaptive quadrature** of the same integral, evaluated along a
   *different* meridian (the cell's left edge) — agreement to 9 decimal
   places across quads at resolutions 1–2 plus the equator-symmetric
   case.
2. An explicit **not-the-edge-midpoint** assertion for asymmetric cells,
   so the specific wrong answer can't quietly come back.
3. A **fixed-seed equal-area Monte Carlo** mean (20,000 samples) for the
   worst affected cell, with a 6-standard-error bound (~0.35°) tight
   enough to catch the original ~0.63° error — fully independent of any
   quadrature.

Confirmed the new test fails against the pre-fix implementation
(0.626° discrepancy reported) and passes after. Full suite: 121 tests +
all doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
