### PR TITLE
Rewrite cells_from_line as an exact sweep; fix cap-cell tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,4 +155,8 @@ dmypy.json
 cython_debug/
 
 # conda package build files
-/output/
+/output
+
+# Editor settings
+.vscode/
+

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,51 @@
 0.7.0
 ^^^^^
+**Breaking change:** rewrote ``RHEALPixDGGS.cells_from_line`` (the engine
+behind ``rhp_wrappers.linetrace``) to be exact for every cell shape,
+replacing an edge-walking algorithm that modelled each cell as a
+straight-edged quadrilateral -- wrong for polar cells (cap cells are
+circles in longitude-latitude coordinates; dart and skew-quad edges are
+curves), forbidden from ever revisiting a cell (correct polar paths do),
+and equipped with a fail-safe that silently jumped to the end cell,
+skipping arbitrarily many cells. Confirmed failures included skipping a
+cell a segment crossed straight through the middle of, and polar traces
+missing 20 cells at once. The new implementation sweeps the segment's
+planar image for cell-edge crossings: the crossing parameters are exact
+(piece boundaries -- region and polar-triangle changes and the longitude
+wrap -- are known in closed form, and every crossing is bracketed and
+solved to machine precision), and each inter-crossing interval midpoint
+is located with the shape-exact ``cell_from_point``. Validated against
+an independent dense point-location oracle on hundreds of random
+segments (equatorial, polar, region-crossing, planar): zero
+disagreements, and the sweep catches sliver crossings as short as 1/500
+of a cell that sampling misses. Consequences:
+
+- The cap-cell limitation is gone: ``tests``' known-failure case now has
+  its correct expected sequence (confirmed leg-by-leg by dense point
+  location) and passes as a regular test. ``LINETRACE_WARNING`` and the
+  warning emission are removed from ``rhp_wrappers.linetrace``
+  (``verbose`` still controls the malformed-geometry warnings).
+- Some previously returned sequences change: cells the old algorithm
+  skipped are now included (e.g. a cell a segment crossed through the
+  middle of), and cells it invented are gone. Cells met in a single
+  point only (a segment passing exactly through a cell corner) are not
+  included.
+- Longitude-latitude segments are documented as straight in coordinate
+  space (plate carree, matching the shapely input type and GeoJSON RFC
+  7946's planar reading): segments spanning more than half a turn of
+  longitude run the long way around by default rather than wrapping.
+  Splitting inputs at the antimeridian, as RFC 7946 prescribes, avoids
+  the ambiguity; the new ``wrap_antimeridian`` keyword (on
+  ``cells_from_line`` and ``linetrace``, default False) traces such
+  segments the short way instead, equivalent to splitting. This
+  replaces the previous blanket "cannot handle the antimeridian"
+  caveat, and ``polyfill``'s antimeridian TODO is likewise resolved by
+  documenting the split-first requirement.
+- **Breaking change (harmless):** removed
+  ``RHEALPixDGGS.antimeridian_check_and_flip``, which existed solely to
+  patch cell edges for the old algorithm's shapely intersection tests.
+
+
 Adopted the organisation's repository-standards check
 (``manaakiwhenua-standards``) as a GitHub Actions workflow, with its
 status badge in the README (issue #84). The check requires a non-empty

--- a/docs/make_figures.py
+++ b/docs/make_figures.py
@@ -420,3 +420,109 @@ fig.tight_layout()
 fig.savefig(OUT / "wrappers_nz.svg", bbox_inches="tight")
 plt.close(fig)
 print("wrapper examples written")
+
+
+# ---------------------------------------------------------------- figure 5
+# linetrace across the north polar cap: the case where cells are not
+# rectangles in longitude-latitude space, seen from above the pole.
+from rhealpixdggs import rhp_wrappers
+
+CAP_LINE = [
+    (-134.998756, 86.549596),
+    (-179.141527, 88.504030),
+    (-44.874903, 86.549596),
+    (-89.669615, 86.549596),
+    (-134, 86),
+]
+CAP_RES = 3
+traced = rhp_wrappers.linetrace(LineString(CAP_LINE), CAP_RES, plane=False)
+traced_set = set(traced)
+
+fig, ax = plt.subplots(figsize=(6.5, 6.5))
+VIEW = (0.0, 90.0)  # straight down onto the north pole
+
+# Arctic coastlines for context (northern Greenland, Svalbard, Franz
+# Josef Land reach into this view).
+for seg in COASTLINES:
+    lons = [p[0] for p in seg]
+    lats = [p[1] for p in seg]
+    x, y, vis = ortho(lons, lats, *VIEW)
+    ax.plot(np.where(vis, x, np.nan), np.where(vis, y, np.nan),
+            color=COAST_COLOR, linewidth=0.7, zorder=1)
+
+# Graticule: parallels and meridians in the window.
+for glat in (82, 84, 86, 88):
+    lons = np.linspace(-180, 180, 721)
+    x, y, vis = ortho(lons, np.full_like(lons, glat), *VIEW)
+    ax.plot(np.where(vis, x, np.nan), np.where(vis, y, np.nan),
+            color="#cccccc", linewidth=0.4)
+for glon in range(-180, 180, 30):
+    lats = np.linspace(78, 90, 121)
+    x, y, vis = ortho(np.full_like(lats, glon), lats, *VIEW)
+    ax.plot(np.where(vis, x, np.nan), np.where(vis, y, np.nan),
+            color="#cccccc", linewidth=0.4)
+
+# The resolution 4 sub-grid, as a faint outline.
+for cell3 in rdggs.cell(["N", 4, 4]).subcells():
+    for cell4 in cell3.subcells():
+        pts = cell4.boundary(n=20, plane=False)
+        pts = pts + [pts[0]]
+        x, y, vis = ortho([p[0] for p in pts], [p[1] for p in pts], *VIEW)
+        ax.plot(np.where(vis, x, np.nan), np.where(vis, y, np.nan),
+                color=FACE_COLORS["N"], linewidth=0.35, alpha=0.45, zorder=2)
+
+# The resolution 3 cells around the pole (the children of N44), traced
+# ones filled.
+for cell in rdggs.cell(["N", 4, 4]).subcells():
+    pts = cell.boundary(n=60, plane=False)
+    pts = pts + [pts[0]]
+    lons = [p[0] for p in pts]
+    lats = [p[1] for p in pts]
+    x, y, vis = ortho(lons, lats, *VIEW)
+    name = str(cell)
+    if name in traced_set:
+        ax.fill(x, y, color=FACE_COLORS["N"], alpha=0.3, linewidth=0)
+    ax.plot(np.where(vis, x, np.nan), np.where(vis, y, np.nan),
+            color=FACE_COLORS["N"], linewidth=1.2, zorder=3)
+    nx, ny, _ = ortho(*cell.nucleus(plane=False), *VIEW)
+    ax.text(
+        nx,
+        ny,
+        name,
+        ha="center",
+        va="center",
+        fontsize=9,
+        color="#333333",
+        bbox=dict(facecolor="white", alpha=0.6, linewidth=0, pad=1),
+        zorder=5,
+    )
+
+# The linestring, densified per leg in longitude-latitude space (its
+# segments are straight in that space, so on the globe each leg curves
+# around the pole).
+for a, b in zip(CAP_LINE, CAP_LINE[1:]):
+    ts = np.linspace(0, 1, 400)
+    lons = a[0] + ts * (b[0] - a[0])
+    lats = a[1] + ts * (b[1] - a[1])
+    x, y, vis = ortho(lons, lats, *VIEW)
+    ax.plot(np.where(vis, x, np.nan), np.where(vis, y, np.nan),
+            color="#222222", linewidth=1.8)
+sx, sy, _ = ortho(*CAP_LINE[0], *VIEW)
+ex, ey, _ = ortho(*CAP_LINE[-1], *VIEW)
+ax.plot([sx], [sy], marker="o", color="#222222", markersize=5, zorder=4)
+ax.plot([ex], [ey], marker="s", color="#222222", markersize=5, zorder=4)
+
+lim = float(np.cos(np.radians(80.0)))
+ax.set_xlim(-lim, lim)
+ax.set_ylim(-lim, lim)
+ax.set_aspect("equal")
+ax.axis("off")
+ax.set_title(
+    "linetrace across the north polar cap (resolution %d, view from above the pole)\n"
+    "traced: %s" % (CAP_RES, " → ".join(traced)),
+    fontsize=10,
+)
+fig.tight_layout()
+fig.savefig(OUT / "wrappers_cap_trace.svg", bbox_inches="tight")
+plt.close(fig)
+print("cap trace figure written")

--- a/docs/source/images/wrappers_cap_trace.svg
+++ b/docs/source/images/wrappers_cap_trace.svg
@@ -1,0 +1,11622 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="435.216pt" height="460.01225pt" viewBox="0 0 435.216 460.01225" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>1970-01-01T00:00:00+00:00</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.8.2, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 460.01225 
+L 435.216 460.01225 
+L 435.216 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="line2d_1">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_2">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_3">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_4">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_5">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_6">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_7">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_8">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_9">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_10">
+    <path d="M -1 155.628174 
+L -0.402649 156.527528 
+L -1 157.135401 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_11">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_12">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_13">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_14">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_15">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_16">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_17">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_18">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_19">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_20">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_21">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_22">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_23">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_24">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_25">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_26">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_27">
+    <path d="M 0.843274 182.321486 
+L -1 184.997358 
+M -1 181.883524 
+L 0.843274 182.321486 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_28">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_29">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_30">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_31">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_32">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_33">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_34">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_35">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_36">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_37">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_38">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_39">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_40">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_41">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_42">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_43">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_44">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_45">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_46">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_47">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_48">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_49">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_50">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_51">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_52">
+    <path d="M 0 0 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_53">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_54">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_55">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_56">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_57">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_58">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_59">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_60">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_61">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_62">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_63">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_64">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_65">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_66">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_67">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_68">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_69">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_70">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_71">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_72">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_73">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_74">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_75">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_76">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_77">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_78">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_79">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_80">
+    <path d="M 0 0 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_81">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_82">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_83">
+    <path d="M 357.320546 382.865166 
+L 359.253989 375.422693 
+L 362.54257 371.452424 
+L 367.214286 374.658588 
+L 364.756729 369.88111 
+L 364.195 365.232069 
+L 370.906854 364.243515 
+L 372.557693 367.271392 
+L 371.68991 372.642672 
+L 370.818723 376.084803 
+L 373.064578 378.712314 
+L 372.793986 384.177489 
+L 366.502928 383.686304 
+L 363.133784 377.765587 
+L 357.320546 382.865166 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_84">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_85">
+    <path d="M 313.921384 428.152041 
+L 313.982928 440.66345 
+L 304.786241 447.539728 
+L 292.925791 448.496286 
+L 290.334214 443.338155 
+L 285.163955 444.750507 
+L 278.43296 436.877316 
+L 286.785319 427.86152 
+L 293.333723 430.702451 
+L 294.212799 423.583341 
+L 304.369822 424.732934 
+L 313.921384 428.152041 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_86">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_87">
+    <path d="M 274.343078 452.050601 
+L 273.827147 444.814617 
+L 278.783484 442.614855 
+L 285.451103 448.122756 
+L 302.842766 458.300801 
+L 301.179773 461.01225 
+M 258.863798 461.01225 
+L 257.063294 456.441538 
+L 265.500612 447.065318 
+L 269.18311 453.67701 
+L 274.343078 452.050601 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_88">
+    <path d="M 0 0 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_89">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_90">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_91">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_92">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_93">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_94">
+    <path d="M 0 0 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_95">
+    <path d="M 0 0 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_96">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_97">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_98">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_99">
+    <path d="M 0 0 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_100">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_101">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_102">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_103">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_104">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_105">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_106">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_107">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_108">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_109">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_110">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_111">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_112">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_113">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_114">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_115">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_116">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_117">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_118">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_119">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_120">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_121">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_122">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_123">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_124">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_125">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_126">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_127">
+    <path d="M 408.725194 23.853784 
+L 399.014711 14.576524 
+L 392.35999 -1 
+M 424.737402 -1 
+L 428.744565 -0.09942 
+L 427.941779 17.05092 
+L 416.306973 25.472998 
+L 408.725194 23.853784 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_128">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_129">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_130">
+    <path d="M 406.233707 229.949613 
+L 400.936298 223.326855 
+L 410.599987 215.679843 
+L 429.204652 204.38288 
+L 436.216 203.509321 
+M 436.216 230.38385 
+L 424.816022 233.192846 
+L 420.857624 238.213958 
+L 406.233707 229.949613 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_131">
+    <path d="M 20.845456 221.666615 
+L 26.947257 224.63847 
+L 28.117658 228.161638 
+L 33.003793 227.112103 
+L 33.598789 234.660347 
+L 22.321537 238.542444 
+L 14.016608 250.189857 
+L 0.416758 253.71074 
+L -1 254.827889 
+M -1 221.075962 
+L 2.275609 219.482525 
+L 11.905213 218.204333 
+L 20.845456 221.666615 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_132">
+    <path d="M 46.825177 237.672574 
+L 50.753679 242.113034 
+L 51.463277 245.500783 
+L 55.058312 251.007782 
+L 63.121516 254.5626 
+L 62.329974 258.012536 
+L 56.823053 261.633619 
+L 68.31781 262.270777 
+L 72.132672 265.185078 
+L 75.197611 269.29588 
+L 77.68055 276.644279 
+L 75.806177 278.499587 
+L 81.198713 284.547733 
+L 81.631346 290.113828 
+L 82.291752 295.706738 
+L 83.42454 302.631715 
+L 83.367228 308.808487 
+L 80.535893 315.747732 
+L 75.542697 318.279559 
+L 64.247981 316.09939 
+L 57.37926 311.23262 
+L 51.981178 310.476156 
+L 54.78505 316.67453 
+L 40.124795 314.689303 
+L 32.60548 311.685392 
+L 14.507674 311.624362 
+L 8.843208 305.263932 
+L 4.081706 304.1162 
+L -1 293.356477 
+M -1 257.978855 
+L 2.110002 255.556962 
+L 12.732993 253.385881 
+L 12.596322 263.234216 
+L 10.659978 266.317124 
+L 18.907327 270.866741 
+L 20.340597 262.789853 
+L 18.135884 250.768271 
+L 25.055782 244.532884 
+L 33.491548 241.76156 
+L 39.670032 238.155412 
+L 46.825177 237.672574 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_133">
+    <path d="M 104.339527 348.905215 
+L 119.383548 346.250312 
+L 125.317609 352.791989 
+L 132.634006 348.765015 
+L 140.512999 352.148721 
+L 155.309319 364.144137 
+L 163.019863 385.766309 
+L 155.314322 391.38182 
+L 145.101389 387.718657 
+L 130.708752 382.01373 
+L 129.991521 385.963029 
+L 140.10122 389.057227 
+L 144.880985 399.479568 
+L 152.738691 395.946889 
+L 152.151809 403.831695 
+L 144.2839 413.73311 
+L 154.705623 409.543979 
+L 171.283995 406.457512 
+L 179.031782 412.608089 
+L 178.811958 421.713505 
+L 161.995732 432.764292 
+L 158.73171 436.798673 
+L 146.74919 436.599452 
+L 154.34995 440.256014 
+L 145.409313 453.279359 
+L 140.431251 461.01225 
+M -1 324.033651 
+L -0.445713 324.480591 
+L 14.339272 334.137904 
+L 21.8385 332.349241 
+L 24.753624 320.232515 
+L 33.617614 319.930812 
+L 51.701803 324.438934 
+L 55.819693 327.581304 
+L 63.552858 322.084414 
+L 71.763682 325.651463 
+L 79.206034 331.572797 
+L 84.336032 338.755104 
+L 80.985094 345.195281 
+L 94.774082 344.055217 
+L 93.289069 354.326354 
+L 94.868658 358.473725 
+L 94.381627 367.699669 
+L 97.531595 354.767011 
+L 104.339527 348.905215 
+L 104.339527 348.905215 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_134">
+    <path clip-path="url(#p7c8276638b)" style="fill: none; stroke: #9a9a9a; stroke-width: 0.7; stroke-linecap: square"/>
+   </g>
+   <g id="patch_2">
+    <path d="M 254.082592 242.40425 
+L 254.069666 243.375223 
+L 254.030896 244.345507 
+L 253.966311 245.314416 
+L 253.875956 246.281261 
+L 253.759895 247.245359 
+L 253.61821 248.206026 
+L 253.451002 249.162581 
+L 253.25839 250.114345 
+L 253.040509 251.060644 
+L 252.797514 252.000809 
+L 252.529578 252.934171 
+L 252.23689 253.86007 
+L 251.919658 254.777849 
+L 251.578107 255.686858 
+L 251.212478 256.586453 
+L 250.823032 257.475996 
+L 250.410043 258.354856 
+L 249.973805 259.222411 
+L 249.514626 260.078045 
+L 249.032833 260.921153 
+L 248.528767 261.751136 
+L 248.002785 262.567407 
+L 247.45526 263.369386 
+L 246.886579 264.156506 
+L 246.297147 264.928208 
+L 245.68738 265.683946 
+L 245.057712 266.423184 
+L 244.408587 267.145397 
+L 243.740467 267.850075 
+L 243.053825 268.536717 
+L 242.349147 269.204837 
+L 241.626934 269.853962 
+L 240.887696 270.48363 
+L 240.131958 271.093397 
+L 239.360256 271.682829 
+L 238.573136 272.25151 
+L 237.771157 272.799035 
+L 236.954886 273.325017 
+L 236.124903 273.829083 
+L 235.281795 274.310876 
+L 234.426161 274.770055 
+L 233.558606 275.206293 
+L 232.679746 275.619282 
+L 231.790203 276.008728 
+L 230.890608 276.374357 
+L 229.981599 276.715908 
+L 229.06382 277.03314 
+L 228.137921 277.325828 
+L 227.204559 277.593764 
+L 226.264394 277.836759 
+L 225.318095 278.05464 
+L 224.366331 278.247252 
+L 223.409776 278.41446 
+L 222.449109 278.556145 
+L 221.485011 278.672206 
+L 220.518166 278.762561 
+L 219.549257 278.827146 
+L 218.578973 278.865916 
+L 217.608 278.878842 
+L 216.637027 278.865916 
+L 215.666743 278.827146 
+L 214.697834 278.762561 
+L 213.730989 278.672206 
+L 212.766891 278.556145 
+L 211.806224 278.41446 
+L 210.849669 278.247252 
+L 209.897905 278.05464 
+L 208.951606 277.836759 
+L 208.011441 277.593764 
+L 207.078079 277.325828 
+L 206.15218 277.03314 
+L 205.234401 276.715908 
+L 204.325392 276.374357 
+L 203.425797 276.008728 
+L 202.536254 275.619282 
+L 201.657394 275.206293 
+L 200.789839 274.770055 
+L 199.934205 274.310876 
+L 199.091097 273.829083 
+L 198.261114 273.325017 
+L 197.444843 272.799035 
+L 196.642864 272.25151 
+L 195.855744 271.682829 
+L 195.084042 271.093397 
+L 194.328304 270.48363 
+L 193.589066 269.853962 
+L 192.866853 269.204837 
+L 192.162175 268.536717 
+L 191.475533 267.850075 
+L 190.807413 267.145397 
+L 190.158288 266.423184 
+L 189.52862 265.683946 
+L 188.918853 264.928208 
+L 188.329421 264.156506 
+L 187.76074 263.369386 
+L 187.213215 262.567407 
+L 186.687233 261.751136 
+L 186.183167 260.921153 
+L 185.701374 260.078045 
+L 185.242195 259.222411 
+L 184.805957 258.354856 
+L 184.392968 257.475996 
+L 184.003522 256.586453 
+L 183.637893 255.686858 
+L 183.296342 254.777849 
+L 182.97911 253.86007 
+L 182.686422 252.934171 
+L 182.418486 252.000809 
+L 182.175491 251.060644 
+L 181.95761 250.114345 
+L 181.764998 249.162581 
+L 181.59779 248.206026 
+L 181.456105 247.245359 
+L 181.340044 246.281261 
+L 181.249689 245.314416 
+L 181.185104 244.345507 
+L 181.146334 243.375223 
+L 181.133408 242.40425 
+L 181.146334 241.433277 
+L 181.185104 240.462993 
+L 181.249689 239.494084 
+L 181.340044 238.527239 
+L 181.456105 237.563141 
+L 181.59779 236.602474 
+L 181.764998 235.645919 
+L 181.95761 234.694155 
+L 182.175491 233.747856 
+L 182.418486 232.807691 
+L 182.686422 231.874329 
+L 182.97911 230.94843 
+L 183.296342 230.030651 
+L 183.637893 229.121642 
+L 184.003522 228.222047 
+L 184.392968 227.332504 
+L 184.805957 226.453644 
+L 185.242195 225.586089 
+L 185.701374 224.730455 
+L 186.183167 223.887347 
+L 186.687233 223.057364 
+L 187.213215 222.241093 
+L 187.76074 221.439114 
+L 188.329421 220.651994 
+L 188.918853 219.880292 
+L 189.52862 219.124554 
+L 190.158288 218.385316 
+L 190.807413 217.663103 
+L 191.475533 216.958425 
+L 192.162175 216.271783 
+L 192.866853 215.603663 
+L 193.589066 214.954538 
+L 194.328304 214.32487 
+L 195.084042 213.715103 
+L 195.855744 213.125671 
+L 196.642864 212.55699 
+L 197.444843 212.009465 
+L 198.261114 211.483483 
+L 199.091097 210.979417 
+L 199.934205 210.497624 
+L 200.789839 210.038445 
+L 201.657394 209.602207 
+L 202.536254 209.189218 
+L 203.425797 208.799772 
+L 204.325392 208.434143 
+L 205.234401 208.092592 
+L 206.15218 207.77536 
+L 207.078079 207.482672 
+L 208.011441 207.214736 
+L 208.951606 206.971741 
+L 209.897905 206.75386 
+L 210.849669 206.561248 
+L 211.806224 206.39404 
+L 212.766891 206.252355 
+L 213.730989 206.136294 
+L 214.697834 206.045939 
+L 215.666743 205.981354 
+L 216.637027 205.942584 
+L 217.608 205.929658 
+L 218.578973 205.942584 
+L 219.549257 205.981354 
+L 220.518166 206.045939 
+L 221.485011 206.136294 
+L 222.449109 206.252355 
+L 223.409776 206.39404 
+L 224.366331 206.561248 
+L 225.318095 206.75386 
+L 226.264394 206.971741 
+L 227.204559 207.214736 
+L 228.137921 207.482672 
+L 229.06382 207.77536 
+L 229.981599 208.092592 
+L 230.890608 208.434143 
+L 231.790203 208.799772 
+L 232.679746 209.189218 
+L 233.558606 209.602207 
+L 234.426161 210.038445 
+L 235.281795 210.497624 
+L 236.124903 210.979417 
+L 236.954886 211.483483 
+L 237.771157 212.009465 
+L 238.573136 212.55699 
+L 239.360256 213.125671 
+L 240.131958 213.715103 
+L 240.887696 214.32487 
+L 241.626934 214.954538 
+L 242.349147 215.603663 
+L 243.053825 216.271783 
+L 243.740467 216.958425 
+L 244.408587 217.663103 
+L 245.057712 218.385316 
+L 245.68738 219.124554 
+L 246.297147 219.880292 
+L 246.886579 220.651994 
+L 247.45526 221.439114 
+L 248.002785 222.241093 
+L 248.528767 223.057364 
+L 249.032833 223.887347 
+L 249.514626 224.730455 
+L 249.973805 225.586089 
+L 250.410043 226.453644 
+L 250.823032 227.332504 
+L 251.212478 228.222047 
+L 251.578107 229.121642 
+L 251.919658 230.030651 
+L 252.23689 230.94843 
+L 252.529578 231.874329 
+L 252.797514 232.807691 
+L 253.040509 233.747856 
+L 253.25839 234.694155 
+L 253.451002 235.645919 
+L 253.61821 236.602474 
+L 253.759895 237.563141 
+L 253.875956 238.527239 
+L 253.966311 239.494084 
+L 254.030896 240.462993 
+L 254.069666 241.433277 
+z
+" clip-path="url(#p7c8276638b)" style="fill: #e5735c; opacity: 0.3"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 181.133408 242.40425 
+L 181.146334 243.375223 
+L 181.185104 244.345507 
+L 181.249689 245.314416 
+L 181.340044 246.281261 
+L 181.456105 247.245359 
+L 181.59779 248.206026 
+L 181.764998 249.162581 
+L 181.95761 250.114345 
+L 182.175491 251.060644 
+L 182.418486 252.000809 
+L 182.686422 252.934171 
+L 182.97911 253.86007 
+L 183.296342 254.777849 
+L 183.637893 255.686858 
+L 184.003522 256.586453 
+L 184.392968 257.475996 
+L 184.805957 258.354856 
+L 185.242195 259.222411 
+L 185.701374 260.078045 
+L 186.183167 260.921153 
+L 186.687233 261.751136 
+L 187.213215 262.567407 
+L 187.76074 263.369386 
+L 188.329421 264.156506 
+L 188.918853 264.928208 
+L 189.52862 265.683946 
+L 190.158288 266.423184 
+L 190.807413 267.145397 
+L 191.475533 267.850075 
+L 192.162175 268.536717 
+L 192.866853 269.204837 
+L 193.589066 269.853962 
+L 194.328304 270.48363 
+L 195.084042 271.093397 
+L 195.855744 271.682829 
+L 196.642864 272.25151 
+L 197.444843 272.799035 
+L 198.261114 273.325017 
+L 199.091097 273.829083 
+L 199.934205 274.310876 
+L 200.789839 274.770055 
+L 201.657394 275.206293 
+L 202.536254 275.619282 
+L 203.425797 276.008728 
+L 204.325392 276.374357 
+L 205.234401 276.715908 
+L 206.15218 277.03314 
+L 207.078079 277.325828 
+L 208.011441 277.593764 
+L 208.951606 277.836759 
+L 209.897905 278.05464 
+L 210.849669 278.247252 
+L 211.806224 278.41446 
+L 212.766891 278.556145 
+L 213.730989 278.672206 
+L 214.697834 278.762561 
+L 215.666743 278.827146 
+L 216.637027 278.865916 
+L 217.608 278.878842 
+L 216.637027 280.10248 
+L 215.66666 281.302679 
+L 214.697358 282.481621 
+L 213.729465 283.641231 
+L 212.763238 284.783219 
+L 211.798859 285.909104 
+L 210.836459 287.020242 
+L 209.876124 288.117844 
+L 208.917906 289.202995 
+L 207.961831 290.27667 
+L 207.007902 291.339748 
+L 206.05611 292.393022 
+L 205.106431 293.437209 
+L 204.158832 294.472958 
+L 203.213273 295.500861 
+L 202.269709 296.521454 
+L 201.328091 297.535229 
+L 200.38837 298.542633 
+L 199.450491 299.544075 
+L 198.514401 300.539932 
+L 197.580046 301.530549 
+L 196.647374 302.516244 
+L 195.716331 303.497308 
+L 194.786866 304.474012 
+L 193.858927 305.446606 
+L 192.932465 306.415319 
+L 192.007431 307.380365 
+L 191.083779 308.341944 
+L 190.161463 309.300238 
+L 189.24044 310.25542 
+L 188.320667 311.207649 
+L 187.402103 312.157074 
+L 186.484709 313.103833 
+L 185.568448 314.048056 
+L 184.653282 314.989864 
+L 183.739176 315.929371 
+L 182.826097 316.866684 
+L 181.914013 317.801901 
+L 181.002892 318.735117 
+L 180.092705 319.66642 
+L 179.183422 320.595892 
+L 178.275017 321.523612 
+L 177.367463 322.449652 
+L 176.460735 323.374082 
+L 175.554808 324.296968 
+L 174.649658 325.21837 
+L 173.745264 326.138348 
+L 172.841604 327.056956 
+L 171.938657 327.974246 
+L 171.036404 328.890268 
+L 170.134824 329.805068 
+L 169.233901 330.718692 
+L 168.333615 331.63118 
+L 167.433951 332.542573 
+L 166.534892 333.452909 
+L 165.636423 334.362224 
+L 164.738528 335.270552 
+L 163.841192 336.177926 
+L 162.944403 337.084377 
+L 162.106323 336.59554 
+L 161.272614 336.099284 
+L 160.443341 335.59565 
+L 159.618571 335.084676 
+L 158.798367 334.566403 
+L 157.982796 334.040871 
+L 157.17192 333.508122 
+L 156.365804 332.968198 
+L 155.564512 332.421142 
+L 154.768106 331.866996 
+L 153.976648 331.305804 
+L 153.190203 330.737611 
+L 152.40883 330.162461 
+L 151.632593 329.580399 
+L 150.861552 328.991471 
+L 150.095767 328.395724 
+L 149.335299 327.793205 
+L 148.580209 327.18396 
+L 147.830555 326.568039 
+L 147.086396 325.945489 
+L 146.347791 325.31636 
+L 145.614799 324.6807 
+L 144.887477 324.038561 
+L 144.165882 323.389992 
+L 143.450071 322.735046 
+L 142.7401 322.073772 
+L 142.036026 321.406225 
+L 141.337904 320.732455 
+L 140.645788 320.052516 
+L 139.959734 319.366462 
+L 139.279795 318.674346 
+L 138.606025 317.976224 
+L 137.938478 317.27215 
+L 137.277204 316.562179 
+L 136.622258 315.846368 
+L 135.973689 315.124773 
+L 135.33155 314.397451 
+L 134.69589 313.664459 
+L 134.066761 312.925854 
+L 133.444211 312.181695 
+L 132.82829 311.432041 
+L 132.219045 310.676951 
+L 131.616526 309.916483 
+L 131.020779 309.150698 
+L 130.431851 308.379657 
+L 129.849789 307.60342 
+L 129.274639 306.822047 
+L 128.706446 306.035602 
+L 128.145254 305.244144 
+L 127.591108 304.447738 
+L 127.044052 303.646446 
+L 126.504128 302.84033 
+L 125.971379 302.029454 
+L 125.445847 301.213883 
+L 124.927574 300.393679 
+L 124.4166 299.568909 
+L 123.912966 298.739636 
+L 123.41671 297.905927 
+L 122.927873 297.067847 
+L 123.834324 296.171058 
+L 124.741698 295.273722 
+L 125.650026 294.375827 
+L 126.559341 293.477358 
+L 127.469677 292.578299 
+L 128.38107 291.678635 
+L 129.293558 290.778349 
+L 130.207182 289.877426 
+L 131.121982 288.975846 
+L 132.038004 288.073593 
+L 132.955294 287.170646 
+L 133.873902 286.266986 
+L 134.79388 285.362592 
+L 135.715282 284.457442 
+L 136.638168 283.551515 
+L 137.562598 282.644787 
+L 138.488638 281.737233 
+L 139.416358 280.828828 
+L 140.34583 279.919545 
+L 141.277133 279.009358 
+L 142.210349 278.098237 
+L 143.145566 277.186153 
+L 144.082879 276.273074 
+L 145.022386 275.358968 
+L 145.964194 274.443802 
+L 146.908417 273.527541 
+L 147.855176 272.610147 
+L 148.804601 271.691583 
+L 149.75683 270.77181 
+L 150.712012 269.850787 
+L 151.670306 268.928471 
+L 152.631885 268.004819 
+L 153.596931 267.079785 
+L 154.565644 266.153323 
+L 155.538238 265.225384 
+L 156.514942 264.295919 
+L 157.496006 263.364876 
+L 158.481701 262.432204 
+L 159.472318 261.497849 
+L 160.468175 260.561759 
+L 161.469617 259.62388 
+L 162.477021 258.684159 
+L 163.490796 257.742541 
+L 164.511389 256.798977 
+L 165.539292 255.853418 
+L 166.575041 254.905819 
+L 167.619228 253.95614 
+L 168.672502 253.004348 
+L 169.73558 252.050419 
+L 170.809255 251.094344 
+L 171.894406 250.136126 
+L 172.992008 249.175791 
+L 174.103146 248.213391 
+L 175.229031 247.249012 
+L 176.371019 246.282785 
+L 177.530629 245.314892 
+L 178.709571 244.34559 
+L 179.90977 243.375223 
+z
+" clip-path="url(#p7c8276638b)" style="fill: #e5735c; opacity: 0.3"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 217.608 205.929658 
+L 216.637027 205.942584 
+L 215.666743 205.981354 
+L 214.697834 206.045939 
+L 213.730989 206.136294 
+L 212.766891 206.252355 
+L 211.806224 206.39404 
+L 210.849669 206.561248 
+L 209.897905 206.75386 
+L 208.951606 206.971741 
+L 208.011441 207.214736 
+L 207.078079 207.482672 
+L 206.15218 207.77536 
+L 205.234401 208.092592 
+L 204.325392 208.434143 
+L 203.425797 208.799772 
+L 202.536254 209.189218 
+L 201.657394 209.602207 
+L 200.789839 210.038445 
+L 199.934205 210.497624 
+L 199.091097 210.979417 
+L 198.261114 211.483483 
+L 197.444843 212.009465 
+L 196.642864 212.55699 
+L 195.855744 213.125671 
+L 195.084042 213.715103 
+L 194.328304 214.32487 
+L 193.589066 214.954538 
+L 192.866853 215.603663 
+L 192.162175 216.271783 
+L 191.475533 216.958425 
+L 190.807413 217.663103 
+L 190.158288 218.385316 
+L 189.52862 219.124554 
+L 188.918853 219.880292 
+L 188.329421 220.651994 
+L 187.76074 221.439114 
+L 187.213215 222.241093 
+L 186.687233 223.057364 
+L 186.183167 223.887347 
+L 185.701374 224.730455 
+L 185.242195 225.586089 
+L 184.805957 226.453644 
+L 184.392968 227.332504 
+L 184.003522 228.222047 
+L 183.637893 229.121642 
+L 183.296342 230.030651 
+L 182.97911 230.94843 
+L 182.686422 231.874329 
+L 182.418486 232.807691 
+L 182.175491 233.747856 
+L 181.95761 234.694155 
+L 181.764998 235.645919 
+L 181.59779 236.602474 
+L 181.456105 237.563141 
+L 181.340044 238.527239 
+L 181.249689 239.494084 
+L 181.185104 240.462993 
+L 181.146334 241.433277 
+L 181.133408 242.40425 
+L 179.90977 241.433277 
+L 178.709571 240.46291 
+L 177.530629 239.493608 
+L 176.371019 238.525715 
+L 175.229031 237.559488 
+L 174.103146 236.595109 
+L 172.992008 235.632709 
+L 171.894406 234.672374 
+L 170.809255 233.714156 
+L 169.73558 232.758081 
+L 168.672502 231.804152 
+L 167.619228 230.85236 
+L 166.575041 229.902681 
+L 165.539292 228.955082 
+L 164.511389 228.009523 
+L 163.490796 227.065959 
+L 162.477021 226.124341 
+L 161.469617 225.18462 
+L 160.468175 224.246741 
+L 159.472318 223.310651 
+L 158.481701 222.376296 
+L 157.496006 221.443624 
+L 156.514942 220.512581 
+L 155.538238 219.583116 
+L 154.565644 218.655177 
+L 153.596931 217.728715 
+L 152.631885 216.803681 
+L 151.670306 215.880029 
+L 150.712012 214.957713 
+L 149.75683 214.03669 
+L 148.804601 213.116917 
+L 147.855176 212.198353 
+L 146.908417 211.280959 
+L 145.964194 210.364698 
+L 145.022386 209.449532 
+L 144.082879 208.535426 
+L 143.145566 207.622347 
+L 142.210349 206.710263 
+L 141.277133 205.799142 
+L 140.34583 204.888955 
+L 139.416358 203.979672 
+L 138.488638 203.071267 
+L 137.562598 202.163713 
+L 136.638168 201.256985 
+L 135.715282 200.351058 
+L 134.79388 199.445908 
+L 133.873902 198.541514 
+L 132.955294 197.637854 
+L 132.038004 196.734907 
+L 131.121982 195.832654 
+L 130.207182 194.931074 
+L 129.293558 194.030151 
+L 128.38107 193.129865 
+L 127.469677 192.230201 
+L 126.559341 191.331142 
+L 125.650026 190.432673 
+L 124.741698 189.534778 
+L 123.834324 188.637442 
+L 122.927873 187.740653 
+L 123.41671 186.902573 
+L 123.912966 186.068864 
+L 124.4166 185.239591 
+L 124.927574 184.414821 
+L 125.445847 183.594617 
+L 125.971379 182.779046 
+L 126.504128 181.96817 
+L 127.044052 181.162054 
+L 127.591108 180.360762 
+L 128.145254 179.564356 
+L 128.706446 178.772898 
+L 129.274639 177.986453 
+L 129.849789 177.20508 
+L 130.431851 176.428843 
+L 131.020779 175.657802 
+L 131.616526 174.892017 
+L 132.219045 174.131549 
+L 132.82829 173.376459 
+L 133.444211 172.626805 
+L 134.066761 171.882646 
+L 134.69589 171.144041 
+L 135.33155 170.411049 
+L 135.973689 169.683727 
+L 136.622258 168.962132 
+L 137.277204 168.246321 
+L 137.938478 167.53635 
+L 138.606025 166.832276 
+L 139.279795 166.134154 
+L 139.959734 165.442038 
+L 140.645788 164.755984 
+L 141.337904 164.076045 
+L 142.036026 163.402275 
+L 142.7401 162.734728 
+L 143.450071 162.073454 
+L 144.165882 161.418508 
+L 144.887477 160.769939 
+L 145.614799 160.1278 
+L 146.347791 159.49214 
+L 147.086396 158.863011 
+L 147.830555 158.240461 
+L 148.580209 157.62454 
+L 149.335299 157.015295 
+L 150.095767 156.412776 
+L 150.861552 155.817029 
+L 151.632593 155.228101 
+L 152.40883 154.646039 
+L 153.190203 154.070889 
+L 153.976648 153.502696 
+L 154.768106 152.941504 
+L 155.564512 152.387358 
+L 156.365804 151.840302 
+L 157.17192 151.300378 
+L 157.982796 150.767629 
+L 158.798367 150.242097 
+L 159.618571 149.723824 
+L 160.443341 149.21285 
+L 161.272614 148.709216 
+L 162.106323 148.21296 
+L 162.944403 147.724123 
+L 163.841192 148.630574 
+L 164.738528 149.537948 
+L 165.636423 150.446276 
+L 166.534892 151.355591 
+L 167.433951 152.265927 
+L 168.333615 153.17732 
+L 169.233901 154.089808 
+L 170.134824 155.003432 
+L 171.036404 155.918232 
+L 171.938657 156.834254 
+L 172.841604 157.751544 
+L 173.745264 158.670152 
+L 174.649658 159.59013 
+L 175.554808 160.511532 
+L 176.460735 161.434418 
+L 177.367463 162.358848 
+L 178.275017 163.284888 
+L 179.183422 164.212608 
+L 180.092705 165.14208 
+L 181.002892 166.073383 
+L 181.914013 167.006599 
+L 182.826097 167.941816 
+L 183.739176 168.879129 
+L 184.653282 169.818636 
+L 185.568448 170.760444 
+L 186.484709 171.704667 
+L 187.402103 172.651426 
+L 188.320667 173.600851 
+L 189.24044 174.55308 
+L 190.161463 175.508262 
+L 191.083779 176.466556 
+L 192.007431 177.428135 
+L 192.932465 178.393181 
+L 193.858927 179.361894 
+L 194.786866 180.334488 
+L 195.716331 181.311192 
+L 196.647374 182.292256 
+L 197.580046 183.277951 
+L 198.514401 184.268568 
+L 199.450491 185.264425 
+L 200.38837 186.265867 
+L 201.328091 187.273271 
+L 202.269709 188.287046 
+L 203.213273 189.307639 
+L 204.158832 190.335542 
+L 205.106431 191.371291 
+L 206.05611 192.415478 
+L 207.007902 193.468752 
+L 207.961831 194.53183 
+L 208.917906 195.605505 
+L 209.876124 196.690656 
+L 210.836459 197.788258 
+L 211.798859 198.899396 
+L 212.763238 200.025281 
+L 213.729465 201.167269 
+L 214.697358 202.326879 
+L 215.66666 203.505821 
+L 216.637027 204.70602 
+z
+" clip-path="url(#p7c8276638b)" style="fill: #e5735c; opacity: 0.3"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 181.133408 242.40425 
+L 179.90977 243.375223 
+L 178.709571 244.34559 
+L 177.530629 245.314892 
+L 176.371019 246.282785 
+L 175.229031 247.249012 
+L 174.103146 248.213391 
+L 172.992008 249.175791 
+L 171.894406 250.136126 
+L 170.809255 251.094344 
+L 169.73558 252.050419 
+L 168.672502 253.004348 
+L 167.619228 253.95614 
+L 166.575041 254.905819 
+L 165.539292 255.853418 
+L 164.511389 256.798977 
+L 163.490796 257.742541 
+L 162.477021 258.684159 
+L 161.469617 259.62388 
+L 160.468175 260.561759 
+L 159.472318 261.497849 
+L 158.481701 262.432204 
+L 157.496006 263.364876 
+L 156.514942 264.295919 
+L 155.538238 265.225384 
+L 154.565644 266.153323 
+L 153.596931 267.079785 
+L 152.631885 268.004819 
+L 151.670306 268.928471 
+L 150.712012 269.850787 
+L 149.75683 270.77181 
+L 148.804601 271.691583 
+L 147.855176 272.610147 
+L 146.908417 273.527541 
+L 145.964194 274.443802 
+L 145.022386 275.358968 
+L 144.082879 276.273074 
+L 143.145566 277.186153 
+L 142.210349 278.098237 
+L 141.277133 279.009358 
+L 140.34583 279.919545 
+L 139.416358 280.828828 
+L 138.488638 281.737233 
+L 137.562598 282.644787 
+L 136.638168 283.551515 
+L 135.715282 284.457442 
+L 134.79388 285.362592 
+L 133.873902 286.266986 
+L 132.955294 287.170646 
+L 132.038004 288.073593 
+L 131.121982 288.975846 
+L 130.207182 289.877426 
+L 129.293558 290.778349 
+L 128.38107 291.678635 
+L 127.469677 292.578299 
+L 126.559341 293.477358 
+L 125.650026 294.375827 
+L 124.741698 295.273722 
+L 123.834324 296.171058 
+L 122.927873 297.067847 
+L 122.446493 296.225461 
+L 121.972607 295.378837 
+L 121.506253 294.52804 
+L 121.047468 293.673139 
+L 120.596288 292.814199 
+L 120.152748 291.95129 
+L 119.716884 291.084478 
+L 119.288729 290.213832 
+L 118.868317 289.339421 
+L 118.455682 288.461313 
+L 118.050856 287.579579 
+L 117.653871 286.694286 
+L 117.264758 285.805505 
+L 116.883547 284.913306 
+L 116.510269 284.017759 
+L 116.144954 283.118935 
+L 115.78763 282.216904 
+L 115.438324 281.311737 
+L 115.097065 280.403507 
+L 114.76388 279.492283 
+L 114.438794 278.578139 
+L 114.121834 277.661146 
+L 113.813024 276.741375 
+L 113.512389 275.818901 
+L 113.219951 274.893795 
+L 112.935736 273.96613 
+L 112.659763 273.03598 
+L 112.392057 272.103417 
+L 112.132637 271.168515 
+L 111.881523 270.231348 
+L 111.638737 269.291989 
+L 111.404296 268.350512 
+L 111.17822 267.406992 
+L 110.960525 266.461503 
+L 110.75123 265.514119 
+L 110.550351 264.564915 
+L 110.357904 263.613966 
+L 110.173903 262.661346 
+L 109.998363 261.707131 
+L 109.831298 260.751396 
+L 109.672722 259.794216 
+L 109.522646 258.835666 
+L 109.381082 257.875822 
+L 109.248043 256.914759 
+L 109.123537 255.952554 
+L 109.007575 254.989282 
+L 108.900167 254.025018 
+L 108.80132 253.05984 
+L 108.711042 252.093822 
+L 108.629341 251.127041 
+L 108.556222 250.159573 
+L 108.491693 249.191494 
+L 108.435756 248.222881 
+L 108.388418 247.253809 
+L 108.349682 246.284356 
+L 108.319551 245.314597 
+L 108.298027 244.344609 
+L 108.285112 243.374468 
+L 108.280806 242.40425 
+L 108.285112 241.434032 
+L 108.298027 240.463891 
+L 108.319551 239.493903 
+L 108.349682 238.524144 
+L 108.388418 237.554691 
+L 108.435756 236.585619 
+L 108.491693 235.617006 
+L 108.556222 234.648927 
+L 108.629341 233.681459 
+L 108.711042 232.714678 
+L 108.80132 231.74866 
+L 108.900167 230.783482 
+L 109.007575 229.819218 
+L 109.123537 228.855946 
+L 109.248043 227.893741 
+L 109.381082 226.932678 
+L 109.522646 225.972834 
+L 109.672722 225.014284 
+L 109.831298 224.057104 
+L 109.998363 223.101369 
+L 110.173903 222.147154 
+L 110.357904 221.194534 
+L 110.550351 220.243585 
+L 110.75123 219.294381 
+L 110.960525 218.346997 
+L 111.17822 217.401508 
+L 111.404296 216.457988 
+L 111.638737 215.516511 
+L 111.881523 214.577152 
+L 112.132637 213.639985 
+L 112.392057 212.705083 
+L 112.659763 211.77252 
+L 112.935736 210.84237 
+L 113.219951 209.914705 
+L 113.512389 208.989599 
+L 113.813024 208.067125 
+L 114.121834 207.147354 
+L 114.438794 206.230361 
+L 114.76388 205.316217 
+L 115.097065 204.404993 
+L 115.438324 203.496763 
+L 115.78763 202.591596 
+L 116.144954 201.689565 
+L 116.510269 200.790741 
+L 116.883547 199.895194 
+L 117.264758 199.002995 
+L 117.653871 198.114214 
+L 118.050856 197.228921 
+L 118.455682 196.347187 
+L 118.868317 195.469079 
+L 119.288729 194.594668 
+L 119.716884 193.724022 
+L 120.152748 192.85721 
+L 120.596288 191.994301 
+L 121.047468 191.135361 
+L 121.506253 190.28046 
+L 121.972607 189.429663 
+L 122.446493 188.583039 
+L 122.927873 187.740653 
+L 123.834324 188.637442 
+L 124.741698 189.534778 
+L 125.650026 190.432673 
+L 126.559341 191.331142 
+L 127.469677 192.230201 
+L 128.38107 193.129865 
+L 129.293558 194.030151 
+L 130.207182 194.931074 
+L 131.121982 195.832654 
+L 132.038004 196.734907 
+L 132.955294 197.637854 
+L 133.873902 198.541514 
+L 134.79388 199.445908 
+L 135.715282 200.351058 
+L 136.638168 201.256985 
+L 137.562598 202.163713 
+L 138.488638 203.071267 
+L 139.416358 203.979672 
+L 140.34583 204.888955 
+L 141.277133 205.799142 
+L 142.210349 206.710263 
+L 143.145566 207.622347 
+L 144.082879 208.535426 
+L 145.022386 209.449532 
+L 145.964194 210.364698 
+L 146.908417 211.280959 
+L 147.855176 212.198353 
+L 148.804601 213.116917 
+L 149.75683 214.03669 
+L 150.712012 214.957713 
+L 151.670306 215.880029 
+L 152.631885 216.803681 
+L 153.596931 217.728715 
+L 154.565644 218.655177 
+L 155.538238 219.583116 
+L 156.514942 220.512581 
+L 157.496006 221.443624 
+L 158.481701 222.376296 
+L 159.472318 223.310651 
+L 160.468175 224.246741 
+L 161.469617 225.18462 
+L 162.477021 226.124341 
+L 163.490796 227.065959 
+L 164.511389 228.009523 
+L 165.539292 228.955082 
+L 166.575041 229.902681 
+L 167.619228 230.85236 
+L 168.672502 231.804152 
+L 169.73558 232.758081 
+L 170.809255 233.714156 
+L 171.894406 234.672374 
+L 172.992008 235.632709 
+L 174.103146 236.595109 
+L 175.229031 237.559488 
+L 176.371019 238.525715 
+L 177.530629 239.493608 
+L 178.709571 240.46291 
+L 179.90977 241.433277 
+z
+" clip-path="url(#p7c8276638b)" style="fill: #e5735c; opacity: 0.3"/>
+   </g>
+   <g id="line2d_135">
+    <path d="M 217.608 73.769403 
+L 211.722729 73.872131 
+L 205.844628 74.180189 
+L 199.980859 74.693203 
+L 194.138565 75.410546 
+L 188.324866 76.331346 
+L 182.546844 77.454479 
+L 176.811538 78.778579 
+L 171.125937 80.302031 
+L 165.496967 82.02298 
+L 159.931486 83.939329 
+L 154.436275 86.048743 
+L 149.018029 88.348652 
+L 143.683349 90.836254 
+L 138.438735 93.508518 
+L 133.290577 96.362189 
+L 128.245146 99.393789 
+L 123.30859 102.599626 
+L 118.486924 105.975793 
+L 113.786021 109.518177 
+L 109.21161 113.222463 
+L 104.769263 117.084136 
+L 100.464392 121.098493 
+L 96.302243 125.260642 
+L 92.287886 129.565513 
+L 88.426213 134.00786 
+L 84.721927 138.582271 
+L 81.179543 143.283174 
+L 77.803376 148.10484 
+L 74.597539 153.041396 
+L 71.565939 158.086827 
+L 68.712268 163.234985 
+L 66.040004 168.479599 
+L 63.552402 173.814279 
+L 61.252493 179.232525 
+L 59.143079 184.727736 
+L 57.22673 190.293217 
+L 55.505781 195.922187 
+L 53.982329 201.607788 
+L 52.658229 207.343094 
+L 51.535096 213.121116 
+L 50.614296 218.934815 
+L 49.896953 224.777109 
+L 49.383939 230.640878 
+L 49.075881 236.518979 
+L 48.973153 242.40425 
+L 49.075881 248.289521 
+L 49.383939 254.167622 
+L 49.896953 260.031391 
+L 50.614296 265.873685 
+L 51.535096 271.687384 
+L 52.658229 277.465406 
+L 53.982329 283.200712 
+L 55.505781 288.886313 
+L 57.22673 294.515283 
+L 59.143079 300.080764 
+L 61.252493 305.575975 
+L 63.552402 310.994221 
+L 66.040004 316.328901 
+L 68.712268 321.573515 
+L 71.565939 326.721673 
+L 74.597539 331.767104 
+L 77.803376 336.70366 
+L 81.179543 341.525326 
+L 84.721927 346.226229 
+L 88.426213 350.80064 
+L 92.287886 355.242987 
+L 96.302243 359.547858 
+L 100.464392 363.710007 
+L 104.769263 367.724364 
+L 109.21161 371.586037 
+L 113.786021 375.290323 
+L 118.486924 378.832707 
+L 123.30859 382.208874 
+L 128.245146 385.414711 
+L 133.290577 388.446311 
+L 138.438735 391.299982 
+L 143.683349 393.972246 
+L 149.018029 396.459848 
+L 154.436275 398.759757 
+L 159.931486 400.869171 
+L 165.496967 402.78552 
+L 171.125937 404.506469 
+L 176.811538 406.029921 
+L 182.546844 407.354021 
+L 188.324866 408.477154 
+L 194.138565 409.397954 
+L 199.980859 410.115297 
+L 205.844628 410.628311 
+L 211.722729 410.936369 
+L 217.608 411.039097 
+L 223.493271 410.936369 
+L 229.371372 410.628311 
+L 235.235141 410.115297 
+L 241.077435 409.397954 
+L 246.891134 408.477154 
+L 252.669156 407.354021 
+L 258.404462 406.029921 
+L 264.090063 404.506469 
+L 269.719033 402.78552 
+L 275.284514 400.869171 
+L 280.779725 398.759757 
+L 286.197971 396.459848 
+L 291.532651 393.972246 
+L 296.777265 391.299982 
+L 301.925423 388.446311 
+L 306.970854 385.414711 
+L 311.90741 382.208874 
+L 316.729076 378.832707 
+L 321.429979 375.290323 
+L 326.00439 371.586037 
+L 330.446737 367.724364 
+L 334.751608 363.710007 
+L 338.913757 359.547858 
+L 342.928114 355.242987 
+L 346.789787 350.80064 
+L 350.494073 346.226229 
+L 354.036457 341.525326 
+L 357.412624 336.70366 
+L 360.618461 331.767104 
+L 363.650061 326.721673 
+L 366.503732 321.573515 
+L 369.175996 316.328901 
+L 371.663598 310.994221 
+L 373.963507 305.575975 
+L 376.072921 300.080764 
+L 377.98927 294.515283 
+L 379.710219 288.886313 
+L 381.233671 283.200712 
+L 382.557771 277.465406 
+L 383.680904 271.687384 
+L 384.601704 265.873685 
+L 385.319047 260.031391 
+L 385.832061 254.167622 
+L 386.140119 248.289521 
+L 386.242847 242.40425 
+L 386.140119 236.518979 
+L 385.832061 230.640878 
+L 385.319047 224.777109 
+L 384.601704 218.934815 
+L 383.680904 213.121116 
+L 382.557771 207.343094 
+L 381.233671 201.607788 
+L 379.710219 195.922187 
+L 377.98927 190.293217 
+L 376.072921 184.727736 
+L 373.963507 179.232525 
+L 371.663598 173.814279 
+L 369.175996 168.479599 
+L 366.503732 163.234985 
+L 363.650061 158.086827 
+L 360.618461 153.041396 
+L 357.412624 148.10484 
+L 354.036457 143.283174 
+L 350.494073 138.582271 
+L 346.789787 134.00786 
+L 342.928114 129.565513 
+L 338.913757 125.260642 
+L 334.751608 121.098493 
+L 330.446737 117.084136 
+L 326.00439 113.222463 
+L 321.429979 109.518177 
+L 316.729076 105.975793 
+L 311.90741 102.599626 
+L 306.970854 99.393789 
+L 301.925423 96.362189 
+L 296.777265 93.508518 
+L 291.532651 90.836254 
+L 286.197971 88.348652 
+L 280.779725 86.048743 
+L 275.284514 83.939329 
+L 269.719033 82.02298 
+L 264.090063 80.302031 
+L 258.404462 78.778579 
+L 252.669156 77.454479 
+L 246.891134 76.331346 
+L 241.077435 75.410546 
+L 235.235141 74.693203 
+L 229.371372 74.180189 
+L 223.493271 73.872131 
+L 217.608 73.769403 
+L 217.608 73.769403 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_136">
+    <path d="M 217.608 115.748012 
+L 212.083332 115.868561 
+L 206.569182 116.229977 
+L 201.076044 116.831574 
+L 195.614375 117.672205 
+L 190.194573 118.750271 
+L 184.826953 120.063719 
+L 179.521735 121.610049 
+L 174.289015 123.386318 
+L 169.138756 125.389144 
+L 164.080761 127.614715 
+L 159.124658 130.058795 
+L 154.279881 132.71673 
+L 149.555653 135.583462 
+L 144.960966 138.653534 
+L 140.504568 141.921101 
+L 136.19494 145.379943 
+L 132.040286 149.023476 
+L 128.048515 152.844765 
+L 124.227226 156.836536 
+L 120.583693 160.99119 
+L 117.124851 165.300818 
+L 113.857284 169.757216 
+L 110.787212 174.351903 
+L 107.92048 179.076131 
+L 105.262545 183.920908 
+L 102.818465 188.877011 
+L 100.592894 193.935006 
+L 98.590068 199.085265 
+L 96.813799 204.317985 
+L 95.267469 209.623203 
+L 93.954021 214.990823 
+L 92.875955 220.410625 
+L 92.035324 225.872294 
+L 91.433727 231.365432 
+L 91.072311 236.879582 
+L 90.951762 242.40425 
+L 91.072311 247.928918 
+L 91.433727 253.443068 
+L 92.035324 258.936206 
+L 92.875955 264.397875 
+L 93.954021 269.817677 
+L 95.267469 275.185297 
+L 96.813799 280.490515 
+L 98.590068 285.723235 
+L 100.592894 290.873494 
+L 102.818465 295.931489 
+L 105.262545 300.887592 
+L 107.92048 305.732369 
+L 110.787212 310.456597 
+L 113.857284 315.051284 
+L 117.124851 319.507682 
+L 120.583693 323.81731 
+L 124.227226 327.971964 
+L 128.048515 331.963735 
+L 132.040286 335.785024 
+L 136.19494 339.428557 
+L 140.504568 342.887399 
+L 144.960966 346.154966 
+L 149.555653 349.225038 
+L 154.279881 352.09177 
+L 159.124658 354.749705 
+L 164.080761 357.193785 
+L 169.138756 359.419356 
+L 174.289015 361.422182 
+L 179.521735 363.198451 
+L 184.826953 364.744781 
+L 190.194573 366.058229 
+L 195.614375 367.136295 
+L 201.076044 367.976926 
+L 206.569182 368.578523 
+L 212.083332 368.939939 
+L 217.608 369.060488 
+L 223.132668 368.939939 
+L 228.646818 368.578523 
+L 234.139956 367.976926 
+L 239.601625 367.136295 
+L 245.021427 366.058229 
+L 250.389047 364.744781 
+L 255.694265 363.198451 
+L 260.926985 361.422182 
+L 266.077244 359.419356 
+L 271.135239 357.193785 
+L 276.091342 354.749705 
+L 280.936119 352.09177 
+L 285.660347 349.225038 
+L 290.255034 346.154966 
+L 294.711432 342.887399 
+L 299.02106 339.428557 
+L 303.175714 335.785024 
+L 307.167485 331.963735 
+L 310.988774 327.971964 
+L 314.632307 323.81731 
+L 318.091149 319.507682 
+L 321.358716 315.051284 
+L 324.428788 310.456597 
+L 327.29552 305.732369 
+L 329.953455 300.887592 
+L 332.397535 295.931489 
+L 334.623106 290.873494 
+L 336.625932 285.723235 
+L 338.402201 280.490515 
+L 339.948531 275.185297 
+L 341.261979 269.817677 
+L 342.340045 264.397875 
+L 343.180676 258.936206 
+L 343.782273 253.443068 
+L 344.143689 247.928918 
+L 344.264238 242.40425 
+L 344.143689 236.879582 
+L 343.782273 231.365432 
+L 343.180676 225.872294 
+L 342.340045 220.410625 
+L 341.261979 214.990823 
+L 339.948531 209.623203 
+L 338.402201 204.317985 
+L 336.625932 199.085265 
+L 334.623106 193.935006 
+L 332.397535 188.877011 
+L 329.953455 183.920908 
+L 327.29552 179.076131 
+L 324.428788 174.351903 
+L 321.358716 169.757216 
+L 318.091149 165.300818 
+L 314.632307 160.99119 
+L 310.988774 156.836536 
+L 307.167485 152.844765 
+L 303.175714 149.023476 
+L 299.02106 145.379943 
+L 294.711432 141.921101 
+L 290.255034 138.653534 
+L 285.660347 135.583462 
+L 280.936119 132.71673 
+L 276.091342 130.058795 
+L 271.135239 127.614715 
+L 266.077244 125.389144 
+L 260.926985 123.386318 
+L 255.694265 121.610049 
+L 250.389047 120.063719 
+L 245.021427 118.750271 
+L 239.601625 117.672205 
+L 234.139956 116.831574 
+L 228.646818 116.229977 
+L 223.132668 115.868561 
+L 217.608 115.748012 
+L 217.608 115.748012 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_137">
+    <path d="M 217.608 157.880932 
+L 213.184391 157.996768 
+L 208.772907 158.34396 
+L 204.38564 158.921554 
+L 200.034614 159.727969 
+L 195.731756 160.760994 
+L 191.488858 162.017798 
+L 187.317552 163.494935 
+L 183.229269 165.188357 
+L 179.235217 167.093422 
+L 175.346341 169.204909 
+L 171.573302 171.517031 
+L 167.92644 174.023449 
+L 164.415753 176.717295 
+L 161.050861 179.591184 
+L 157.840989 182.637239 
+L 154.794934 185.847111 
+L 151.921045 189.212003 
+L 149.227199 192.72269 
+L 146.720781 196.369552 
+L 144.408659 200.142591 
+L 142.297172 204.031467 
+L 140.392107 208.025519 
+L 138.698685 212.113802 
+L 137.221548 216.285108 
+L 135.964744 220.528006 
+L 134.931719 224.830864 
+L 134.125304 229.18189 
+L 133.54771 233.569157 
+L 133.200518 237.980641 
+L 133.084682 242.40425 
+L 133.200518 246.827859 
+L 133.54771 251.239343 
+L 134.125304 255.62661 
+L 134.931719 259.977636 
+L 135.964744 264.280494 
+L 137.221548 268.523392 
+L 138.698685 272.694698 
+L 140.392107 276.782981 
+L 142.297172 280.777033 
+L 144.408659 284.665909 
+L 146.720781 288.438948 
+L 149.227199 292.08581 
+L 151.921045 295.596497 
+L 154.794934 298.961389 
+L 157.840989 302.171261 
+L 161.050861 305.217316 
+L 164.415753 308.091205 
+L 167.92644 310.785051 
+L 171.573302 313.291469 
+L 175.346341 315.603591 
+L 179.235217 317.715078 
+L 183.229269 319.620143 
+L 187.317552 321.313565 
+L 191.488858 322.790702 
+L 195.731756 324.047506 
+L 200.034614 325.080531 
+L 204.38564 325.886946 
+L 208.772907 326.46454 
+L 213.184391 326.811732 
+L 217.608 326.927568 
+L 222.031609 326.811732 
+L 226.443093 326.46454 
+L 230.83036 325.886946 
+L 235.181386 325.080531 
+L 239.484244 324.047506 
+L 243.727142 322.790702 
+L 247.898448 321.313565 
+L 251.986731 319.620143 
+L 255.980783 317.715078 
+L 259.869659 315.603591 
+L 263.642698 313.291469 
+L 267.28956 310.785051 
+L 270.800247 308.091205 
+L 274.165139 305.217316 
+L 277.375011 302.171261 
+L 280.421066 298.961389 
+L 283.294955 295.596497 
+L 285.988801 292.08581 
+L 288.495219 288.438948 
+L 290.807341 284.665909 
+L 292.918828 280.777033 
+L 294.823893 276.782981 
+L 296.517315 272.694698 
+L 297.994452 268.523392 
+L 299.251256 264.280494 
+L 300.284281 259.977636 
+L 301.090696 255.62661 
+L 301.66829 251.239343 
+L 302.015482 246.827859 
+L 302.131318 242.40425 
+L 302.015482 237.980641 
+L 301.66829 233.569157 
+L 301.090696 229.18189 
+L 300.284281 224.830864 
+L 299.251256 220.528006 
+L 297.994452 216.285108 
+L 296.517315 212.113802 
+L 294.823893 208.025519 
+L 292.918828 204.031467 
+L 290.807341 200.142591 
+L 288.495219 196.369552 
+L 285.988801 192.72269 
+L 283.294955 189.212003 
+L 280.421066 185.847111 
+L 277.375011 182.637239 
+L 274.165139 179.591184 
+L 270.800247 176.717295 
+L 267.28956 174.023449 
+L 263.642698 171.517031 
+L 259.869659 169.204909 
+L 255.980783 167.093422 
+L 251.986731 165.188357 
+L 247.898448 163.494935 
+L 243.727142 162.017798 
+L 239.484244 160.760994 
+L 235.181386 159.727969 
+L 230.83036 158.921554 
+L 226.443093 158.34396 
+L 222.031609 157.996768 
+L 217.608 157.880932 
+L 217.608 157.880932 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_138">
+    <path d="M 217.608 200.116831 
+L 214.658179 200.219841 
+L 211.722729 200.528369 
+L 208.815951 201.040912 
+L 205.952008 201.754974 
+L 203.144851 202.667074 
+L 200.408157 203.77277 
+L 197.755259 205.066675 
+L 195.199082 206.542485 
+L 192.752079 208.193009 
+L 190.426171 210.010207 
+L 188.23269 211.985226 
+L 186.182323 214.108443 
+L 184.285059 216.369515 
+L 182.550141 218.757425 
+L 180.986021 221.26054 
+L 179.600319 223.866666 
+L 178.399788 226.563104 
+L 177.390274 229.336719 
+L 176.576698 232.173997 
+L 175.963022 235.061117 
+L 175.552236 237.984011 
+L 175.346341 240.92844 
+L 175.346341 243.88006 
+L 175.552236 246.824489 
+L 175.963022 249.747383 
+L 176.576698 252.634503 
+L 177.390274 255.471781 
+L 178.399788 258.245396 
+L 179.600319 260.941834 
+L 180.986021 263.54796 
+L 182.550141 266.051075 
+L 184.285059 268.438985 
+L 186.182323 270.700057 
+L 188.23269 272.823274 
+L 190.426171 274.798293 
+L 192.752079 276.615491 
+L 195.199082 278.266015 
+L 197.755259 279.741825 
+L 200.408157 281.03573 
+L 203.144851 282.141426 
+L 205.952008 283.053526 
+L 208.815951 283.767588 
+L 211.722729 284.280131 
+L 214.658179 284.588659 
+L 217.608 284.691669 
+L 220.557821 284.588659 
+L 223.493271 284.280131 
+L 226.400049 283.767588 
+L 229.263992 283.053526 
+L 232.071149 282.141426 
+L 234.807843 281.03573 
+L 237.460741 279.741825 
+L 240.016918 278.266015 
+L 242.463921 276.615491 
+L 244.789829 274.798293 
+L 246.98331 272.823274 
+L 249.033677 270.700057 
+L 250.930941 268.438985 
+L 252.665859 266.051075 
+L 254.229979 263.54796 
+L 255.615681 260.941834 
+L 256.816212 258.245396 
+L 257.825726 255.471781 
+L 258.639302 252.634503 
+L 259.252978 249.747383 
+L 259.663764 246.824489 
+L 259.869659 243.88006 
+L 259.869659 240.92844 
+L 259.663764 237.984011 
+L 259.252978 235.061117 
+L 258.639302 232.173997 
+L 257.825726 229.336719 
+L 256.816212 226.563104 
+L 255.615681 223.866666 
+L 254.229979 221.26054 
+L 252.665859 218.757425 
+L 250.930941 216.369515 
+L 249.033677 214.108443 
+L 246.98331 211.985226 
+L 244.789829 210.010207 
+L 242.463921 208.193009 
+L 240.016918 206.542485 
+L 237.460741 205.066675 
+L 234.807843 203.77277 
+L 232.071149 202.667074 
+L 229.263992 201.754974 
+L 226.400049 201.040912 
+L 223.493271 200.528369 
+L 220.557821 200.219841 
+L 217.608 200.116831 
+L 217.608 200.116831 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_139">
+    <path d="M 217.608 -1 
+L 217.608 0.831842 
+L 217.608 2.904555 
+L 217.608 4.977996 
+L 217.608 7.052161 
+L 217.608 9.127043 
+L 217.608 11.202635 
+L 217.608 13.278932 
+L 217.608 15.355926 
+L 217.608 17.433613 
+L 217.608 19.511984 
+L 217.608 21.591035 
+L 217.608 23.670758 
+L 217.608 25.751147 
+L 217.608 27.832197 
+L 217.608 29.9139 
+L 217.608 31.99625 
+L 217.608 34.079241 
+L 217.608 36.162867 
+L 217.608 38.247121 
+L 217.608 40.331997 
+L 217.608 42.417489 
+L 217.608 44.503589 
+L 217.608 46.590293 
+L 217.608 48.677593 
+L 217.608 50.765483 
+L 217.608 52.853957 
+L 217.608 54.943009 
+L 217.608 57.032631 
+L 217.608 59.122818 
+L 217.608 61.213563 
+L 217.608 63.304861 
+L 217.608 65.396704 
+L 217.608 67.489086 
+L 217.608 69.582001 
+L 217.608 71.675442 
+L 217.608 73.769403 
+L 217.608 75.863878 
+L 217.608 77.958861 
+L 217.608 80.054344 
+L 217.608 82.150322 
+L 217.608 84.246788 
+L 217.608 86.343736 
+L 217.608 88.441159 
+L 217.608 90.539051 
+L 217.608 92.637406 
+L 217.608 94.736217 
+L 217.608 96.835478 
+L 217.608 98.935182 
+L 217.608 101.035324 
+L 217.608 103.135896 
+L 217.608 105.236892 
+L 217.608 107.338306 
+L 217.608 109.440131 
+L 217.608 111.542362 
+L 217.608 113.644991 
+L 217.608 115.748012 
+L 217.608 117.851419 
+L 217.608 119.955206 
+L 217.608 122.059365 
+L 217.608 124.163892 
+L 217.608 126.268778 
+L 217.608 128.374018 
+L 217.608 130.479605 
+L 217.608 132.585534 
+L 217.608 134.691797 
+L 217.608 136.798388 
+L 217.608 138.905301 
+L 217.608 141.012529 
+L 217.608 143.120065 
+L 217.608 145.227905 
+L 217.608 147.33604 
+L 217.608 149.444465 
+L 217.608 151.553173 
+L 217.608 153.662158 
+L 217.608 155.771413 
+L 217.608 157.880932 
+L 217.608 159.990709 
+L 217.608 162.100736 
+L 217.608 164.211008 
+L 217.608 166.321519 
+L 217.608 168.432261 
+L 217.608 170.543228 
+L 217.608 172.654415 
+L 217.608 174.765814 
+L 217.608 176.877418 
+L 217.608 178.989223 
+L 217.608 181.101221 
+L 217.608 183.213405 
+L 217.608 185.32577 
+L 217.608 187.438308 
+L 217.608 189.551014 
+L 217.608 191.663881 
+L 217.608 193.776903 
+L 217.608 195.890073 
+L 217.608 198.003384 
+L 217.608 200.116831 
+L 217.608 202.230406 
+L 217.608 204.344104 
+L 217.608 206.457918 
+L 217.608 208.571841 
+L 217.608 210.685867 
+L 217.608 212.79999 
+L 217.608 214.914203 
+L 217.608 217.0285 
+L 217.608 219.142875 
+L 217.608 221.25732 
+L 217.608 223.371829 
+L 217.608 225.486396 
+L 217.608 227.601015 
+L 217.608 229.715679 
+L 217.608 231.830382 
+L 217.608 233.945117 
+L 217.608 236.059878 
+L 217.608 238.174658 
+L 217.608 240.289451 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_140">
+    <path d="M 91.645598 24.23097 
+L 92.680083 26.022751 
+L 93.714948 27.81519 
+L 94.750191 29.608283 
+L 95.785808 31.402024 
+L 96.821796 33.196408 
+L 97.858152 34.99143 
+L 98.894873 36.787083 
+L 99.931955 38.583362 
+L 100.969396 40.380262 
+L 102.007193 42.177778 
+L 103.045341 43.975904 
+L 104.083838 45.774634 
+L 105.122681 47.573963 
+L 106.161867 49.373885 
+L 107.201392 51.174396 
+L 108.241254 52.975489 
+L 109.281449 54.777159 
+L 110.321973 56.579401 
+L 111.362825 58.382209 
+L 112.404 60.185577 
+L 113.445496 61.9895 
+L 114.487309 63.793973 
+L 115.529436 65.59899 
+L 116.571874 67.404546 
+L 117.614619 69.210634 
+L 118.65767 71.017251 
+L 119.701022 72.824389 
+L 120.744672 74.632044 
+L 121.788617 76.44021 
+L 122.832854 78.248881 
+L 123.877379 80.058053 
+L 124.92219 81.867719 
+L 125.967284 83.677874 
+L 127.012657 85.488512 
+L 128.058305 87.299629 
+L 129.104227 89.111218 
+L 130.150418 90.923274 
+L 131.196875 92.735792 
+L 132.243596 94.548765 
+L 133.290577 96.362189 
+L 134.337814 98.176057 
+L 135.385305 99.990365 
+L 136.433047 101.805107 
+L 137.481036 103.620277 
+L 138.529269 105.43587 
+L 139.577743 107.25188 
+L 140.626455 109.068302 
+L 141.675401 110.88513 
+L 142.724578 112.702359 
+L 143.773984 114.519982 
+L 144.823614 116.337995 
+L 145.873466 118.156393 
+L 146.923537 119.975168 
+L 147.973823 121.794317 
+L 149.024321 123.613833 
+L 150.075028 125.433711 
+L 151.125941 127.253945 
+L 152.177056 129.07453 
+L 153.22837 130.895461 
+L 154.279881 132.71673 
+L 155.331585 134.538334 
+L 156.383478 136.360267 
+L 157.435558 138.182523 
+L 158.487821 140.005096 
+L 159.540264 141.827981 
+L 160.592884 143.651172 
+L 161.645678 145.474665 
+L 162.698642 147.298452 
+L 163.751773 149.122529 
+L 164.805069 150.946891 
+L 165.858525 152.771531 
+L 166.912139 154.596443 
+L 167.965908 156.421624 
+L 169.019827 158.247066 
+L 170.073895 160.072765 
+L 171.128107 161.898715 
+L 172.182462 163.724909 
+L 173.236954 165.551344 
+L 174.291582 167.378012 
+L 175.346341 169.204909 
+L 176.401229 171.03203 
+L 177.456243 172.859367 
+L 178.511379 174.686916 
+L 179.566634 176.514672 
+L 180.622005 178.342628 
+L 181.677489 180.17078 
+L 182.733082 181.999121 
+L 183.788782 183.827646 
+L 184.844584 185.656349 
+L 185.900486 187.485226 
+L 186.956485 189.314269 
+L 188.012578 191.143475 
+L 189.06876 192.972836 
+L 190.125029 194.802348 
+L 191.181382 196.632005 
+L 192.237816 198.461802 
+L 193.294326 200.291732 
+L 194.350911 202.121791 
+L 195.407567 203.951972 
+L 196.46429 205.782271 
+L 197.521078 207.612681 
+L 198.577927 209.443197 
+L 199.634834 211.273813 
+L 200.691796 213.104524 
+L 201.748809 214.935325 
+L 202.80587 216.766209 
+L 203.862977 218.597171 
+L 204.920125 220.428206 
+L 205.977312 222.259308 
+L 207.034535 224.090471 
+L 208.09179 225.92169 
+L 209.149073 227.752959 
+L 210.206383 229.584273 
+L 211.263715 231.415626 
+L 212.321066 233.247012 
+L 213.378434 235.078426 
+L 214.435814 236.909862 
+L 215.493204 238.741316 
+L 216.5506 240.57278 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_141">
+    <path d="M -0.56528 116.441848 
+L 1.226501 117.476333 
+L 3.01894 118.511198 
+L 4.812033 119.546441 
+L 6.605774 120.582058 
+L 8.400158 121.618046 
+L 10.19518 122.654402 
+L 11.990833 123.691123 
+L 13.787112 124.728205 
+L 15.584012 125.765646 
+L 17.381528 126.803443 
+L 19.179654 127.841591 
+L 20.978384 128.880088 
+L 22.777713 129.918931 
+L 24.577635 130.958117 
+L 26.378146 131.997642 
+L 28.179239 133.037504 
+L 29.980909 134.077699 
+L 31.783151 135.118223 
+L 33.585959 136.159075 
+L 35.389327 137.20025 
+L 37.19325 138.241746 
+L 38.997723 139.283559 
+L 40.80274 140.325686 
+L 42.608296 141.368124 
+L 44.414384 142.410869 
+L 46.221001 143.45392 
+L 48.028139 144.497272 
+L 49.835794 145.540922 
+L 51.64396 146.584867 
+L 53.452631 147.629104 
+L 55.261803 148.673629 
+L 57.071469 149.71844 
+L 58.881624 150.763534 
+L 60.692262 151.808907 
+L 62.503379 152.854555 
+L 64.314968 153.900477 
+L 66.127024 154.946668 
+L 67.939542 155.993125 
+L 69.752515 157.039846 
+L 71.565939 158.086827 
+L 73.379807 159.134064 
+L 75.194115 160.181555 
+L 77.008857 161.229297 
+L 78.824027 162.277286 
+L 80.63962 163.325519 
+L 82.45563 164.373993 
+L 84.272052 165.422705 
+L 86.08888 166.471651 
+L 87.906109 167.520828 
+L 89.723732 168.570234 
+L 91.541745 169.619864 
+L 93.360143 170.669716 
+L 95.178918 171.719787 
+L 96.998067 172.770073 
+L 98.817583 173.820571 
+L 100.637461 174.871278 
+L 102.457695 175.922191 
+L 104.27828 176.973306 
+L 106.099211 178.02462 
+L 107.92048 179.076131 
+L 109.742084 180.127835 
+L 111.564017 181.179728 
+L 113.386273 182.231808 
+L 115.208846 183.284071 
+L 117.031731 184.336514 
+L 118.854922 185.389134 
+L 120.678415 186.441928 
+L 122.502202 187.494892 
+L 124.326279 188.548023 
+L 126.150641 189.601319 
+L 127.975281 190.654775 
+L 129.800193 191.708389 
+L 131.625374 192.762158 
+L 133.450816 193.816077 
+L 135.276515 194.870145 
+L 137.102465 195.924357 
+L 138.928659 196.978712 
+L 140.755094 198.033204 
+L 142.581762 199.087832 
+L 144.408659 200.142591 
+L 146.23578 201.197479 
+L 148.063117 202.252493 
+L 149.890666 203.307629 
+L 151.718422 204.362884 
+L 153.546378 205.418255 
+L 155.37453 206.473739 
+L 157.202871 207.529332 
+L 159.031396 208.585032 
+L 160.860099 209.640834 
+L 162.688976 210.696736 
+L 164.518019 211.752735 
+L 166.347225 212.808828 
+L 168.176586 213.86501 
+L 170.006098 214.921279 
+L 171.835755 215.977632 
+L 173.665552 217.034066 
+L 175.495482 218.090576 
+L 177.325541 219.147161 
+L 179.155722 220.203817 
+L 180.986021 221.26054 
+L 182.816431 222.317328 
+L 184.646947 223.374177 
+L 186.477563 224.431084 
+L 188.308274 225.488046 
+L 190.139075 226.545059 
+L 191.969959 227.60212 
+L 193.800921 228.659227 
+L 195.631956 229.716375 
+L 197.463058 230.773562 
+L 199.294221 231.830785 
+L 201.12544 232.88804 
+L 202.956709 233.945323 
+L 204.788023 235.002633 
+L 206.619376 236.059965 
+L 208.450762 237.117316 
+L 210.282176 238.174684 
+L 212.113612 239.232064 
+L 213.945066 240.289454 
+L 215.77653 241.34685 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_142">
+    <path d="M -1 242.40425 
+L 0.954897 242.40425 
+L 3.035947 242.40425 
+L 5.11765 242.40425 
+L 7.2 242.40425 
+L 9.282991 242.40425 
+L 11.366617 242.40425 
+L 13.450871 242.40425 
+L 15.535747 242.40425 
+L 17.621239 242.40425 
+L 19.707339 242.40425 
+L 21.794043 242.40425 
+L 23.881343 242.40425 
+L 25.969233 242.40425 
+L 28.057707 242.40425 
+L 30.146759 242.40425 
+L 32.236381 242.40425 
+L 34.326568 242.40425 
+L 36.417313 242.40425 
+L 38.508611 242.40425 
+L 40.600454 242.40425 
+L 42.692836 242.40425 
+L 44.785751 242.40425 
+L 46.879192 242.40425 
+L 48.973153 242.40425 
+L 51.067628 242.40425 
+L 53.162611 242.40425 
+L 55.258094 242.40425 
+L 57.354072 242.40425 
+L 59.450538 242.40425 
+L 61.547486 242.40425 
+L 63.644909 242.40425 
+L 65.742801 242.40425 
+L 67.841156 242.40425 
+L 69.939967 242.40425 
+L 72.039228 242.40425 
+L 74.138932 242.40425 
+L 76.239074 242.40425 
+L 78.339646 242.40425 
+L 80.440642 242.40425 
+L 82.542056 242.40425 
+L 84.643881 242.40425 
+L 86.746112 242.40425 
+L 88.848741 242.40425 
+L 90.951762 242.40425 
+L 93.055169 242.40425 
+L 95.158956 242.40425 
+L 97.263115 242.40425 
+L 99.367642 242.40425 
+L 101.472528 242.40425 
+L 103.577768 242.40425 
+L 105.683355 242.40425 
+L 107.789284 242.40425 
+L 109.895547 242.40425 
+L 112.002138 242.40425 
+L 114.109051 242.40425 
+L 116.216279 242.40425 
+L 118.323815 242.40425 
+L 120.431655 242.40425 
+L 122.53979 242.40425 
+L 124.648215 242.40425 
+L 126.756923 242.40425 
+L 128.865908 242.40425 
+L 130.975163 242.40425 
+L 133.084682 242.40425 
+L 135.194459 242.40425 
+L 137.304486 242.40425 
+L 139.414758 242.40425 
+L 141.525269 242.40425 
+L 143.636011 242.40425 
+L 145.746978 242.40425 
+L 147.858165 242.40425 
+L 149.969564 242.40425 
+L 152.081168 242.40425 
+L 154.192973 242.40425 
+L 156.304971 242.40425 
+L 158.417155 242.40425 
+L 160.52952 242.40425 
+L 162.642058 242.40425 
+L 164.754764 242.40425 
+L 166.867631 242.40425 
+L 168.980653 242.40425 
+L 171.093823 242.40425 
+L 173.207134 242.40425 
+L 175.320581 242.40425 
+L 177.434156 242.40425 
+L 179.547854 242.40425 
+L 181.661668 242.40425 
+L 183.775591 242.40425 
+L 185.889617 242.40425 
+L 188.00374 242.40425 
+L 190.117953 242.40425 
+L 192.23225 242.40425 
+L 194.346625 242.40425 
+L 196.46107 242.40425 
+L 198.575579 242.40425 
+L 200.690146 242.40425 
+L 202.804765 242.40425 
+L 204.919429 242.40425 
+L 207.034132 242.40425 
+L 209.148867 242.40425 
+L 211.263628 242.40425 
+L 213.378408 242.40425 
+L 215.493201 242.40425 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_143">
+    <path d="M -0.56528 368.366652 
+L 1.226501 367.332167 
+L 3.01894 366.297302 
+L 4.812033 365.262059 
+L 6.605774 364.226442 
+L 8.400158 363.190454 
+L 10.19518 362.154098 
+L 11.990833 361.117377 
+L 13.787112 360.080295 
+L 15.584012 359.042854 
+L 17.381528 358.005057 
+L 19.179654 356.966909 
+L 20.978384 355.928412 
+L 22.777713 354.889569 
+L 24.577635 353.850383 
+L 26.378146 352.810858 
+L 28.179239 351.770996 
+L 29.980909 350.730801 
+L 31.783151 349.690277 
+L 33.585959 348.649425 
+L 35.389327 347.60825 
+L 37.19325 346.566754 
+L 38.997723 345.524941 
+L 40.80274 344.482814 
+L 42.608296 343.440376 
+L 44.414384 342.397631 
+L 46.221001 341.35458 
+L 48.028139 340.311228 
+L 49.835794 339.267578 
+L 51.64396 338.223633 
+L 53.452631 337.179396 
+L 55.261803 336.134871 
+L 57.071469 335.09006 
+L 58.881624 334.044966 
+L 60.692262 332.999593 
+L 62.503379 331.953945 
+L 64.314968 330.908023 
+L 66.127024 329.861832 
+L 67.939542 328.815375 
+L 69.752515 327.768654 
+L 71.565939 326.721673 
+L 73.379807 325.674436 
+L 75.194115 324.626945 
+L 77.008857 323.579203 
+L 78.824027 322.531214 
+L 80.63962 321.482981 
+L 82.45563 320.434507 
+L 84.272052 319.385795 
+L 86.08888 318.336849 
+L 87.906109 317.287672 
+L 89.723732 316.238266 
+L 91.541745 315.188636 
+L 93.360143 314.138784 
+L 95.178918 313.088713 
+L 96.998067 312.038427 
+L 98.817583 310.987929 
+L 100.637461 309.937222 
+L 102.457695 308.886309 
+L 104.27828 307.835194 
+L 106.099211 306.78388 
+L 107.92048 305.732369 
+L 109.742084 304.680665 
+L 111.564017 303.628772 
+L 113.386273 302.576692 
+L 115.208846 301.524429 
+L 117.031731 300.471986 
+L 118.854922 299.419366 
+L 120.678415 298.366572 
+L 122.502202 297.313608 
+L 124.326279 296.260477 
+L 126.150641 295.207181 
+L 127.975281 294.153725 
+L 129.800193 293.100111 
+L 131.625374 292.046342 
+L 133.450816 290.992423 
+L 135.276515 289.938355 
+L 137.102465 288.884143 
+L 138.928659 287.829788 
+L 140.755094 286.775296 
+L 142.581762 285.720668 
+L 144.408659 284.665909 
+L 146.23578 283.611021 
+L 148.063117 282.556007 
+L 149.890666 281.500871 
+L 151.718422 280.445616 
+L 153.546378 279.390245 
+L 155.37453 278.334761 
+L 157.202871 277.279168 
+L 159.031396 276.223468 
+L 160.860099 275.167666 
+L 162.688976 274.111764 
+L 164.518019 273.055765 
+L 166.347225 271.999672 
+L 168.176586 270.94349 
+L 170.006098 269.887221 
+L 171.835755 268.830868 
+L 173.665552 267.774434 
+L 175.495482 266.717924 
+L 177.325541 265.661339 
+L 179.155722 264.604683 
+L 180.986021 263.54796 
+L 182.816431 262.491172 
+L 184.646947 261.434323 
+L 186.477563 260.377416 
+L 188.308274 259.320454 
+L 190.139075 258.263441 
+L 191.969959 257.20638 
+L 193.800921 256.149273 
+L 195.631956 255.092125 
+L 197.463058 254.034938 
+L 199.294221 252.977715 
+L 201.12544 251.92046 
+L 202.956709 250.863177 
+L 204.788023 249.805867 
+L 206.619376 248.748535 
+L 208.450762 247.691184 
+L 210.282176 246.633816 
+L 212.113612 245.576436 
+L 213.945066 244.519046 
+L 215.77653 243.46165 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_144">
+    <path d="M 91.645598 460.57753 
+L 92.680083 458.785749 
+L 93.714948 456.99331 
+L 94.750191 455.200217 
+L 95.785808 453.406476 
+L 96.821796 451.612092 
+L 97.858152 449.81707 
+L 98.894873 448.021417 
+L 99.931955 446.225138 
+L 100.969396 444.428238 
+L 102.007193 442.630722 
+L 103.045341 440.832596 
+L 104.083838 439.033866 
+L 105.122681 437.234537 
+L 106.161867 435.434615 
+L 107.201392 433.634104 
+L 108.241254 431.833011 
+L 109.281449 430.031341 
+L 110.321973 428.229099 
+L 111.362825 426.426291 
+L 112.404 424.622923 
+L 113.445496 422.819 
+L 114.487309 421.014527 
+L 115.529436 419.20951 
+L 116.571874 417.403954 
+L 117.614619 415.597866 
+L 118.65767 413.791249 
+L 119.701022 411.984111 
+L 120.744672 410.176456 
+L 121.788617 408.36829 
+L 122.832854 406.559619 
+L 123.877379 404.750447 
+L 124.92219 402.940781 
+L 125.967284 401.130626 
+L 127.012657 399.319988 
+L 128.058305 397.508871 
+L 129.104227 395.697282 
+L 130.150418 393.885226 
+L 131.196875 392.072708 
+L 132.243596 390.259735 
+L 133.290577 388.446311 
+L 134.337814 386.632443 
+L 135.385305 384.818135 
+L 136.433047 383.003393 
+L 137.481036 381.188223 
+L 138.529269 379.37263 
+L 139.577743 377.55662 
+L 140.626455 375.740198 
+L 141.675401 373.92337 
+L 142.724578 372.106141 
+L 143.773984 370.288518 
+L 144.823614 368.470505 
+L 145.873466 366.652107 
+L 146.923537 364.833332 
+L 147.973823 363.014183 
+L 149.024321 361.194667 
+L 150.075028 359.374789 
+L 151.125941 357.554555 
+L 152.177056 355.73397 
+L 153.22837 353.913039 
+L 154.279881 352.09177 
+L 155.331585 350.270166 
+L 156.383478 348.448233 
+L 157.435558 346.625977 
+L 158.487821 344.803404 
+L 159.540264 342.980519 
+L 160.592884 341.157328 
+L 161.645678 339.333835 
+L 162.698642 337.510048 
+L 163.751773 335.685971 
+L 164.805069 333.861609 
+L 165.858525 332.036969 
+L 166.912139 330.212057 
+L 167.965908 328.386876 
+L 169.019827 326.561434 
+L 170.073895 324.735735 
+L 171.128107 322.909785 
+L 172.182462 321.083591 
+L 173.236954 319.257156 
+L 174.291582 317.430488 
+L 175.346341 315.603591 
+L 176.401229 313.77647 
+L 177.456243 311.949133 
+L 178.511379 310.121584 
+L 179.566634 308.293828 
+L 180.622005 306.465872 
+L 181.677489 304.63772 
+L 182.733082 302.809379 
+L 183.788782 300.980854 
+L 184.844584 299.152151 
+L 185.900486 297.323274 
+L 186.956485 295.494231 
+L 188.012578 293.665025 
+L 189.06876 291.835664 
+L 190.125029 290.006152 
+L 191.181382 288.176495 
+L 192.237816 286.346698 
+L 193.294326 284.516768 
+L 194.350911 282.686709 
+L 195.407567 280.856528 
+L 196.46429 279.026229 
+L 197.521078 277.195819 
+L 198.577927 275.365303 
+L 199.634834 273.534687 
+L 200.691796 271.703976 
+L 201.748809 269.873175 
+L 202.80587 268.042291 
+L 203.862977 266.211329 
+L 204.920125 264.380294 
+L 205.977312 262.549192 
+L 207.034535 260.718029 
+L 208.09179 258.88681 
+L 209.149073 257.055541 
+L 210.206383 255.224227 
+L 211.263715 253.392874 
+L 212.321066 251.561488 
+L 213.378434 249.730074 
+L 214.435814 247.898638 
+L 215.493204 246.067184 
+L 216.5506 244.23572 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_145">
+    <path d="M 217.608 461.01225 
+L 217.608 459.057353 
+L 217.608 456.976303 
+L 217.608 454.8946 
+L 217.608 452.81225 
+L 217.608 450.729259 
+L 217.608 448.645633 
+L 217.608 446.561379 
+L 217.608 444.476503 
+L 217.608 442.391011 
+L 217.608 440.304911 
+L 217.608 438.218207 
+L 217.608 436.130907 
+L 217.608 434.043017 
+L 217.608 431.954543 
+L 217.608 429.865491 
+L 217.608 427.775869 
+L 217.608 425.685682 
+L 217.608 423.594937 
+L 217.608 421.503639 
+L 217.608 419.411796 
+L 217.608 417.319414 
+L 217.608 415.226499 
+L 217.608 413.133058 
+L 217.608 411.039097 
+L 217.608 408.944622 
+L 217.608 406.849639 
+L 217.608 404.754156 
+L 217.608 402.658178 
+L 217.608 400.561712 
+L 217.608 398.464764 
+L 217.608 396.367341 
+L 217.608 394.269449 
+L 217.608 392.171094 
+L 217.608 390.072283 
+L 217.608 387.973022 
+L 217.608 385.873318 
+L 217.608 383.773176 
+L 217.608 381.672604 
+L 217.608 379.571608 
+L 217.608 377.470194 
+L 217.608 375.368369 
+L 217.608 373.266138 
+L 217.608 371.163509 
+L 217.608 369.060488 
+L 217.608 366.957081 
+L 217.608 364.853294 
+L 217.608 362.749135 
+L 217.608 360.644608 
+L 217.608 358.539722 
+L 217.608 356.434482 
+L 217.608 354.328895 
+L 217.608 352.222966 
+L 217.608 350.116703 
+L 217.608 348.010112 
+L 217.608 345.903199 
+L 217.608 343.795971 
+L 217.608 341.688435 
+L 217.608 339.580595 
+L 217.608 337.47246 
+L 217.608 335.364035 
+L 217.608 333.255327 
+L 217.608 331.146342 
+L 217.608 329.037087 
+L 217.608 326.927568 
+L 217.608 324.817791 
+L 217.608 322.707764 
+L 217.608 320.597492 
+L 217.608 318.486981 
+L 217.608 316.376239 
+L 217.608 314.265272 
+L 217.608 312.154085 
+L 217.608 310.042686 
+L 217.608 307.931082 
+L 217.608 305.819277 
+L 217.608 303.707279 
+L 217.608 301.595095 
+L 217.608 299.48273 
+L 217.608 297.370192 
+L 217.608 295.257486 
+L 217.608 293.144619 
+L 217.608 291.031597 
+L 217.608 288.918427 
+L 217.608 286.805116 
+L 217.608 284.691669 
+L 217.608 282.578094 
+L 217.608 280.464396 
+L 217.608 278.350582 
+L 217.608 276.236659 
+L 217.608 274.122633 
+L 217.608 272.00851 
+L 217.608 269.894297 
+L 217.608 267.78 
+L 217.608 265.665625 
+L 217.608 263.55118 
+L 217.608 261.436671 
+L 217.608 259.322104 
+L 217.608 257.207485 
+L 217.608 255.092821 
+L 217.608 252.978118 
+L 217.608 250.863383 
+L 217.608 248.748622 
+L 217.608 246.633842 
+L 217.608 244.519049 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_146">
+    <path d="M 343.570402 460.57753 
+L 342.535917 458.785749 
+L 341.501052 456.99331 
+L 340.465809 455.200217 
+L 339.430192 453.406476 
+L 338.394204 451.612092 
+L 337.357848 449.81707 
+L 336.321127 448.021417 
+L 335.284045 446.225138 
+L 334.246604 444.428238 
+L 333.208807 442.630722 
+L 332.170659 440.832596 
+L 331.132162 439.033866 
+L 330.093319 437.234537 
+L 329.054133 435.434615 
+L 328.014608 433.634104 
+L 326.974746 431.833011 
+L 325.934551 430.031341 
+L 324.894027 428.229099 
+L 323.853175 426.426291 
+L 322.812 424.622923 
+L 321.770504 422.819 
+L 320.728691 421.014527 
+L 319.686564 419.20951 
+L 318.644126 417.403954 
+L 317.601381 415.597866 
+L 316.55833 413.791249 
+L 315.514978 411.984111 
+L 314.471328 410.176456 
+L 313.427383 408.36829 
+L 312.383146 406.559619 
+L 311.338621 404.750447 
+L 310.29381 402.940781 
+L 309.248716 401.130626 
+L 308.203343 399.319988 
+L 307.157695 397.508871 
+L 306.111773 395.697282 
+L 305.065582 393.885226 
+L 304.019125 392.072708 
+L 302.972404 390.259735 
+L 301.925423 388.446311 
+L 300.878186 386.632443 
+L 299.830695 384.818135 
+L 298.782953 383.003393 
+L 297.734964 381.188223 
+L 296.686731 379.37263 
+L 295.638257 377.55662 
+L 294.589545 375.740198 
+L 293.540599 373.92337 
+L 292.491422 372.106141 
+L 291.442016 370.288518 
+L 290.392386 368.470505 
+L 289.342534 366.652107 
+L 288.292463 364.833332 
+L 287.242177 363.014183 
+L 286.191679 361.194667 
+L 285.140972 359.374789 
+L 284.090059 357.554555 
+L 283.038944 355.73397 
+L 281.98763 353.913039 
+L 280.936119 352.09177 
+L 279.884415 350.270166 
+L 278.832522 348.448233 
+L 277.780442 346.625977 
+L 276.728179 344.803404 
+L 275.675736 342.980519 
+L 274.623116 341.157328 
+L 273.570322 339.333835 
+L 272.517358 337.510048 
+L 271.464227 335.685971 
+L 270.410931 333.861609 
+L 269.357475 332.036969 
+L 268.303861 330.212057 
+L 267.250092 328.386876 
+L 266.196173 326.561434 
+L 265.142105 324.735735 
+L 264.087893 322.909785 
+L 263.033538 321.083591 
+L 261.979046 319.257156 
+L 260.924418 317.430488 
+L 259.869659 315.603591 
+L 258.814771 313.77647 
+L 257.759757 311.949133 
+L 256.704621 310.121584 
+L 255.649366 308.293828 
+L 254.593995 306.465872 
+L 253.538511 304.63772 
+L 252.482918 302.809379 
+L 251.427218 300.980854 
+L 250.371416 299.152151 
+L 249.315514 297.323274 
+L 248.259515 295.494231 
+L 247.203422 293.665025 
+L 246.14724 291.835664 
+L 245.090971 290.006152 
+L 244.034618 288.176495 
+L 242.978184 286.346698 
+L 241.921674 284.516768 
+L 240.865089 282.686709 
+L 239.808433 280.856528 
+L 238.75171 279.026229 
+L 237.694922 277.195819 
+L 236.638073 275.365303 
+L 235.581166 273.534687 
+L 234.524204 271.703976 
+L 233.467191 269.873175 
+L 232.41013 268.042291 
+L 231.353023 266.211329 
+L 230.295875 264.380294 
+L 229.238688 262.549192 
+L 228.181465 260.718029 
+L 227.12421 258.88681 
+L 226.066927 257.055541 
+L 225.009617 255.224227 
+L 223.952285 253.392874 
+L 222.894934 251.561488 
+L 221.837566 249.730074 
+L 220.780186 247.898638 
+L 219.722796 246.067184 
+L 218.6654 244.23572 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_147">
+    <path d="M 435.78128 368.366652 
+L 433.989499 367.332167 
+L 432.19706 366.297302 
+L 430.403967 365.262059 
+L 428.610226 364.226442 
+L 426.815842 363.190454 
+L 425.02082 362.154098 
+L 423.225167 361.117377 
+L 421.428888 360.080295 
+L 419.631988 359.042854 
+L 417.834472 358.005057 
+L 416.036346 356.966909 
+L 414.237616 355.928412 
+L 412.438287 354.889569 
+L 410.638365 353.850383 
+L 408.837854 352.810858 
+L 407.036761 351.770996 
+L 405.235091 350.730801 
+L 403.432849 349.690277 
+L 401.630041 348.649425 
+L 399.826673 347.60825 
+L 398.02275 346.566754 
+L 396.218277 345.524941 
+L 394.41326 344.482814 
+L 392.607704 343.440376 
+L 390.801616 342.397631 
+L 388.994999 341.35458 
+L 387.187861 340.311228 
+L 385.380206 339.267578 
+L 383.57204 338.223633 
+L 381.763369 337.179396 
+L 379.954197 336.134871 
+L 378.144531 335.09006 
+L 376.334376 334.044966 
+L 374.523738 332.999593 
+L 372.712621 331.953945 
+L 370.901032 330.908023 
+L 369.088976 329.861832 
+L 367.276458 328.815375 
+L 365.463485 327.768654 
+L 363.650061 326.721673 
+L 361.836193 325.674436 
+L 360.021885 324.626945 
+L 358.207143 323.579203 
+L 356.391973 322.531214 
+L 354.57638 321.482981 
+L 352.76037 320.434507 
+L 350.943948 319.385795 
+L 349.12712 318.336849 
+L 347.309891 317.287672 
+L 345.492268 316.238266 
+L 343.674255 315.188636 
+L 341.855857 314.138784 
+L 340.037082 313.088713 
+L 338.217933 312.038427 
+L 336.398417 310.987929 
+L 334.578539 309.937222 
+L 332.758305 308.886309 
+L 330.93772 307.835194 
+L 329.116789 306.78388 
+L 327.29552 305.732369 
+L 325.473916 304.680665 
+L 323.651983 303.628772 
+L 321.829727 302.576692 
+L 320.007154 301.524429 
+L 318.184269 300.471986 
+L 316.361078 299.419366 
+L 314.537585 298.366572 
+L 312.713798 297.313608 
+L 310.889721 296.260477 
+L 309.065359 295.207181 
+L 307.240719 294.153725 
+L 305.415807 293.100111 
+L 303.590626 292.046342 
+L 301.765184 290.992423 
+L 299.939485 289.938355 
+L 298.113535 288.884143 
+L 296.287341 287.829788 
+L 294.460906 286.775296 
+L 292.634238 285.720668 
+L 290.807341 284.665909 
+L 288.98022 283.611021 
+L 287.152883 282.556007 
+L 285.325334 281.500871 
+L 283.497578 280.445616 
+L 281.669622 279.390245 
+L 279.84147 278.334761 
+L 278.013129 277.279168 
+L 276.184604 276.223468 
+L 274.355901 275.167666 
+L 272.527024 274.111764 
+L 270.697981 273.055765 
+L 268.868775 271.999672 
+L 267.039414 270.94349 
+L 265.209902 269.887221 
+L 263.380245 268.830868 
+L 261.550448 267.774434 
+L 259.720518 266.717924 
+L 257.890459 265.661339 
+L 256.060278 264.604683 
+L 254.229979 263.54796 
+L 252.399569 262.491172 
+L 250.569053 261.434323 
+L 248.738437 260.377416 
+L 246.907726 259.320454 
+L 245.076925 258.263441 
+L 243.246041 257.20638 
+L 241.415079 256.149273 
+L 239.584044 255.092125 
+L 237.752942 254.034938 
+L 235.921779 252.977715 
+L 234.09056 251.92046 
+L 232.259291 250.863177 
+L 230.427977 249.805867 
+L 228.596624 248.748535 
+L 226.765238 247.691184 
+L 224.933824 246.633816 
+L 223.102388 245.576436 
+L 221.270934 244.519046 
+L 219.43947 243.46165 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_148">
+    <path d="M 436.216 242.40425 
+L 434.261103 242.40425 
+L 432.180053 242.40425 
+L 430.09835 242.40425 
+L 428.016 242.40425 
+L 425.933009 242.40425 
+L 423.849383 242.40425 
+L 421.765129 242.40425 
+L 419.680253 242.40425 
+L 417.594761 242.40425 
+L 415.508661 242.40425 
+L 413.421957 242.40425 
+L 411.334657 242.40425 
+L 409.246767 242.40425 
+L 407.158293 242.40425 
+L 405.069241 242.40425 
+L 402.979619 242.40425 
+L 400.889432 242.40425 
+L 398.798687 242.40425 
+L 396.707389 242.40425 
+L 394.615546 242.40425 
+L 392.523164 242.40425 
+L 390.430249 242.40425 
+L 388.336808 242.40425 
+L 386.242847 242.40425 
+L 384.148372 242.40425 
+L 382.053389 242.40425 
+L 379.957906 242.40425 
+L 377.861928 242.40425 
+L 375.765462 242.40425 
+L 373.668514 242.40425 
+L 371.571091 242.40425 
+L 369.473199 242.40425 
+L 367.374844 242.40425 
+L 365.276033 242.40425 
+L 363.176772 242.40425 
+L 361.077068 242.40425 
+L 358.976926 242.40425 
+L 356.876354 242.40425 
+L 354.775358 242.40425 
+L 352.673944 242.40425 
+L 350.572119 242.40425 
+L 348.469888 242.40425 
+L 346.367259 242.40425 
+L 344.264238 242.40425 
+L 342.160831 242.40425 
+L 340.057044 242.40425 
+L 337.952885 242.40425 
+L 335.848358 242.40425 
+L 333.743472 242.40425 
+L 331.638232 242.40425 
+L 329.532645 242.40425 
+L 327.426716 242.40425 
+L 325.320453 242.40425 
+L 323.213862 242.40425 
+L 321.106949 242.40425 
+L 318.999721 242.40425 
+L 316.892185 242.40425 
+L 314.784345 242.40425 
+L 312.67621 242.40425 
+L 310.567785 242.40425 
+L 308.459077 242.40425 
+L 306.350092 242.40425 
+L 304.240837 242.40425 
+L 302.131318 242.40425 
+L 300.021541 242.40425 
+L 297.911514 242.40425 
+L 295.801242 242.40425 
+L 293.690731 242.40425 
+L 291.579989 242.40425 
+L 289.469022 242.40425 
+L 287.357835 242.40425 
+L 285.246436 242.40425 
+L 283.134832 242.40425 
+L 281.023027 242.40425 
+L 278.911029 242.40425 
+L 276.798845 242.40425 
+L 274.68648 242.40425 
+L 272.573942 242.40425 
+L 270.461236 242.40425 
+L 268.348369 242.40425 
+L 266.235347 242.40425 
+L 264.122177 242.40425 
+L 262.008866 242.40425 
+L 259.895419 242.40425 
+L 257.781844 242.40425 
+L 255.668146 242.40425 
+L 253.554332 242.40425 
+L 251.440409 242.40425 
+L 249.326383 242.40425 
+L 247.21226 242.40425 
+L 245.098047 242.40425 
+L 242.98375 242.40425 
+L 240.869375 242.40425 
+L 238.75493 242.40425 
+L 236.640421 242.40425 
+L 234.525854 242.40425 
+L 232.411235 242.40425 
+L 230.296571 242.40425 
+L 228.181868 242.40425 
+L 226.067133 242.40425 
+L 223.952372 242.40425 
+L 221.837592 242.40425 
+L 219.722799 242.40425 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_149">
+    <path d="M 435.78128 116.441848 
+L 433.989499 117.476333 
+L 432.19706 118.511198 
+L 430.403967 119.546441 
+L 428.610226 120.582058 
+L 426.815842 121.618046 
+L 425.02082 122.654402 
+L 423.225167 123.691123 
+L 421.428888 124.728205 
+L 419.631988 125.765646 
+L 417.834472 126.803443 
+L 416.036346 127.841591 
+L 414.237616 128.880088 
+L 412.438287 129.918931 
+L 410.638365 130.958117 
+L 408.837854 131.997642 
+L 407.036761 133.037504 
+L 405.235091 134.077699 
+L 403.432849 135.118223 
+L 401.630041 136.159075 
+L 399.826673 137.20025 
+L 398.02275 138.241746 
+L 396.218277 139.283559 
+L 394.41326 140.325686 
+L 392.607704 141.368124 
+L 390.801616 142.410869 
+L 388.994999 143.45392 
+L 387.187861 144.497272 
+L 385.380206 145.540922 
+L 383.57204 146.584867 
+L 381.763369 147.629104 
+L 379.954197 148.673629 
+L 378.144531 149.71844 
+L 376.334376 150.763534 
+L 374.523738 151.808907 
+L 372.712621 152.854555 
+L 370.901032 153.900477 
+L 369.088976 154.946668 
+L 367.276458 155.993125 
+L 365.463485 157.039846 
+L 363.650061 158.086827 
+L 361.836193 159.134064 
+L 360.021885 160.181555 
+L 358.207143 161.229297 
+L 356.391973 162.277286 
+L 354.57638 163.325519 
+L 352.76037 164.373993 
+L 350.943948 165.422705 
+L 349.12712 166.471651 
+L 347.309891 167.520828 
+L 345.492268 168.570234 
+L 343.674255 169.619864 
+L 341.855857 170.669716 
+L 340.037082 171.719787 
+L 338.217933 172.770073 
+L 336.398417 173.820571 
+L 334.578539 174.871278 
+L 332.758305 175.922191 
+L 330.93772 176.973306 
+L 329.116789 178.02462 
+L 327.29552 179.076131 
+L 325.473916 180.127835 
+L 323.651983 181.179728 
+L 321.829727 182.231808 
+L 320.007154 183.284071 
+L 318.184269 184.336514 
+L 316.361078 185.389134 
+L 314.537585 186.441928 
+L 312.713798 187.494892 
+L 310.889721 188.548023 
+L 309.065359 189.601319 
+L 307.240719 190.654775 
+L 305.415807 191.708389 
+L 303.590626 192.762158 
+L 301.765184 193.816077 
+L 299.939485 194.870145 
+L 298.113535 195.924357 
+L 296.287341 196.978712 
+L 294.460906 198.033204 
+L 292.634238 199.087832 
+L 290.807341 200.142591 
+L 288.98022 201.197479 
+L 287.152883 202.252493 
+L 285.325334 203.307629 
+L 283.497578 204.362884 
+L 281.669622 205.418255 
+L 279.84147 206.473739 
+L 278.013129 207.529332 
+L 276.184604 208.585032 
+L 274.355901 209.640834 
+L 272.527024 210.696736 
+L 270.697981 211.752735 
+L 268.868775 212.808828 
+L 267.039414 213.86501 
+L 265.209902 214.921279 
+L 263.380245 215.977632 
+L 261.550448 217.034066 
+L 259.720518 218.090576 
+L 257.890459 219.147161 
+L 256.060278 220.203817 
+L 254.229979 221.26054 
+L 252.399569 222.317328 
+L 250.569053 223.374177 
+L 248.738437 224.431084 
+L 246.907726 225.488046 
+L 245.076925 226.545059 
+L 243.246041 227.60212 
+L 241.415079 228.659227 
+L 239.584044 229.716375 
+L 237.752942 230.773562 
+L 235.921779 231.830785 
+L 234.09056 232.88804 
+L 232.259291 233.945323 
+L 230.427977 235.002633 
+L 228.596624 236.059965 
+L 226.765238 237.117316 
+L 224.933824 238.174684 
+L 223.102388 239.232064 
+L 221.270934 240.289454 
+L 219.43947 241.34685 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_150">
+    <path d="M 343.570402 24.23097 
+L 342.535917 26.022751 
+L 341.501052 27.81519 
+L 340.465809 29.608283 
+L 339.430192 31.402024 
+L 338.394204 33.196408 
+L 337.357848 34.99143 
+L 336.321127 36.787083 
+L 335.284045 38.583362 
+L 334.246604 40.380262 
+L 333.208807 42.177778 
+L 332.170659 43.975904 
+L 331.132162 45.774634 
+L 330.093319 47.573963 
+L 329.054133 49.373885 
+L 328.014608 51.174396 
+L 326.974746 52.975489 
+L 325.934551 54.777159 
+L 324.894027 56.579401 
+L 323.853175 58.382209 
+L 322.812 60.185577 
+L 321.770504 61.9895 
+L 320.728691 63.793973 
+L 319.686564 65.59899 
+L 318.644126 67.404546 
+L 317.601381 69.210634 
+L 316.55833 71.017251 
+L 315.514978 72.824389 
+L 314.471328 74.632044 
+L 313.427383 76.44021 
+L 312.383146 78.248881 
+L 311.338621 80.058053 
+L 310.29381 81.867719 
+L 309.248716 83.677874 
+L 308.203343 85.488512 
+L 307.157695 87.299629 
+L 306.111773 89.111218 
+L 305.065582 90.923274 
+L 304.019125 92.735792 
+L 302.972404 94.548765 
+L 301.925423 96.362189 
+L 300.878186 98.176057 
+L 299.830695 99.990365 
+L 298.782953 101.805107 
+L 297.734964 103.620277 
+L 296.686731 105.43587 
+L 295.638257 107.25188 
+L 294.589545 109.068302 
+L 293.540599 110.88513 
+L 292.491422 112.702359 
+L 291.442016 114.519982 
+L 290.392386 116.337995 
+L 289.342534 118.156393 
+L 288.292463 119.975168 
+L 287.242177 121.794317 
+L 286.191679 123.613833 
+L 285.140972 125.433711 
+L 284.090059 127.253945 
+L 283.038944 129.07453 
+L 281.98763 130.895461 
+L 280.936119 132.71673 
+L 279.884415 134.538334 
+L 278.832522 136.360267 
+L 277.780442 138.182523 
+L 276.728179 140.005096 
+L 275.675736 141.827981 
+L 274.623116 143.651172 
+L 273.570322 145.474665 
+L 272.517358 147.298452 
+L 271.464227 149.122529 
+L 270.410931 150.946891 
+L 269.357475 152.771531 
+L 268.303861 154.596443 
+L 267.250092 156.421624 
+L 266.196173 158.247066 
+L 265.142105 160.072765 
+L 264.087893 161.898715 
+L 263.033538 163.724909 
+L 261.979046 165.551344 
+L 260.924418 167.378012 
+L 259.869659 169.204909 
+L 258.814771 171.03203 
+L 257.759757 172.859367 
+L 256.704621 174.686916 
+L 255.649366 176.514672 
+L 254.593995 178.342628 
+L 253.538511 180.17078 
+L 252.482918 181.999121 
+L 251.427218 183.827646 
+L 250.371416 185.656349 
+L 249.315514 187.485226 
+L 248.259515 189.314269 
+L 247.203422 191.143475 
+L 246.14724 192.972836 
+L 245.090971 194.802348 
+L 244.034618 196.632005 
+L 242.978184 198.461802 
+L 241.921674 200.291732 
+L 240.865089 202.121791 
+L 239.808433 203.951972 
+L 238.75171 205.782271 
+L 237.694922 207.612681 
+L 236.638073 209.443197 
+L 235.581166 211.273813 
+L 234.524204 213.104524 
+L 233.467191 214.935325 
+L 232.41013 216.766209 
+L 231.353023 218.597171 
+L 230.295875 220.428206 
+L 229.238688 222.259308 
+L 228.181465 224.090471 
+L 227.12421 225.92169 
+L 226.066927 227.752959 
+L 225.009617 229.584273 
+L 223.952285 231.415626 
+L 222.894934 233.247012 
+L 221.837566 235.078426 
+L 220.780186 236.909862 
+L 219.722796 238.741316 
+L 218.6654 240.57278 
+L 217.608 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #cccccc; stroke-width: 0.4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_151">
+    <path d="M 302.673659 242.40425 
+L 303.945424 241.399623 
+L 305.205772 240.395164 
+L 306.455194 239.390991 
+L 307.694155 238.387208 
+L 308.923095 237.383907 
+L 310.142428 236.381169 
+L 311.352551 235.379067 
+L 312.553836 234.377663 
+L 313.746637 233.377011 
+L 314.931291 232.377161 
+L 316.108116 231.378153 
+L 317.277415 230.380023 
+L 318.439476 229.382803 
+L 319.594572 228.386518 
+L 320.742964 227.391191 
+L 321.8849 226.39684 
+L 323.020614 225.403481 
+L 324.150332 224.411125 
+L 325.274268 223.419782 
+L 325.444113 224.409585 
+L 325.604859 225.400907 
+L 325.756492 226.393664 
+L 325.899 227.387771 
+L 326.032369 228.383146 
+L 326.15659 229.379703 
+L 326.271651 230.37736 
+L 326.377544 231.376031 
+L 326.474258 232.375634 
+L 326.561786 233.376082 
+L 326.64012 234.377292 
+L 326.709254 235.37918 
+L 326.769182 236.38166 
+L 326.819899 237.384648 
+L 326.8614 238.38806 
+L 326.893683 239.391811 
+L 326.916744 240.395816 
+L 326.930581 241.399991 
+L 326.935194 242.40425 
+L 326.930581 243.408509 
+L 326.916744 244.412684 
+L 326.893683 245.416689 
+L 326.8614 246.42044 
+L 326.819899 247.423852 
+L 326.769182 248.42684 
+L 326.709254 249.42932 
+L 326.64012 250.431208 
+L 326.561786 251.432418 
+L 326.474258 252.432866 
+L 326.377544 253.432469 
+L 326.271651 254.43114 
+L 326.15659 255.428797 
+L 326.032369 256.425354 
+L 325.899 257.420729 
+L 325.756492 258.414836 
+L 325.604859 259.407593 
+L 325.444113 260.398915 
+L 325.274268 261.388718 
+L 324.150332 260.397375 
+L 323.020614 259.405019 
+L 321.8849 258.41166 
+L 320.742964 257.417309 
+L 319.594572 256.421982 
+L 318.439476 255.425697 
+L 317.277415 254.428477 
+L 316.108116 253.430347 
+L 314.931291 252.431339 
+L 313.746637 251.431489 
+L 312.553836 250.430837 
+L 311.352551 249.429433 
+L 310.142428 248.427331 
+L 308.923095 247.424593 
+L 307.694155 246.421292 
+L 306.455194 245.417509 
+L 305.205772 244.413336 
+L 303.945424 243.408877 
+L 302.673659 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_152">
+    <path d="M 300.540885 261.33314 
+L 300.758655 260.352364 
+L 300.964827 259.369084 
+L 301.159372 258.383438 
+L 301.342263 257.395563 
+L 301.513474 256.405597 
+L 301.672981 255.413678 
+L 301.820762 254.419945 
+L 301.956797 253.424535 
+L 302.081066 252.427588 
+L 302.193553 251.429243 
+L 302.294241 250.42964 
+L 302.383116 249.428916 
+L 302.460167 248.427213 
+L 302.525381 247.42467 
+L 302.578751 246.421427 
+L 302.620269 245.417623 
+L 302.649928 244.413399 
+L 302.667726 243.408894 
+L 302.673659 242.40425 
+L 303.945424 243.408877 
+L 305.205772 244.413336 
+L 306.455194 245.417509 
+L 307.694155 246.421292 
+L 308.923095 247.424593 
+L 310.142428 248.427331 
+L 311.352551 249.429433 
+L 312.553836 250.430837 
+L 313.746637 251.431489 
+L 314.931291 252.431339 
+L 316.108116 253.430347 
+L 317.277415 254.428477 
+L 318.439476 255.425697 
+L 319.594572 256.421982 
+L 320.742964 257.417309 
+L 321.8849 258.41166 
+L 323.020614 259.405019 
+L 324.150332 260.397375 
+L 325.274268 261.388718 
+L 325.095337 262.376919 
+L 324.907337 263.363435 
+L 324.710283 264.348183 
+L 324.504192 265.331079 
+L 324.28908 266.31204 
+L 324.064967 267.290984 
+L 323.83187 268.267828 
+L 323.58981 269.242489 
+L 323.338808 270.214886 
+L 323.078884 271.184936 
+L 322.81006 272.152558 
+L 322.532359 273.11767 
+L 322.245804 274.080189 
+L 321.95042 275.040037 
+L 321.646232 275.99713 
+L 321.333264 276.951388 
+L 321.011545 277.902732 
+L 320.6811 278.85108 
+L 320.341957 279.796352 
+L 319.332211 278.835088 
+L 318.319614 277.872774 
+L 317.304059 276.909391 
+L 316.285435 275.94492 
+L 315.263626 274.979338 
+L 314.238509 274.012625 
+L 313.209953 273.04476 
+L 312.177822 272.075723 
+L 311.141973 271.105492 
+L 310.102254 270.134047 
+L 309.058504 269.161366 
+L 308.010554 268.18743 
+L 306.958225 267.212218 
+L 305.901328 266.235711 
+L 304.839663 265.257891 
+L 303.773018 264.278739 
+L 302.701168 263.29824 
+L 301.623875 262.316378 
+L 300.540885 261.33314 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_153">
+    <path d="M 294.24951 279.312856 
+L 294.680064 278.405128 
+L 295.099867 277.492379 
+L 295.508861 276.574736 
+L 295.906989 275.652326 
+L 296.294196 274.725279 
+L 296.670426 273.793723 
+L 297.035629 272.857789 
+L 297.389753 271.917607 
+L 297.732748 270.973308 
+L 298.064567 270.025024 
+L 298.385163 269.072888 
+L 298.694492 268.117031 
+L 298.99251 267.157588 
+L 299.279177 266.194693 
+L 299.554451 265.228479 
+L 299.818295 264.259081 
+L 300.070672 263.286635 
+L 300.311546 262.311276 
+L 300.540885 261.33314 
+L 301.623875 262.316378 
+L 302.701168 263.29824 
+L 303.773018 264.278739 
+L 304.839663 265.257891 
+L 305.901328 266.235711 
+L 306.958225 267.212218 
+L 308.010554 268.18743 
+L 309.058504 269.161366 
+L 310.102254 270.134047 
+L 311.141973 271.105492 
+L 312.177822 272.075723 
+L 313.209953 273.04476 
+L 314.238509 274.012625 
+L 315.263626 274.979338 
+L 316.285435 275.94492 
+L 317.304059 276.909391 
+L 318.319614 277.872774 
+L 319.332211 278.835088 
+L 320.341957 279.796352 
+L 319.994146 280.73847 
+L 319.637695 281.677353 
+L 319.272635 282.612921 
+L 318.898996 283.545098 
+L 318.51681 284.473802 
+L 318.12611 285.398957 
+L 317.726928 286.320483 
+L 317.319297 287.238304 
+L 316.903253 288.152342 
+L 316.47883 289.06252 
+L 316.046065 289.96876 
+L 315.604993 290.870988 
+L 315.155652 291.769125 
+L 314.69808 292.663097 
+L 314.232315 293.552828 
+L 313.758397 294.438243 
+L 313.276366 295.319267 
+L 312.786262 296.195826 
+L 312.288127 297.067847 
+L 311.349854 296.139581 
+L 310.410591 295.210731 
+L 309.470304 294.281279 
+L 308.528955 293.35121 
+L 307.586507 292.420507 
+L 306.642919 291.489153 
+L 305.69815 290.55713 
+L 304.752153 289.624418 
+L 303.804882 288.690998 
+L 302.856286 287.756849 
+L 301.906314 286.82195 
+L 300.954909 285.886279 
+L 300.002012 284.949812 
+L 299.04756 284.012524 
+L 298.091487 283.074391 
+L 297.133722 282.135386 
+L 296.174192 281.195481 
+L 295.212816 280.254648 
+L 294.24951 279.312856 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_154">
+    <path d="M 302.673659 242.40425 
+L 302.667726 241.399606 
+L 302.649928 240.395101 
+L 302.620269 239.390877 
+L 302.578751 238.387073 
+L 302.525381 237.38383 
+L 302.460167 236.381287 
+L 302.383116 235.379584 
+L 302.294241 234.37886 
+L 302.193553 233.379257 
+L 302.081066 232.380912 
+L 301.956797 231.383965 
+L 301.820762 230.388555 
+L 301.672981 229.394822 
+L 301.513474 228.402903 
+L 301.342263 227.412937 
+L 301.159372 226.425062 
+L 300.964827 225.439416 
+L 300.758655 224.456136 
+L 300.540885 223.47536 
+L 301.623875 222.492122 
+L 302.701168 221.51026 
+L 303.773018 220.529761 
+L 304.839663 219.550609 
+L 305.901328 218.572789 
+L 306.958225 217.596282 
+L 308.010554 216.62107 
+L 309.058504 215.647134 
+L 310.102254 214.674453 
+L 311.141973 213.703008 
+L 312.177822 212.732777 
+L 313.209953 211.76374 
+L 314.238509 210.795875 
+L 315.263626 209.829162 
+L 316.285435 208.86358 
+L 317.304059 207.899109 
+L 318.319614 206.935726 
+L 319.332211 205.973412 
+L 320.341957 205.012148 
+L 320.6811 205.95742 
+L 321.011545 206.905768 
+L 321.333264 207.857112 
+L 321.646232 208.81137 
+L 321.95042 209.768463 
+L 322.245804 210.728311 
+L 322.532359 211.69083 
+L 322.81006 212.655942 
+L 323.078884 213.623564 
+L 323.338808 214.593614 
+L 323.58981 215.566011 
+L 323.83187 216.540672 
+L 324.064967 217.517516 
+L 324.28908 218.49646 
+L 324.504192 219.477421 
+L 324.710283 220.460317 
+L 324.907337 221.445065 
+L 325.095337 222.431581 
+L 325.274268 223.419782 
+L 324.150332 224.411125 
+L 323.020614 225.403481 
+L 321.8849 226.39684 
+L 320.742964 227.391191 
+L 319.594572 228.386518 
+L 318.439476 229.382803 
+L 317.277415 230.380023 
+L 316.108116 231.378153 
+L 314.931291 232.377161 
+L 313.746637 233.377011 
+L 312.553836 234.377663 
+L 311.352551 235.379067 
+L 310.142428 236.381169 
+L 308.923095 237.383907 
+L 307.694155 238.387208 
+L 306.455194 239.390991 
+L 305.205772 240.395164 
+L 303.945424 241.399623 
+L 302.673659 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_155">
+    <path d="M 278.387068 242.40425 
+L 279.657681 241.399343 
+L 280.91263 240.394713 
+L 282.152848 239.390573 
+L 283.379196 238.387105 
+L 284.592475 237.384458 
+L 285.793425 236.382758 
+L 286.982734 235.382111 
+L 288.161041 234.382602 
+L 289.328941 233.384301 
+L 290.486987 232.387264 
+L 291.635696 231.391535 
+L 292.775548 230.397149 
+L 293.906994 229.404131 
+L 295.030453 228.412499 
+L 296.146319 227.422264 
+L 297.254961 226.433434 
+L 298.356723 225.446009 
+L 299.451929 224.459986 
+L 300.540885 223.47536 
+L 300.758655 224.456136 
+L 300.964827 225.439416 
+L 301.159372 226.425062 
+L 301.342263 227.412937 
+L 301.513474 228.402903 
+L 301.672981 229.394822 
+L 301.820762 230.388555 
+L 301.956797 231.383965 
+L 302.081066 232.380912 
+L 302.193553 233.379257 
+L 302.294241 234.37886 
+L 302.383116 235.379584 
+L 302.460167 236.381287 
+L 302.525381 237.38383 
+L 302.578751 238.387073 
+L 302.620269 239.390877 
+L 302.649928 240.395101 
+L 302.667726 241.399606 
+L 302.673659 242.40425 
+L 302.667726 243.408894 
+L 302.649928 244.413399 
+L 302.620269 245.417623 
+L 302.578751 246.421427 
+L 302.525381 247.42467 
+L 302.460167 248.427213 
+L 302.383116 249.428916 
+L 302.294241 250.42964 
+L 302.193553 251.429243 
+L 302.081066 252.427588 
+L 301.956797 253.424535 
+L 301.820762 254.419945 
+L 301.672981 255.413678 
+L 301.513474 256.405597 
+L 301.342263 257.395563 
+L 301.159372 258.383438 
+L 300.964827 259.369084 
+L 300.758655 260.352364 
+L 300.540885 261.33314 
+L 299.451929 260.348514 
+L 298.356723 259.362491 
+L 297.254961 258.375066 
+L 296.146319 257.386236 
+L 295.030453 256.396001 
+L 293.906994 255.404369 
+L 292.775548 254.411351 
+L 291.635696 253.416965 
+L 290.486987 252.421236 
+L 289.328941 251.424199 
+L 288.161041 250.425898 
+L 286.982734 249.426389 
+L 285.793425 248.425742 
+L 284.592475 247.424042 
+L 283.379196 246.421395 
+L 282.152848 245.417927 
+L 280.91263 244.413787 
+L 279.657681 243.409157 
+L 278.387068 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_156">
+    <path d="M 275.412329 261.186015 
+L 275.714964 260.227714 
+L 276.001713 259.26454 
+L 276.272498 258.296757 
+L 276.527245 257.324629 
+L 276.765883 256.348422 
+L 276.988349 255.368403 
+L 277.194581 254.384839 
+L 277.384522 253.398 
+L 277.558121 252.408156 
+L 277.71533 251.415576 
+L 277.856106 250.420533 
+L 277.980411 249.423299 
+L 278.088211 248.424145 
+L 278.179477 247.423346 
+L 278.254182 246.421174 
+L 278.312308 245.417904 
+L 278.353837 244.413811 
+L 278.37876 243.409168 
+L 278.387068 242.40425 
+L 279.657681 243.409157 
+L 280.91263 244.413787 
+L 282.152848 245.417927 
+L 283.379196 246.421395 
+L 284.592475 247.424042 
+L 285.793425 248.425742 
+L 286.982734 249.426389 
+L 288.161041 250.425898 
+L 289.328941 251.424199 
+L 290.486987 252.421236 
+L 291.635696 253.416965 
+L 292.775548 254.411351 
+L 293.906994 255.404369 
+L 295.030453 256.396001 
+L 296.146319 257.386236 
+L 297.254961 258.375066 
+L 298.356723 259.362491 
+L 299.451929 260.348514 
+L 300.540885 261.33314 
+L 300.311546 262.311276 
+L 300.070672 263.286635 
+L 299.818295 264.259081 
+L 299.554451 265.228479 
+L 299.279177 266.194693 
+L 298.99251 267.157588 
+L 298.694492 268.117031 
+L 298.385163 269.072888 
+L 298.064567 270.025024 
+L 297.732748 270.973308 
+L 297.389753 271.917607 
+L 297.035629 272.857789 
+L 296.670426 273.793723 
+L 296.294196 274.725279 
+L 295.906989 275.652326 
+L 295.508861 276.574736 
+L 295.099867 277.492379 
+L 294.680064 278.405128 
+L 294.24951 279.312856 
+L 293.284184 278.370074 
+L 292.316743 277.42627 
+L 291.347084 276.481409 
+L 290.375098 275.535456 
+L 289.40067 274.588374 
+L 288.423674 273.640124 
+L 287.443978 272.690666 
+L 286.461438 271.739958 
+L 285.475901 270.787957 
+L 284.487203 269.834617 
+L 283.495168 268.879892 
+L 282.499604 267.923732 
+L 281.500306 266.966087 
+L 280.497052 266.006906 
+L 279.489603 265.046134 
+L 278.4777 264.083716 
+L 277.461061 263.119596 
+L 276.439381 262.153715 
+L 275.412329 261.186015 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_157">
+    <path d="M 300.540885 223.47536 
+L 300.311546 222.497224 
+L 300.070672 221.521865 
+L 299.818295 220.549419 
+L 299.554451 219.580021 
+L 299.279177 218.613807 
+L 298.99251 217.650912 
+L 298.694492 216.691469 
+L 298.385163 215.735612 
+L 298.064567 214.783476 
+L 297.732748 213.835192 
+L 297.389753 212.890893 
+L 297.035629 211.950711 
+L 296.670426 211.014777 
+L 296.294196 210.083221 
+L 295.906989 209.156174 
+L 295.508861 208.233764 
+L 295.099867 207.316121 
+L 294.680064 206.403372 
+L 294.24951 205.495644 
+L 295.212816 204.553852 
+L 296.174192 203.613019 
+L 297.133722 202.673114 
+L 298.091487 201.734109 
+L 299.04756 200.795976 
+L 300.002012 199.858688 
+L 300.954909 198.922221 
+L 301.906314 197.98655 
+L 302.856286 197.051651 
+L 303.804882 196.117502 
+L 304.752153 195.184082 
+L 305.69815 194.25137 
+L 306.642919 193.319347 
+L 307.586507 192.387993 
+L 308.528955 191.45729 
+L 309.470304 190.527221 
+L 310.410591 189.597769 
+L 311.349854 188.668919 
+L 312.288127 187.740653 
+L 312.786262 188.612674 
+L 313.276366 189.489233 
+L 313.758397 190.370257 
+L 314.232315 191.255672 
+L 314.69808 192.145403 
+L 315.155652 193.039375 
+L 315.604993 193.937512 
+L 316.046065 194.83974 
+L 316.47883 195.74598 
+L 316.903253 196.656158 
+L 317.319297 197.570196 
+L 317.726928 198.488017 
+L 318.12611 199.409543 
+L 318.51681 200.334698 
+L 318.898996 201.263402 
+L 319.272635 202.195579 
+L 319.637695 203.131147 
+L 319.994146 204.07003 
+L 320.341957 205.012148 
+L 319.332211 205.973412 
+L 318.319614 206.935726 
+L 317.304059 207.899109 
+L 316.285435 208.86358 
+L 315.263626 209.829162 
+L 314.238509 210.795875 
+L 313.209953 211.76374 
+L 312.177822 212.732777 
+L 311.141973 213.703008 
+L 310.102254 214.674453 
+L 309.058504 215.647134 
+L 308.010554 216.62107 
+L 306.958225 217.596282 
+L 305.901328 218.572789 
+L 304.839663 219.550609 
+L 303.773018 220.529761 
+L 302.701168 221.51026 
+L 301.623875 222.492122 
+L 300.540885 223.47536 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_158">
+    <path d="M 278.387068 242.40425 
+L 278.37876 241.399332 
+L 278.353837 240.394689 
+L 278.312308 239.390596 
+L 278.254182 238.387326 
+L 278.179477 237.385154 
+L 278.088211 236.384355 
+L 277.980411 235.385201 
+L 277.856106 234.387967 
+L 277.71533 233.392924 
+L 277.558121 232.400344 
+L 277.384522 231.4105 
+L 277.194581 230.423661 
+L 276.988349 229.440097 
+L 276.765883 228.460078 
+L 276.527245 227.483871 
+L 276.272498 226.511743 
+L 276.001713 225.54396 
+L 275.714964 224.580786 
+L 275.412329 223.622485 
+L 276.439381 222.654785 
+L 277.461061 221.688904 
+L 278.4777 220.724784 
+L 279.489603 219.762366 
+L 280.497052 218.801594 
+L 281.500306 217.842413 
+L 282.499604 216.884768 
+L 283.495168 215.928608 
+L 284.487203 214.973883 
+L 285.475901 214.020543 
+L 286.461438 213.068542 
+L 287.443978 212.117834 
+L 288.423674 211.168376 
+L 289.40067 210.220126 
+L 290.375098 209.273044 
+L 291.347084 208.327091 
+L 292.316743 207.38223 
+L 293.284184 206.438426 
+L 294.24951 205.495644 
+L 294.680064 206.403372 
+L 295.099867 207.316121 
+L 295.508861 208.233764 
+L 295.906989 209.156174 
+L 296.294196 210.083221 
+L 296.670426 211.014777 
+L 297.035629 211.950711 
+L 297.389753 212.890893 
+L 297.732748 213.835192 
+L 298.064567 214.783476 
+L 298.385163 215.735612 
+L 298.694492 216.691469 
+L 298.99251 217.650912 
+L 299.279177 218.613807 
+L 299.554451 219.580021 
+L 299.818295 220.549419 
+L 300.070672 221.521865 
+L 300.311546 222.497224 
+L 300.540885 223.47536 
+L 299.451929 224.459986 
+L 298.356723 225.446009 
+L 297.254961 226.433434 
+L 296.146319 227.422264 
+L 295.030453 228.412499 
+L 293.906994 229.404131 
+L 292.775548 230.397149 
+L 291.635696 231.391535 
+L 290.486987 232.387264 
+L 289.328941 233.384301 
+L 288.161041 234.382602 
+L 286.982734 235.382111 
+L 285.793425 236.382758 
+L 284.592475 237.384458 
+L 283.379196 238.387105 
+L 282.152848 239.390573 
+L 280.91263 240.394713 
+L 279.657681 241.399343 
+L 278.387068 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_159">
+    <path d="M 254.082592 242.40425 
+L 255.348725 241.399216 
+L 256.589832 240.39485 
+L 257.808314 239.391653 
+L 259.006286 238.389999 
+L 260.185617 237.39016 
+L 261.347961 236.392331 
+L 262.494789 235.396644 
+L 263.62741 234.403186 
+L 264.746996 233.412006 
+L 265.854594 232.423125 
+L 266.951146 231.436542 
+L 268.037498 230.452239 
+L 269.114415 229.470187 
+L 270.182589 228.490344 
+L 271.242644 227.512664 
+L 272.295151 226.537095 
+L 273.340626 225.563581 
+L 274.379542 224.592064 
+L 275.412329 223.622485 
+L 275.714964 224.580786 
+L 276.001713 225.54396 
+L 276.272498 226.511743 
+L 276.527245 227.483871 
+L 276.765883 228.460078 
+L 276.988349 229.440097 
+L 277.194581 230.423661 
+L 277.384522 231.4105 
+L 277.558121 232.400344 
+L 277.71533 233.392924 
+L 277.856106 234.387967 
+L 277.980411 235.385201 
+L 278.088211 236.384355 
+L 278.179477 237.385154 
+L 278.254182 238.387326 
+L 278.312308 239.390596 
+L 278.353837 240.394689 
+L 278.37876 241.399332 
+L 278.387068 242.40425 
+L 278.37876 243.409168 
+L 278.353837 244.413811 
+L 278.312308 245.417904 
+L 278.254182 246.421174 
+L 278.179477 247.423346 
+L 278.088211 248.424145 
+L 277.980411 249.423299 
+L 277.856106 250.420533 
+L 277.71533 251.415576 
+L 277.558121 252.408156 
+L 277.384522 253.398 
+L 277.194581 254.384839 
+L 276.988349 255.368403 
+L 276.765883 256.348422 
+L 276.527245 257.324629 
+L 276.272498 258.296757 
+L 276.001713 259.26454 
+L 275.714964 260.227714 
+L 275.412329 261.186015 
+L 274.379542 260.216436 
+L 273.340626 259.244919 
+L 272.295151 258.271405 
+L 271.242644 257.295836 
+L 270.182589 256.318156 
+L 269.114415 255.338313 
+L 268.037498 254.356261 
+L 266.951146 253.371958 
+L 265.854594 252.385375 
+L 264.746996 251.396494 
+L 263.62741 250.405314 
+L 262.494789 249.411856 
+L 261.347961 248.416169 
+L 260.185617 247.41834 
+L 259.006286 246.418501 
+L 257.808314 245.416847 
+L 256.589832 244.41365 
+L 255.348725 243.409284 
+L 254.082592 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_160">
+    <path d="M 284.11501 295.441821 
+L 284.736757 294.652659 
+L 285.349141 293.856209 
+L 285.952075 293.052583 
+L 286.545477 292.241892 
+L 287.129263 291.424249 
+L 287.703351 290.599768 
+L 288.267663 289.768565 
+L 288.822118 288.930755 
+L 289.36664 288.086456 
+L 289.901152 287.235784 
+L 290.42558 286.378859 
+L 290.939852 285.5158 
+L 291.443895 284.646728 
+L 291.937638 283.771763 
+L 292.421014 282.891028 
+L 292.893954 282.004646 
+L 293.356393 281.11274 
+L 293.808266 280.215435 
+L 294.24951 279.312856 
+L 295.212816 280.254648 
+L 296.174192 281.195481 
+L 297.133722 282.135386 
+L 298.091487 283.074391 
+L 299.04756 284.012524 
+L 300.002012 284.949812 
+L 300.954909 285.886279 
+L 301.906314 286.82195 
+L 302.856286 287.756849 
+L 303.804882 288.690998 
+L 304.752153 289.624418 
+L 305.69815 290.55713 
+L 306.642919 291.489153 
+L 307.586507 292.420507 
+L 308.528955 293.35121 
+L 309.470304 294.281279 
+L 310.410591 295.210731 
+L 311.349854 296.139581 
+L 312.288127 297.067847 
+L 311.782003 297.935255 
+L 311.267932 298.797977 
+L 310.745958 299.65594 
+L 310.216125 300.509073 
+L 309.678478 301.357302 
+L 309.133062 302.200557 
+L 308.579922 303.038767 
+L 308.019107 303.871859 
+L 307.450662 304.699766 
+L 306.874637 305.522415 
+L 306.291079 306.339739 
+L 305.700038 307.151668 
+L 305.101563 307.958133 
+L 304.495706 308.759067 
+L 303.882517 309.554402 
+L 303.262048 310.344071 
+L 302.634352 311.128006 
+L 301.999481 311.906143 
+L 301.357489 312.678415 
+L 300.45156 311.772583 
+L 299.545477 310.866613 
+L 298.639236 309.960506 
+L 297.732835 309.054258 
+L 296.826271 308.147868 
+L 295.91954 307.241333 
+L 295.01264 306.33465 
+L 294.105566 305.427817 
+L 293.198315 304.520832 
+L 292.290882 303.613691 
+L 291.383264 302.706392 
+L 290.475456 301.79893 
+L 289.567452 300.891302 
+L 288.659248 299.983504 
+L 287.750838 299.075533 
+L 286.842215 298.167384 
+L 285.933375 297.259052 
+L 285.024309 296.350533 
+L 284.11501 295.441821 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_161">
+    <path d="M 270.645571 308.91126 
+L 271.427334 308.280236 
+L 272.201591 307.640023 
+L 272.968232 306.990711 
+L 273.727152 306.33239 
+L 274.478244 305.665151 
+L 275.221403 304.989089 
+L 275.956526 304.304297 
+L 276.68351 303.610871 
+L 277.402254 302.908907 
+L 278.112657 302.198504 
+L 278.814621 301.47976 
+L 279.508047 300.752776 
+L 280.192839 300.017653 
+L 280.868901 299.274494 
+L 281.53614 298.523402 
+L 282.194461 297.764482 
+L 282.843773 296.997841 
+L 283.483986 296.223584 
+L 284.11501 295.441821 
+L 285.024309 296.350533 
+L 285.933375 297.259052 
+L 286.842215 298.167384 
+L 287.750838 299.075533 
+L 288.659248 299.983504 
+L 289.567452 300.891302 
+L 290.475456 301.79893 
+L 291.383264 302.706392 
+L 292.290882 303.613691 
+L 293.198315 304.520832 
+L 294.105566 305.427817 
+L 295.01264 306.33465 
+L 295.91954 307.241333 
+L 296.826271 308.147868 
+L 297.732835 309.054258 
+L 298.639236 309.960506 
+L 299.545477 310.866613 
+L 300.45156 311.772583 
+L 301.357489 312.678415 
+L 300.70843 313.444758 
+L 300.052359 314.205106 
+L 299.389332 314.959395 
+L 298.719403 315.707562 
+L 298.04263 316.449543 
+L 297.35907 317.185277 
+L 296.668781 317.9147 
+L 295.971821 318.637752 
+L 295.268248 319.354371 
+L 294.558121 320.064498 
+L 293.841502 320.768071 
+L 293.11845 321.465031 
+L 292.389027 322.15532 
+L 291.653293 322.83888 
+L 290.911312 323.515653 
+L 290.163145 324.185582 
+L 289.408856 324.848609 
+L 288.648508 325.50468 
+L 287.882165 326.153739 
+L 286.976333 325.24781 
+L 286.070363 324.341727 
+L 285.164256 323.435486 
+L 284.258008 322.529085 
+L 283.351618 321.622521 
+L 282.445083 320.71579 
+L 281.5384 319.80889 
+L 280.631567 318.901816 
+L 279.724582 317.994565 
+L 278.817441 317.087132 
+L 277.910142 316.179514 
+L 277.00268 315.271706 
+L 276.095052 314.363702 
+L 275.187254 313.455498 
+L 274.279283 312.547088 
+L 273.371134 311.638465 
+L 272.462802 310.729625 
+L 271.554283 309.820559 
+L 270.645571 308.91126 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_162">
+    <path d="M 254.516606 319.04576 
+L 255.419185 318.604516 
+L 256.31649 318.152643 
+L 257.208396 317.690204 
+L 258.094778 317.217264 
+L 258.975513 316.733888 
+L 259.850478 316.240145 
+L 260.71955 315.736102 
+L 261.582609 315.22183 
+L 262.439534 314.697402 
+L 263.290206 314.16289 
+L 264.134505 313.618368 
+L 264.972315 313.063913 
+L 265.803518 312.499601 
+L 266.627999 311.925513 
+L 267.445642 311.341727 
+L 268.256333 310.748325 
+L 269.059959 310.145391 
+L 269.856409 309.533007 
+L 270.645571 308.91126 
+L 271.554283 309.820559 
+L 272.462802 310.729625 
+L 273.371134 311.638465 
+L 274.279283 312.547088 
+L 275.187254 313.455498 
+L 276.095052 314.363702 
+L 277.00268 315.271706 
+L 277.910142 316.179514 
+L 278.817441 317.087132 
+L 279.724582 317.994565 
+L 280.631567 318.901816 
+L 281.5384 319.80889 
+L 282.445083 320.71579 
+L 283.351618 321.622521 
+L 284.258008 322.529085 
+L 285.164256 323.435486 
+L 286.070363 324.341727 
+L 286.976333 325.24781 
+L 287.882165 326.153739 
+L 287.109893 326.795731 
+L 286.331756 327.430602 
+L 285.547821 328.058298 
+L 284.758152 328.678767 
+L 283.962817 329.291956 
+L 283.161883 329.897813 
+L 282.355418 330.496288 
+L 281.543489 331.087329 
+L 280.726165 331.670887 
+L 279.903516 332.246912 
+L 279.075609 332.815357 
+L 278.242517 333.376172 
+L 277.404307 333.929312 
+L 276.561052 334.474728 
+L 275.712823 335.012375 
+L 274.85969 335.542208 
+L 274.001727 336.064182 
+L 273.139005 336.578253 
+L 272.271597 337.084377 
+L 271.343331 336.146104 
+L 270.414481 335.206841 
+L 269.485029 334.266554 
+L 268.55496 333.325205 
+L 267.624257 332.382757 
+L 266.692903 331.439169 
+L 265.76088 330.4944 
+L 264.828168 329.548403 
+L 263.894748 328.601132 
+L 262.960599 327.652536 
+L 262.0257 326.702564 
+L 261.090029 325.751159 
+L 260.153562 324.798262 
+L 259.216274 323.84381 
+L 258.278141 322.887737 
+L 257.339136 321.929972 
+L 256.399231 320.970442 
+L 255.458398 320.009066 
+L 254.516606 319.04576 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_163">
+    <path d="M 266.779299 278.12929 
+L 267.363253 277.311411 
+L 267.933605 276.483989 
+L 268.490198 275.647249 
+L 269.032881 274.801422 
+L 269.561504 273.946737 
+L 270.075924 273.083429 
+L 270.576 272.211733 
+L 271.061595 271.331889 
+L 271.532576 270.444136 
+L 271.988815 269.548717 
+L 272.430186 268.645877 
+L 272.85657 267.735863 
+L 273.267849 266.818923 
+L 273.663912 265.895309 
+L 274.044649 264.965273 
+L 274.409957 264.029068 
+L 274.759736 263.086952 
+L 275.09389 262.139181 
+L 275.412329 261.186015 
+L 276.439381 262.153715 
+L 277.461061 263.119596 
+L 278.4777 264.083716 
+L 279.489603 265.046134 
+L 280.497052 266.006906 
+L 281.500306 266.966087 
+L 282.499604 267.923732 
+L 283.495168 268.879892 
+L 284.487203 269.834617 
+L 285.475901 270.787957 
+L 286.461438 271.739958 
+L 287.443978 272.690666 
+L 288.423674 273.640124 
+L 289.40067 274.588374 
+L 290.375098 275.535456 
+L 291.347084 276.481409 
+L 292.316743 277.42627 
+L 293.284184 278.370074 
+L 294.24951 279.312856 
+L 293.808266 280.215435 
+L 293.356393 281.11274 
+L 292.893954 282.004646 
+L 292.421014 282.891028 
+L 291.937638 283.771763 
+L 291.443895 284.646728 
+L 290.939852 285.5158 
+L 290.42558 286.378859 
+L 289.901152 287.235784 
+L 289.36664 288.086456 
+L 288.822118 288.930755 
+L 288.267663 289.768565 
+L 287.703351 290.599768 
+L 287.129263 291.424249 
+L 286.545477 292.241892 
+L 285.952075 293.052583 
+L 285.349141 293.856209 
+L 284.736757 294.652659 
+L 284.11501 295.441821 
+L 283.205471 294.53291 
+L 282.295683 293.623795 
+L 281.385638 292.71447 
+L 280.475325 291.804927 
+L 279.564735 290.89516 
+L 278.653856 289.98516 
+L 277.742677 289.074919 
+L 276.831185 288.164429 
+L 275.919366 287.25368 
+L 275.007206 286.342662 
+L 274.094688 285.431364 
+L 273.181796 284.519774 
+L 272.268511 283.60788 
+L 271.354813 282.695668 
+L 270.44068 281.783123 
+L 269.526089 280.870231 
+L 268.611014 279.956974 
+L 267.695427 279.043333 
+L 266.779299 278.12929 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_164">
+    <path d="M 253.33304 291.575549 
+L 254.141152 290.978152 
+L 254.939276 290.367475 
+L 255.727194 289.743685 
+L 256.504691 289.106953 
+L 257.271554 288.457454 
+L 258.027574 287.795363 
+L 258.772543 287.120864 
+L 259.506258 286.434139 
+L 260.228518 285.735377 
+L 260.939127 285.024768 
+L 261.637889 284.302508 
+L 262.324614 283.568793 
+L 262.999113 282.823824 
+L 263.661204 282.067804 
+L 264.310703 281.300941 
+L 264.947435 280.523444 
+L 265.571225 279.735526 
+L 266.181902 278.937402 
+L 266.779299 278.12929 
+L 267.695427 279.043333 
+L 268.611014 279.956974 
+L 269.526089 280.870231 
+L 270.44068 281.783123 
+L 271.354813 282.695668 
+L 272.268511 283.60788 
+L 273.181796 284.519774 
+L 274.094688 285.431364 
+L 275.007206 286.342662 
+L 275.919366 287.25368 
+L 276.831185 288.164429 
+L 277.742677 289.074919 
+L 278.653856 289.98516 
+L 279.564735 290.89516 
+L 280.475325 291.804927 
+L 281.385638 292.71447 
+L 282.295683 293.623795 
+L 283.205471 294.53291 
+L 284.11501 295.441821 
+L 283.483986 296.223584 
+L 282.843773 296.997841 
+L 282.194461 297.764482 
+L 281.53614 298.523402 
+L 280.868901 299.274494 
+L 280.192839 300.017653 
+L 279.508047 300.752776 
+L 278.814621 301.47976 
+L 278.112657 302.198504 
+L 277.402254 302.908907 
+L 276.68351 303.610871 
+L 275.956526 304.304297 
+L 275.221403 304.989089 
+L 274.478244 305.665151 
+L 273.727152 306.33239 
+L 272.968232 306.990711 
+L 272.201591 307.640023 
+L 271.427334 308.280236 
+L 270.645571 308.91126 
+L 269.73666 308.001721 
+L 268.827545 307.091933 
+L 267.91822 306.181888 
+L 267.008677 305.271575 
+L 266.09891 304.360985 
+L 265.18891 303.450106 
+L 264.278669 302.538927 
+L 263.368179 301.627435 
+L 262.45743 300.715616 
+L 261.546412 299.803456 
+L 260.635114 298.890938 
+L 259.723524 297.978046 
+L 258.81163 297.064761 
+L 257.899418 296.151063 
+L 256.986873 295.23693 
+L 256.073981 294.322339 
+L 255.160724 293.407264 
+L 254.247083 292.491677 
+L 253.33304 291.575549 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_165">
+    <path d="M 236.389765 300.208579 
+L 237.342931 299.89014 
+L 238.290702 299.555986 
+L 239.232818 299.206207 
+L 240.169023 298.840899 
+L 241.099059 298.460162 
+L 242.022673 298.064099 
+L 242.939613 297.65282 
+L 243.849627 297.226436 
+L 244.752467 296.785065 
+L 245.647886 296.328826 
+L 246.535639 295.857845 
+L 247.415483 295.37225 
+L 248.287179 294.872174 
+L 249.150487 294.357754 
+L 250.005172 293.829131 
+L 250.850999 293.286448 
+L 251.687739 292.729855 
+L 252.515161 292.159503 
+L 253.33304 291.575549 
+L 254.247083 292.491677 
+L 255.160724 293.407264 
+L 256.073981 294.322339 
+L 256.986873 295.23693 
+L 257.899418 296.151063 
+L 258.81163 297.064761 
+L 259.723524 297.978046 
+L 260.635114 298.890938 
+L 261.546412 299.803456 
+L 262.45743 300.715616 
+L 263.368179 301.627435 
+L 264.278669 302.538927 
+L 265.18891 303.450106 
+L 266.09891 304.360985 
+L 267.008677 305.271575 
+L 267.91822 306.181888 
+L 268.827545 307.091933 
+L 269.73666 308.001721 
+L 270.645571 308.91126 
+L 269.856409 309.533007 
+L 269.059959 310.145391 
+L 268.256333 310.748325 
+L 267.445642 311.341727 
+L 266.627999 311.925513 
+L 265.803518 312.499601 
+L 264.972315 313.063913 
+L 264.134505 313.618368 
+L 263.290206 314.16289 
+L 262.439534 314.697402 
+L 261.582609 315.22183 
+L 260.71955 315.736102 
+L 259.850478 316.240145 
+L 258.975513 316.733888 
+L 258.094778 317.217264 
+L 257.208396 317.690204 
+L 256.31649 318.152643 
+L 255.419185 318.604516 
+L 254.516606 319.04576 
+L 253.573824 318.080434 
+L 252.63002 317.112993 
+L 251.685159 316.143334 
+L 250.739206 315.171348 
+L 249.792124 314.19692 
+L 248.843874 313.219924 
+L 247.894416 312.240228 
+L 246.943708 311.257688 
+L 245.991707 310.272151 
+L 245.038367 309.283453 
+L 244.083642 308.291418 
+L 243.127482 307.295854 
+L 242.169837 306.296556 
+L 241.210656 305.293302 
+L 240.249884 304.285853 
+L 239.287466 303.27395 
+L 238.323346 302.257311 
+L 237.357465 301.235631 
+L 236.389765 300.208579 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_166">
+    <path d="M 249.195923 260.641546 
+L 249.686446 259.764237 
+L 250.152609 258.873745 
+L 250.594058 257.970746 
+L 251.010458 257.055927 
+L 251.401493 256.129981 
+L 251.766865 255.193612 
+L 252.106298 254.247531 
+L 252.419533 253.292456 
+L 252.706332 252.329113 
+L 252.966479 251.358233 
+L 253.199775 250.380554 
+L 253.406043 249.396817 
+L 253.585126 248.40777 
+L 253.736889 247.414165 
+L 253.861216 246.416755 
+L 253.958013 245.416298 
+L 254.027206 244.413554 
+L 254.068743 243.409283 
+L 254.082592 242.40425 
+L 255.348725 243.409284 
+L 256.589832 244.41365 
+L 257.808314 245.416847 
+L 259.006286 246.418501 
+L 260.185617 247.41834 
+L 261.347961 248.416169 
+L 262.494789 249.411856 
+L 263.62741 250.405314 
+L 264.746996 251.396494 
+L 265.854594 252.385375 
+L 266.951146 253.371958 
+L 268.037498 254.356261 
+L 269.114415 255.338313 
+L 270.182589 256.318156 
+L 271.242644 257.295836 
+L 272.295151 258.271405 
+L 273.340626 259.244919 
+L 274.379542 260.216436 
+L 275.412329 261.186015 
+L 275.09389 262.139181 
+L 274.759736 263.086952 
+L 274.409957 264.029068 
+L 274.044649 264.965273 
+L 273.663912 265.895309 
+L 273.267849 266.818923 
+L 272.85657 267.735863 
+L 272.430186 268.645877 
+L 271.988815 269.548717 
+L 271.532576 270.444136 
+L 271.061595 271.331889 
+L 270.576 272.211733 
+L 270.075924 273.083429 
+L 269.561504 273.946737 
+L 269.032881 274.801422 
+L 268.490198 275.647249 
+L 267.933605 276.483989 
+L 267.363253 277.311411 
+L 266.779299 278.12929 
+L 265.862595 277.214822 
+L 264.945281 276.299908 
+L 264.027315 275.384521 
+L 263.108656 274.468634 
+L 262.189254 273.552219 
+L 261.269058 272.635242 
+L 260.348009 271.717668 
+L 259.426044 270.799459 
+L 258.50309 269.880574 
+L 257.579069 268.960965 
+L 256.653892 268.040582 
+L 255.72746 267.119369 
+L 254.799663 266.197265 
+L 253.870376 265.274201 
+L 252.939457 264.350103 
+L 252.006747 263.424887 
+L 251.072065 262.49846 
+L 250.135203 261.570718 
+L 249.195923 260.641546 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_167">
+    <path d="M 235.845296 273.992173 
+L 236.708756 273.477663 
+L 237.557711 272.939556 
+L 238.391516 272.37826 
+L 239.209539 271.794203 
+L 240.011158 271.187828 
+L 240.795764 270.559595 
+L 241.562762 269.909981 
+L 242.311569 269.239479 
+L 243.041616 268.5486 
+L 243.75235 267.837866 
+L 244.443229 267.107819 
+L 245.113731 266.359012 
+L 245.763345 265.592014 
+L 246.391578 264.807408 
+L 246.997953 264.005789 
+L 247.58201 263.187766 
+L 248.143306 262.353961 
+L 248.681413 261.505006 
+L 249.195923 260.641546 
+L 250.135203 261.570718 
+L 251.072065 262.49846 
+L 252.006747 263.424887 
+L 252.939457 264.350103 
+L 253.870376 265.274201 
+L 254.799663 266.197265 
+L 255.72746 267.119369 
+L 256.653892 268.040582 
+L 257.579069 268.960965 
+L 258.50309 269.880574 
+L 259.426044 270.799459 
+L 260.348009 271.717668 
+L 261.269058 272.635242 
+L 262.189254 273.552219 
+L 263.108656 274.468634 
+L 264.027315 275.384521 
+L 264.945281 276.299908 
+L 265.862595 277.214822 
+L 266.779299 278.12929 
+L 266.181902 278.937402 
+L 265.571225 279.735526 
+L 264.947435 280.523444 
+L 264.310703 281.300941 
+L 263.661204 282.067804 
+L 262.999113 282.823824 
+L 262.324614 283.568793 
+L 261.637889 284.302508 
+L 260.939127 285.024768 
+L 260.228518 285.735377 
+L 259.506258 286.434139 
+L 258.772543 287.120864 
+L 258.027574 287.795363 
+L 257.271554 288.457454 
+L 256.504691 289.106953 
+L 255.727194 289.743685 
+L 254.939276 290.367475 
+L 254.141152 290.978152 
+L 253.33304 291.575549 
+L 252.418572 290.658845 
+L 251.503658 289.741531 
+L 250.588271 288.823565 
+L 249.672384 287.904906 
+L 248.755969 286.985504 
+L 247.838992 286.065308 
+L 246.921418 285.144259 
+L 246.003209 284.222294 
+L 245.084324 283.29934 
+L 244.164715 282.375319 
+L 243.244332 281.450142 
+L 242.323119 280.52371 
+L 241.401015 279.595913 
+L 240.477951 278.666626 
+L 239.553853 277.735707 
+L 238.628637 276.802997 
+L 237.70221 275.868315 
+L 236.774468 274.931453 
+L 235.845296 273.992173 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_168">
+    <path d="M 217.608 278.878842 
+L 218.613033 278.864993 
+L 219.617304 278.823456 
+L 220.620048 278.754263 
+L 221.620505 278.657466 
+L 222.617915 278.533139 
+L 223.61152 278.381376 
+L 224.600567 278.202293 
+L 225.584304 277.996025 
+L 226.561983 277.762729 
+L 227.532863 277.502582 
+L 228.496206 277.215783 
+L 229.451281 276.902548 
+L 230.397362 276.563115 
+L 231.333731 276.197743 
+L 232.259677 275.806708 
+L 233.174496 275.390308 
+L 234.077495 274.948859 
+L 234.967987 274.482696 
+L 235.845296 273.992173 
+L 236.774468 274.931453 
+L 237.70221 275.868315 
+L 238.628637 276.802997 
+L 239.553853 277.735707 
+L 240.477951 278.666626 
+L 241.401015 279.595913 
+L 242.323119 280.52371 
+L 243.244332 281.450142 
+L 244.164715 282.375319 
+L 245.084324 283.29934 
+L 246.003209 284.222294 
+L 246.921418 285.144259 
+L 247.838992 286.065308 
+L 248.755969 286.985504 
+L 249.672384 287.904906 
+L 250.588271 288.823565 
+L 251.503658 289.741531 
+L 252.418572 290.658845 
+L 253.33304 291.575549 
+L 252.515161 292.159503 
+L 251.687739 292.729855 
+L 250.850999 293.286448 
+L 250.005172 293.829131 
+L 249.150487 294.357754 
+L 248.287179 294.872174 
+L 247.415483 295.37225 
+L 246.535639 295.857845 
+L 245.647886 296.328826 
+L 244.752467 296.785065 
+L 243.849627 297.226436 
+L 242.939613 297.65282 
+L 242.022673 298.064099 
+L 241.099059 298.460162 
+L 240.169023 298.840899 
+L 239.232818 299.206207 
+L 238.290702 299.555986 
+L 237.342931 299.89014 
+L 236.389765 300.208579 
+L 235.420186 299.175792 
+L 234.448669 298.136876 
+L 233.475155 297.091401 
+L 232.499586 296.038894 
+L 231.521906 294.978839 
+L 230.542063 293.910665 
+L 229.560011 292.833748 
+L 228.575708 291.747396 
+L 227.589125 290.650844 
+L 226.600244 289.543246 
+L 225.609064 288.42366 
+L 224.615606 287.291039 
+L 223.619919 286.144211 
+L 222.62209 284.981867 
+L 221.622251 283.802536 
+L 220.620597 282.604564 
+L 219.6174 281.386082 
+L 218.613034 280.144975 
+L 217.608 278.878842 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_169">
+    <path d="M 236.53689 325.337135 
+L 237.515026 325.107796 
+L 238.490385 324.866922 
+L 239.462831 324.614545 
+L 240.432229 324.350701 
+L 241.398443 324.075427 
+L 242.361338 323.78876 
+L 243.320781 323.490742 
+L 244.276638 323.181413 
+L 245.228774 322.860817 
+L 246.177058 322.528998 
+L 247.121357 322.186003 
+L 248.061539 321.831879 
+L 248.997473 321.466676 
+L 249.929029 321.090446 
+L 250.856076 320.703239 
+L 251.778486 320.305111 
+L 252.696129 319.896117 
+L 253.608878 319.476314 
+L 254.516606 319.04576 
+L 255.458398 320.009066 
+L 256.399231 320.970442 
+L 257.339136 321.929972 
+L 258.278141 322.887737 
+L 259.216274 323.84381 
+L 260.153562 324.798262 
+L 261.090029 325.751159 
+L 262.0257 326.702564 
+L 262.960599 327.652536 
+L 263.894748 328.601132 
+L 264.828168 329.548403 
+L 265.76088 330.4944 
+L 266.692903 331.439169 
+L 267.624257 332.382757 
+L 268.55496 333.325205 
+L 269.485029 334.266554 
+L 270.414481 335.206841 
+L 271.343331 336.146104 
+L 272.271597 337.084377 
+L 271.399576 337.582512 
+L 270.523017 338.072616 
+L 269.641993 338.554647 
+L 268.756578 339.028565 
+L 267.866847 339.49433 
+L 266.972875 339.951902 
+L 266.074738 340.401243 
+L 265.17251 340.842315 
+L 264.26627 341.27508 
+L 263.356092 341.699503 
+L 262.442054 342.115547 
+L 261.524233 342.523178 
+L 260.602707 342.92236 
+L 259.677552 343.31306 
+L 258.748848 343.695246 
+L 257.816671 344.068885 
+L 256.881103 344.433945 
+L 255.94222 344.790396 
+L 255.000102 345.138207 
+L 254.038838 344.128461 
+L 253.076524 343.115864 
+L 252.113141 342.100309 
+L 251.14867 341.081685 
+L 250.183088 340.059876 
+L 249.216375 339.034759 
+L 248.24851 338.006203 
+L 247.279473 336.974072 
+L 246.309242 335.938223 
+L 245.337797 334.898504 
+L 244.365116 333.854754 
+L 243.39118 332.806804 
+L 242.415968 331.754475 
+L 241.439461 330.697578 
+L 240.461641 329.635913 
+L 239.482489 328.569268 
+L 238.50199 327.497418 
+L 237.520128 326.420125 
+L 236.53689 325.337135 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_170">
+    <path d="M 217.608 327.469909 
+L 218.612644 327.463976 
+L 219.617149 327.446178 
+L 220.621373 327.416519 
+L 221.625177 327.375001 
+L 222.62842 327.321631 
+L 223.630963 327.256417 
+L 224.632666 327.179366 
+L 225.63339 327.090491 
+L 226.632993 326.989803 
+L 227.631338 326.877316 
+L 228.628285 326.753047 
+L 229.623695 326.617012 
+L 230.617428 326.469231 
+L 231.609347 326.309724 
+L 232.599313 326.138513 
+L 233.587188 325.955622 
+L 234.572834 325.761077 
+L 235.556114 325.554905 
+L 236.53689 325.337135 
+L 237.520128 326.420125 
+L 238.50199 327.497418 
+L 239.482489 328.569268 
+L 240.461641 329.635913 
+L 241.439461 330.697578 
+L 242.415968 331.754475 
+L 243.39118 332.806804 
+L 244.365116 333.854754 
+L 245.337797 334.898504 
+L 246.309242 335.938223 
+L 247.279473 336.974072 
+L 248.24851 338.006203 
+L 249.216375 339.034759 
+L 250.183088 340.059876 
+L 251.14867 341.081685 
+L 252.113141 342.100309 
+L 253.076524 343.115864 
+L 254.038838 344.128461 
+L 255.000102 345.138207 
+L 254.05483 345.47735 
+L 253.106482 345.807795 
+L 252.155138 346.129514 
+L 251.20088 346.442482 
+L 250.243787 346.74667 
+L 249.283939 347.042054 
+L 248.32142 347.328609 
+L 247.356308 347.60631 
+L 246.388686 347.875134 
+L 245.418636 348.135058 
+L 244.446239 348.38606 
+L 243.471578 348.62812 
+L 242.494734 348.861217 
+L 241.51579 349.08533 
+L 240.534829 349.300442 
+L 239.551933 349.506533 
+L 238.567185 349.703587 
+L 237.580669 349.891587 
+L 236.592468 350.070518 
+L 235.601125 348.946582 
+L 234.608769 347.816864 
+L 233.61541 346.68115 
+L 232.621059 345.539214 
+L 231.625732 344.390822 
+L 230.629447 343.235726 
+L 229.632227 342.073665 
+L 228.634097 340.904366 
+L 227.635089 339.727541 
+L 226.635239 338.542887 
+L 225.634587 337.350086 
+L 224.633183 336.148801 
+L 223.631081 334.938678 
+L 222.628343 333.719345 
+L 221.625042 332.490405 
+L 220.621259 331.251444 
+L 219.617086 330.002022 
+L 218.612627 328.741674 
+L 217.608 327.469909 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_171">
+    <path d="M 217.608 327.469909 
+L 218.612627 328.741674 
+L 219.617086 330.002022 
+L 220.621259 331.251444 
+L 221.625042 332.490405 
+L 222.628343 333.719345 
+L 223.631081 334.938678 
+L 224.633183 336.148801 
+L 225.634587 337.350086 
+L 226.635239 338.542887 
+L 227.635089 339.727541 
+L 228.634097 340.904366 
+L 229.632227 342.073665 
+L 230.629447 343.235726 
+L 231.625732 344.390822 
+L 232.621059 345.539214 
+L 233.61541 346.68115 
+L 234.608769 347.816864 
+L 235.601125 348.946582 
+L 236.592468 350.070518 
+L 235.602665 350.240363 
+L 234.611343 350.401109 
+L 233.618586 350.552742 
+L 232.624479 350.69525 
+L 231.629104 350.828619 
+L 230.632547 350.95284 
+L 229.63489 351.067901 
+L 228.636219 351.173794 
+L 227.636616 351.270508 
+L 226.636168 351.358036 
+L 225.634958 351.43637 
+L 224.63307 351.505504 
+L 223.63059 351.565432 
+L 222.627602 351.616149 
+L 221.62419 351.65765 
+L 220.620439 351.689933 
+L 219.616434 351.712994 
+L 218.612259 351.726831 
+L 217.608 351.731444 
+L 216.603741 351.726831 
+L 215.599566 351.712994 
+L 214.595561 351.689933 
+L 213.59181 351.65765 
+L 212.588398 351.616149 
+L 211.58541 351.565432 
+L 210.58293 351.505504 
+L 209.581042 351.43637 
+L 208.579832 351.358036 
+L 207.579384 351.270508 
+L 206.579781 351.173794 
+L 205.58111 351.067901 
+L 204.583453 350.95284 
+L 203.586896 350.828619 
+L 202.591521 350.69525 
+L 201.597414 350.552742 
+L 200.604657 350.401109 
+L 199.613335 350.240363 
+L 198.623532 350.070518 
+L 199.614875 348.946582 
+L 200.607231 347.816864 
+L 201.60059 346.68115 
+L 202.594941 345.539214 
+L 203.590268 344.390822 
+L 204.586553 343.235726 
+L 205.583773 342.073665 
+L 206.581903 340.904366 
+L 207.580911 339.727541 
+L 208.580761 338.542887 
+L 209.581413 337.350086 
+L 210.582817 336.148801 
+L 211.584919 334.938678 
+L 212.587657 333.719345 
+L 213.590958 332.490405 
+L 214.594741 331.251444 
+L 215.598914 330.002022 
+L 216.603373 328.741674 
+L 217.608 327.469909 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_172">
+    <path d="M 217.608 303.183318 
+L 218.612918 303.17501 
+L 219.617561 303.150087 
+L 220.621654 303.108558 
+L 221.624924 303.050432 
+L 222.627096 302.975727 
+L 223.627895 302.884461 
+L 224.627049 302.776661 
+L 225.624283 302.652356 
+L 226.619326 302.51158 
+L 227.611906 302.354371 
+L 228.60175 302.180772 
+L 229.588589 301.990831 
+L 230.572153 301.784599 
+L 231.552172 301.562133 
+L 232.528379 301.323495 
+L 233.500507 301.068748 
+L 234.46829 300.797963 
+L 235.431464 300.511214 
+L 236.389765 300.208579 
+L 237.357465 301.235631 
+L 238.323346 302.257311 
+L 239.287466 303.27395 
+L 240.249884 304.285853 
+L 241.210656 305.293302 
+L 242.169837 306.296556 
+L 243.127482 307.295854 
+L 244.083642 308.291418 
+L 245.038367 309.283453 
+L 245.991707 310.272151 
+L 246.943708 311.257688 
+L 247.894416 312.240228 
+L 248.843874 313.219924 
+L 249.792124 314.19692 
+L 250.739206 315.171348 
+L 251.685159 316.143334 
+L 252.63002 317.112993 
+L 253.573824 318.080434 
+L 254.516606 319.04576 
+L 253.608878 319.476314 
+L 252.696129 319.896117 
+L 251.778486 320.305111 
+L 250.856076 320.703239 
+L 249.929029 321.090446 
+L 248.997473 321.466676 
+L 248.061539 321.831879 
+L 247.121357 322.186003 
+L 246.177058 322.528998 
+L 245.228774 322.860817 
+L 244.276638 323.181413 
+L 243.320781 323.490742 
+L 242.361338 323.78876 
+L 241.398443 324.075427 
+L 240.432229 324.350701 
+L 239.462831 324.614545 
+L 238.490385 324.866922 
+L 237.515026 325.107796 
+L 236.53689 325.337135 
+L 235.552264 324.248179 
+L 234.566241 323.152973 
+L 233.578816 322.051211 
+L 232.589986 320.942569 
+L 231.599751 319.826703 
+L 230.608119 318.703244 
+L 229.615101 317.571798 
+L 228.620715 316.431946 
+L 227.624986 315.283237 
+L 226.627949 314.125191 
+L 225.629648 312.957291 
+L 224.630139 311.778984 
+L 223.629492 310.589675 
+L 222.627792 309.388725 
+L 221.625145 308.175446 
+L 220.621677 306.949098 
+L 219.617537 305.70888 
+L 218.612907 304.453931 
+L 217.608 303.183318 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_173">
+    <path d="M 217.608 303.183318 
+L 218.612907 304.453931 
+L 219.617537 305.70888 
+L 220.621677 306.949098 
+L 221.625145 308.175446 
+L 222.627792 309.388725 
+L 223.629492 310.589675 
+L 224.630139 311.778984 
+L 225.629648 312.957291 
+L 226.627949 314.125191 
+L 227.624986 315.283237 
+L 228.620715 316.431946 
+L 229.615101 317.571798 
+L 230.608119 318.703244 
+L 231.599751 319.826703 
+L 232.589986 320.942569 
+L 233.578816 322.051211 
+L 234.566241 323.152973 
+L 235.552264 324.248179 
+L 236.53689 325.337135 
+L 235.556114 325.554905 
+L 234.572834 325.761077 
+L 233.587188 325.955622 
+L 232.599313 326.138513 
+L 231.609347 326.309724 
+L 230.617428 326.469231 
+L 229.623695 326.617012 
+L 228.628285 326.753047 
+L 227.631338 326.877316 
+L 226.632993 326.989803 
+L 225.63339 327.090491 
+L 224.632666 327.179366 
+L 223.630963 327.256417 
+L 222.62842 327.321631 
+L 221.625177 327.375001 
+L 220.621373 327.416519 
+L 219.617149 327.446178 
+L 218.612644 327.463976 
+L 217.608 327.469909 
+L 216.603356 327.463976 
+L 215.598851 327.446178 
+L 214.594627 327.416519 
+L 213.590823 327.375001 
+L 212.58758 327.321631 
+L 211.585037 327.256417 
+L 210.583334 327.179366 
+L 209.58261 327.090491 
+L 208.583007 326.989803 
+L 207.584662 326.877316 
+L 206.587715 326.753047 
+L 205.592305 326.617012 
+L 204.598572 326.469231 
+L 203.606653 326.309724 
+L 202.616687 326.138513 
+L 201.628812 325.955622 
+L 200.643166 325.761077 
+L 199.659886 325.554905 
+L 198.67911 325.337135 
+L 199.663736 324.248179 
+L 200.649759 323.152973 
+L 201.637184 322.051211 
+L 202.626014 320.942569 
+L 203.616249 319.826703 
+L 204.607881 318.703244 
+L 205.600899 317.571798 
+L 206.595285 316.431946 
+L 207.591014 315.283237 
+L 208.588051 314.125191 
+L 209.586352 312.957291 
+L 210.585861 311.778984 
+L 211.586508 310.589675 
+L 212.588208 309.388725 
+L 213.590855 308.175446 
+L 214.594323 306.949098 
+L 215.598463 305.70888 
+L 216.603093 304.453931 
+L 217.608 303.183318 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_174">
+    <path d="M 198.67911 325.337135 
+L 199.659886 325.554905 
+L 200.643166 325.761077 
+L 201.628812 325.955622 
+L 202.616687 326.138513 
+L 203.606653 326.309724 
+L 204.598572 326.469231 
+L 205.592305 326.617012 
+L 206.587715 326.753047 
+L 207.584662 326.877316 
+L 208.583007 326.989803 
+L 209.58261 327.090491 
+L 210.583334 327.179366 
+L 211.585037 327.256417 
+L 212.58758 327.321631 
+L 213.590823 327.375001 
+L 214.594627 327.416519 
+L 215.598851 327.446178 
+L 216.603356 327.463976 
+L 217.608 327.469909 
+L 216.603373 328.741674 
+L 215.598914 330.002022 
+L 214.594741 331.251444 
+L 213.590958 332.490405 
+L 212.587657 333.719345 
+L 211.584919 334.938678 
+L 210.582817 336.148801 
+L 209.581413 337.350086 
+L 208.580761 338.542887 
+L 207.580911 339.727541 
+L 206.581903 340.904366 
+L 205.583773 342.073665 
+L 204.586553 343.235726 
+L 203.590268 344.390822 
+L 202.594941 345.539214 
+L 201.60059 346.68115 
+L 200.607231 347.816864 
+L 199.614875 348.946582 
+L 198.623532 350.070518 
+L 197.635331 349.891587 
+L 196.648815 349.703587 
+L 195.664067 349.506533 
+L 194.681171 349.300442 
+L 193.70021 349.08533 
+L 192.721266 348.861217 
+L 191.744422 348.62812 
+L 190.769761 348.38606 
+L 189.797364 348.135058 
+L 188.827314 347.875134 
+L 187.859692 347.60631 
+L 186.89458 347.328609 
+L 185.932061 347.042054 
+L 184.972213 346.74667 
+L 184.01512 346.442482 
+L 183.060862 346.129514 
+L 182.109518 345.807795 
+L 181.16117 345.47735 
+L 180.215898 345.138207 
+L 181.177162 344.128461 
+L 182.139476 343.115864 
+L 183.102859 342.100309 
+L 184.06733 341.081685 
+L 185.032912 340.059876 
+L 185.999625 339.034759 
+L 186.96749 338.006203 
+L 187.936527 336.974072 
+L 188.906758 335.938223 
+L 189.878203 334.898504 
+L 190.850884 333.854754 
+L 191.82482 332.806804 
+L 192.800032 331.754475 
+L 193.776539 330.697578 
+L 194.754359 329.635913 
+L 195.733511 328.569268 
+L 196.71401 327.497418 
+L 197.695872 326.420125 
+L 198.67911 325.337135 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_175">
+    <path d="M 217.608 278.878842 
+L 218.613034 280.144975 
+L 219.6174 281.386082 
+L 220.620597 282.604564 
+L 221.622251 283.802536 
+L 222.62209 284.981867 
+L 223.619919 286.144211 
+L 224.615606 287.291039 
+L 225.609064 288.42366 
+L 226.600244 289.543246 
+L 227.589125 290.650844 
+L 228.575708 291.747396 
+L 229.560011 292.833748 
+L 230.542063 293.910665 
+L 231.521906 294.978839 
+L 232.499586 296.038894 
+L 233.475155 297.091401 
+L 234.448669 298.136876 
+L 235.420186 299.175792 
+L 236.389765 300.208579 
+L 235.431464 300.511214 
+L 234.46829 300.797963 
+L 233.500507 301.068748 
+L 232.528379 301.323495 
+L 231.552172 301.562133 
+L 230.572153 301.784599 
+L 229.588589 301.990831 
+L 228.60175 302.180772 
+L 227.611906 302.354371 
+L 226.619326 302.51158 
+L 225.624283 302.652356 
+L 224.627049 302.776661 
+L 223.627895 302.884461 
+L 222.627096 302.975727 
+L 221.624924 303.050432 
+L 220.621654 303.108558 
+L 219.617561 303.150087 
+L 218.612918 303.17501 
+L 217.608 303.183318 
+L 216.603082 303.17501 
+L 215.598439 303.150087 
+L 214.594346 303.108558 
+L 213.591076 303.050432 
+L 212.588904 302.975727 
+L 211.588105 302.884461 
+L 210.588951 302.776661 
+L 209.591717 302.652356 
+L 208.596674 302.51158 
+L 207.604094 302.354371 
+L 206.61425 302.180772 
+L 205.627411 301.990831 
+L 204.643847 301.784599 
+L 203.663828 301.562133 
+L 202.687621 301.323495 
+L 201.715493 301.068748 
+L 200.74771 300.797963 
+L 199.784536 300.511214 
+L 198.826235 300.208579 
+L 199.795814 299.175792 
+L 200.767331 298.136876 
+L 201.740845 297.091401 
+L 202.716414 296.038894 
+L 203.694094 294.978839 
+L 204.673937 293.910665 
+L 205.655989 292.833748 
+L 206.640292 291.747396 
+L 207.626875 290.650844 
+L 208.615756 289.543246 
+L 209.606936 288.42366 
+L 210.600394 287.291039 
+L 211.596081 286.144211 
+L 212.59391 284.981867 
+L 213.593749 283.802536 
+L 214.595403 282.604564 
+L 215.5986 281.386082 
+L 216.602966 280.144975 
+L 217.608 278.878842 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_176">
+    <path d="M 198.826235 300.208579 
+L 199.784536 300.511214 
+L 200.74771 300.797963 
+L 201.715493 301.068748 
+L 202.687621 301.323495 
+L 203.663828 301.562133 
+L 204.643847 301.784599 
+L 205.627411 301.990831 
+L 206.61425 302.180772 
+L 207.604094 302.354371 
+L 208.596674 302.51158 
+L 209.591717 302.652356 
+L 210.588951 302.776661 
+L 211.588105 302.884461 
+L 212.588904 302.975727 
+L 213.591076 303.050432 
+L 214.594346 303.108558 
+L 215.598439 303.150087 
+L 216.603082 303.17501 
+L 217.608 303.183318 
+L 216.603093 304.453931 
+L 215.598463 305.70888 
+L 214.594323 306.949098 
+L 213.590855 308.175446 
+L 212.588208 309.388725 
+L 211.586508 310.589675 
+L 210.585861 311.778984 
+L 209.586352 312.957291 
+L 208.588051 314.125191 
+L 207.591014 315.283237 
+L 206.595285 316.431946 
+L 205.600899 317.571798 
+L 204.607881 318.703244 
+L 203.616249 319.826703 
+L 202.626014 320.942569 
+L 201.637184 322.051211 
+L 200.649759 323.152973 
+L 199.663736 324.248179 
+L 198.67911 325.337135 
+L 197.700974 325.107796 
+L 196.725615 324.866922 
+L 195.753169 324.614545 
+L 194.783771 324.350701 
+L 193.817557 324.075427 
+L 192.854662 323.78876 
+L 191.895219 323.490742 
+L 190.939362 323.181413 
+L 189.987226 322.860817 
+L 189.038942 322.528998 
+L 188.094643 322.186003 
+L 187.154461 321.831879 
+L 186.218527 321.466676 
+L 185.286971 321.090446 
+L 184.359924 320.703239 
+L 183.437514 320.305111 
+L 182.519871 319.896117 
+L 181.607122 319.476314 
+L 180.699394 319.04576 
+L 181.642176 318.080434 
+L 182.58598 317.112993 
+L 183.530841 316.143334 
+L 184.476794 315.171348 
+L 185.423876 314.19692 
+L 186.372126 313.219924 
+L 187.321584 312.240228 
+L 188.272292 311.257688 
+L 189.224293 310.272151 
+L 190.177633 309.283453 
+L 191.132358 308.291418 
+L 192.088518 307.295854 
+L 193.046163 306.296556 
+L 194.005344 305.293302 
+L 194.966116 304.285853 
+L 195.928534 303.27395 
+L 196.892654 302.257311 
+L 197.858535 301.235631 
+L 198.826235 300.208579 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_177">
+    <path d="M 180.699394 319.04576 
+L 181.607122 319.476314 
+L 182.519871 319.896117 
+L 183.437514 320.305111 
+L 184.359924 320.703239 
+L 185.286971 321.090446 
+L 186.218527 321.466676 
+L 187.154461 321.831879 
+L 188.094643 322.186003 
+L 189.038942 322.528998 
+L 189.987226 322.860817 
+L 190.939362 323.181413 
+L 191.895219 323.490742 
+L 192.854662 323.78876 
+L 193.817557 324.075427 
+L 194.783771 324.350701 
+L 195.753169 324.614545 
+L 196.725615 324.866922 
+L 197.700974 325.107796 
+L 198.67911 325.337135 
+L 197.695872 326.420125 
+L 196.71401 327.497418 
+L 195.733511 328.569268 
+L 194.754359 329.635913 
+L 193.776539 330.697578 
+L 192.800032 331.754475 
+L 191.82482 332.806804 
+L 190.850884 333.854754 
+L 189.878203 334.898504 
+L 188.906758 335.938223 
+L 187.936527 336.974072 
+L 186.96749 338.006203 
+L 185.999625 339.034759 
+L 185.032912 340.059876 
+L 184.06733 341.081685 
+L 183.102859 342.100309 
+L 182.139476 343.115864 
+L 181.177162 344.128461 
+L 180.215898 345.138207 
+L 179.27378 344.790396 
+L 178.334897 344.433945 
+L 177.399329 344.068885 
+L 176.467152 343.695246 
+L 175.538448 343.31306 
+L 174.613293 342.92236 
+L 173.691767 342.523178 
+L 172.773946 342.115547 
+L 171.859908 341.699503 
+L 170.94973 341.27508 
+L 170.04349 340.842315 
+L 169.141262 340.401243 
+L 168.243125 339.951902 
+L 167.349153 339.49433 
+L 166.459422 339.028565 
+L 165.574007 338.554647 
+L 164.692983 338.072616 
+L 163.816424 337.582512 
+L 162.944403 337.084377 
+L 163.872669 336.146104 
+L 164.801519 335.206841 
+L 165.730971 334.266554 
+L 166.66104 333.325205 
+L 167.591743 332.382757 
+L 168.523097 331.439169 
+L 169.45512 330.4944 
+L 170.387832 329.548403 
+L 171.321252 328.601132 
+L 172.255401 327.652536 
+L 173.1903 326.702564 
+L 174.125971 325.751159 
+L 175.062438 324.798262 
+L 175.999726 323.84381 
+L 176.937859 322.887737 
+L 177.876864 321.929972 
+L 178.816769 320.970442 
+L 179.757602 320.009066 
+L 180.699394 319.04576 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_178">
+    <path d="M 294.24951 205.495644 
+L 293.808266 204.593065 
+L 293.356393 203.69576 
+L 292.893954 202.803854 
+L 292.421014 201.917472 
+L 291.937638 201.036737 
+L 291.443895 200.161772 
+L 290.939852 199.2927 
+L 290.42558 198.429641 
+L 289.901152 197.572716 
+L 289.36664 196.722044 
+L 288.822118 195.877745 
+L 288.267663 195.039935 
+L 287.703351 194.208732 
+L 287.129263 193.384251 
+L 286.545477 192.566608 
+L 285.952075 191.755917 
+L 285.349141 190.952291 
+L 284.736757 190.155841 
+L 284.11501 189.366679 
+L 285.024309 188.457967 
+L 285.933375 187.549448 
+L 286.842215 186.641116 
+L 287.750838 185.732967 
+L 288.659248 184.824996 
+L 289.567452 183.917198 
+L 290.475456 183.00957 
+L 291.383264 182.102108 
+L 292.290882 181.194809 
+L 293.198315 180.287668 
+L 294.105566 179.380683 
+L 295.01264 178.47385 
+L 295.91954 177.567167 
+L 296.826271 176.660632 
+L 297.732835 175.754242 
+L 298.639236 174.847994 
+L 299.545477 173.941887 
+L 300.45156 173.035917 
+L 301.357489 172.130085 
+L 301.999481 172.902357 
+L 302.634352 173.680494 
+L 303.262048 174.464429 
+L 303.882517 175.254098 
+L 304.495706 176.049433 
+L 305.101563 176.850367 
+L 305.700038 177.656832 
+L 306.291079 178.468761 
+L 306.874637 179.286085 
+L 307.450662 180.108734 
+L 308.019107 180.936641 
+L 308.579922 181.769733 
+L 309.133062 182.607943 
+L 309.678478 183.451198 
+L 310.216125 184.299427 
+L 310.745958 185.15256 
+L 311.267932 186.010523 
+L 311.782003 186.873245 
+L 312.288127 187.740653 
+L 311.349854 188.668919 
+L 310.410591 189.597769 
+L 309.470304 190.527221 
+L 308.528955 191.45729 
+L 307.586507 192.387993 
+L 306.642919 193.319347 
+L 305.69815 194.25137 
+L 304.752153 195.184082 
+L 303.804882 196.117502 
+L 302.856286 197.051651 
+L 301.906314 197.98655 
+L 300.954909 198.922221 
+L 300.002012 199.858688 
+L 299.04756 200.795976 
+L 298.091487 201.734109 
+L 297.133722 202.673114 
+L 296.174192 203.613019 
+L 295.212816 204.553852 
+L 294.24951 205.495644 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_179">
+    <path d="M 275.412329 223.622485 
+L 275.09389 222.669319 
+L 274.759736 221.721548 
+L 274.409957 220.779432 
+L 274.044649 219.843227 
+L 273.663912 218.913191 
+L 273.267849 217.989577 
+L 272.85657 217.072637 
+L 272.430186 216.162623 
+L 271.988815 215.259783 
+L 271.532576 214.364364 
+L 271.061595 213.476611 
+L 270.576 212.596767 
+L 270.075924 211.725071 
+L 269.561504 210.861763 
+L 269.032881 210.007078 
+L 268.490198 209.161251 
+L 267.933605 208.324511 
+L 267.363253 207.497089 
+L 266.779299 206.67921 
+L 267.695427 205.765167 
+L 268.611014 204.851526 
+L 269.526089 203.938269 
+L 270.44068 203.025377 
+L 271.354813 202.112832 
+L 272.268511 201.20062 
+L 273.181796 200.288726 
+L 274.094688 199.377136 
+L 275.007206 198.465838 
+L 275.919366 197.55482 
+L 276.831185 196.644071 
+L 277.742677 195.733581 
+L 278.653856 194.82334 
+L 279.564735 193.91334 
+L 280.475325 193.003573 
+L 281.385638 192.09403 
+L 282.295683 191.184705 
+L 283.205471 190.27559 
+L 284.11501 189.366679 
+L 284.736757 190.155841 
+L 285.349141 190.952291 
+L 285.952075 191.755917 
+L 286.545477 192.566608 
+L 287.129263 193.384251 
+L 287.703351 194.208732 
+L 288.267663 195.039935 
+L 288.822118 195.877745 
+L 289.36664 196.722044 
+L 289.901152 197.572716 
+L 290.42558 198.429641 
+L 290.939852 199.2927 
+L 291.443895 200.161772 
+L 291.937638 201.036737 
+L 292.421014 201.917472 
+L 292.893954 202.803854 
+L 293.356393 203.69576 
+L 293.808266 204.593065 
+L 294.24951 205.495644 
+L 293.284184 206.438426 
+L 292.316743 207.38223 
+L 291.347084 208.327091 
+L 290.375098 209.273044 
+L 289.40067 210.220126 
+L 288.423674 211.168376 
+L 287.443978 212.117834 
+L 286.461438 213.068542 
+L 285.475901 214.020543 
+L 284.487203 214.973883 
+L 283.495168 215.928608 
+L 282.499604 216.884768 
+L 281.500306 217.842413 
+L 280.497052 218.801594 
+L 279.489603 219.762366 
+L 278.4777 220.724784 
+L 277.461061 221.688904 
+L 276.439381 222.654785 
+L 275.412329 223.622485 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_180">
+    <path d="M 254.082592 242.40425 
+L 254.068743 241.399217 
+L 254.027206 240.394946 
+L 253.958013 239.392202 
+L 253.861216 238.391745 
+L 253.736889 237.394335 
+L 253.585126 236.40073 
+L 253.406043 235.411683 
+L 253.199775 234.427946 
+L 252.966479 233.450267 
+L 252.706332 232.479387 
+L 252.419533 231.516044 
+L 252.106298 230.560969 
+L 251.766865 229.614888 
+L 251.401493 228.678519 
+L 251.010458 227.752573 
+L 250.594058 226.837754 
+L 250.152609 225.934755 
+L 249.686446 225.044263 
+L 249.195923 224.166954 
+L 250.135203 223.237782 
+L 251.072065 222.31004 
+L 252.006747 221.383613 
+L 252.939457 220.458397 
+L 253.870376 219.534299 
+L 254.799663 218.611235 
+L 255.72746 217.689131 
+L 256.653892 216.767918 
+L 257.579069 215.847535 
+L 258.50309 214.927926 
+L 259.426044 214.009041 
+L 260.348009 213.090832 
+L 261.269058 212.173258 
+L 262.189254 211.256281 
+L 263.108656 210.339866 
+L 264.027315 209.423979 
+L 264.945281 208.508592 
+L 265.862595 207.593678 
+L 266.779299 206.67921 
+L 267.363253 207.497089 
+L 267.933605 208.324511 
+L 268.490198 209.161251 
+L 269.032881 210.007078 
+L 269.561504 210.861763 
+L 270.075924 211.725071 
+L 270.576 212.596767 
+L 271.061595 213.476611 
+L 271.532576 214.364364 
+L 271.988815 215.259783 
+L 272.430186 216.162623 
+L 272.85657 217.072637 
+L 273.267849 217.989577 
+L 273.663912 218.913191 
+L 274.044649 219.843227 
+L 274.409957 220.779432 
+L 274.759736 221.721548 
+L 275.09389 222.669319 
+L 275.412329 223.622485 
+L 274.379542 224.592064 
+L 273.340626 225.563581 
+L 272.295151 226.537095 
+L 271.242644 227.512664 
+L 270.182589 228.490344 
+L 269.114415 229.470187 
+L 268.037498 230.452239 
+L 266.951146 231.436542 
+L 265.854594 232.423125 
+L 264.746996 233.412006 
+L 263.62741 234.403186 
+L 262.494789 235.396644 
+L 261.347961 236.392331 
+L 260.185617 237.39016 
+L 259.006286 238.389999 
+L 257.808314 239.391653 
+L 256.589832 240.39485 
+L 255.348725 241.399216 
+L 254.082592 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_181">
+    <path d="M 284.11501 189.366679 
+L 283.483986 188.584916 
+L 282.843773 187.810659 
+L 282.194461 187.044018 
+L 281.53614 186.285098 
+L 280.868901 185.534006 
+L 280.192839 184.790847 
+L 279.508047 184.055724 
+L 278.814621 183.32874 
+L 278.112657 182.609996 
+L 277.402254 181.899593 
+L 276.68351 181.197629 
+L 275.956526 180.504203 
+L 275.221403 179.819411 
+L 274.478244 179.143349 
+L 273.727152 178.47611 
+L 272.968232 177.817789 
+L 272.201591 177.168477 
+L 271.427334 176.528264 
+L 270.645571 175.89724 
+L 271.554283 174.987941 
+L 272.462802 174.078875 
+L 273.371134 173.170035 
+L 274.279283 172.261412 
+L 275.187254 171.353002 
+L 276.095052 170.444798 
+L 277.00268 169.536794 
+L 277.910142 168.628986 
+L 278.817441 167.721368 
+L 279.724582 166.813935 
+L 280.631567 165.906684 
+L 281.5384 164.99961 
+L 282.445083 164.09271 
+L 283.351618 163.185979 
+L 284.258008 162.279415 
+L 285.164256 161.373014 
+L 286.070363 160.466773 
+L 286.976333 159.56069 
+L 287.882165 158.654761 
+L 288.648508 159.30382 
+L 289.408856 159.959891 
+L 290.163145 160.622918 
+L 290.911312 161.292847 
+L 291.653293 161.96962 
+L 292.389027 162.65318 
+L 293.11845 163.343469 
+L 293.841502 164.040429 
+L 294.558121 164.744002 
+L 295.268248 165.454129 
+L 295.971821 166.170748 
+L 296.668781 166.8938 
+L 297.35907 167.623223 
+L 298.04263 168.358957 
+L 298.719403 169.100938 
+L 299.389332 169.849105 
+L 300.052359 170.603394 
+L 300.70843 171.363742 
+L 301.357489 172.130085 
+L 300.45156 173.035917 
+L 299.545477 173.941887 
+L 298.639236 174.847994 
+L 297.732835 175.754242 
+L 296.826271 176.660632 
+L 295.91954 177.567167 
+L 295.01264 178.47385 
+L 294.105566 179.380683 
+L 293.198315 180.287668 
+L 292.290882 181.194809 
+L 291.383264 182.102108 
+L 290.475456 183.00957 
+L 289.567452 183.917198 
+L 288.659248 184.824996 
+L 287.750838 185.732967 
+L 286.842215 186.641116 
+L 285.933375 187.549448 
+L 285.024309 188.457967 
+L 284.11501 189.366679 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_182">
+    <path d="M 266.779299 206.67921 
+L 266.181902 205.871098 
+L 265.571225 205.072974 
+L 264.947435 204.285056 
+L 264.310703 203.507559 
+L 263.661204 202.740696 
+L 262.999113 201.984676 
+L 262.324614 201.239707 
+L 261.637889 200.505992 
+L 260.939127 199.783732 
+L 260.228518 199.073123 
+L 259.506258 198.374361 
+L 258.772543 197.687636 
+L 258.027574 197.013137 
+L 257.271554 196.351046 
+L 256.504691 195.701547 
+L 255.727194 195.064815 
+L 254.939276 194.441025 
+L 254.141152 193.830348 
+L 253.33304 193.232951 
+L 254.247083 192.316823 
+L 255.160724 191.401236 
+L 256.073981 190.486161 
+L 256.986873 189.57157 
+L 257.899418 188.657437 
+L 258.81163 187.743739 
+L 259.723524 186.830454 
+L 260.635114 185.917562 
+L 261.546412 185.005044 
+L 262.45743 184.092884 
+L 263.368179 183.181065 
+L 264.278669 182.269573 
+L 265.18891 181.358394 
+L 266.09891 180.447515 
+L 267.008677 179.536925 
+L 267.91822 178.626612 
+L 268.827545 177.716567 
+L 269.73666 176.806779 
+L 270.645571 175.89724 
+L 271.427334 176.528264 
+L 272.201591 177.168477 
+L 272.968232 177.817789 
+L 273.727152 178.47611 
+L 274.478244 179.143349 
+L 275.221403 179.819411 
+L 275.956526 180.504203 
+L 276.68351 181.197629 
+L 277.402254 181.899593 
+L 278.112657 182.609996 
+L 278.814621 183.32874 
+L 279.508047 184.055724 
+L 280.192839 184.790847 
+L 280.868901 185.534006 
+L 281.53614 186.285098 
+L 282.194461 187.044018 
+L 282.843773 187.810659 
+L 283.483986 188.584916 
+L 284.11501 189.366679 
+L 283.205471 190.27559 
+L 282.295683 191.184705 
+L 281.385638 192.09403 
+L 280.475325 193.003573 
+L 279.564735 193.91334 
+L 278.653856 194.82334 
+L 277.742677 195.733581 
+L 276.831185 196.644071 
+L 275.919366 197.55482 
+L 275.007206 198.465838 
+L 274.094688 199.377136 
+L 273.181796 200.288726 
+L 272.268511 201.20062 
+L 271.354813 202.112832 
+L 270.44068 203.025377 
+L 269.526089 203.938269 
+L 268.611014 204.851526 
+L 267.695427 205.765167 
+L 266.779299 206.67921 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_183">
+    <path d="M 249.195923 224.166954 
+L 248.681413 223.303494 
+L 248.143306 222.454539 
+L 247.58201 221.620734 
+L 246.997953 220.802711 
+L 246.391578 220.001092 
+L 245.763345 219.216486 
+L 245.113731 218.449488 
+L 244.443229 217.700681 
+L 243.75235 216.970634 
+L 243.041616 216.2599 
+L 242.311569 215.569021 
+L 241.562762 214.898519 
+L 240.795764 214.248905 
+L 240.011158 213.620672 
+L 239.209539 213.014297 
+L 238.391516 212.43024 
+L 237.557711 211.868944 
+L 236.708756 211.330837 
+L 235.845296 210.816327 
+L 236.774468 209.877047 
+L 237.70221 208.940185 
+L 238.628637 208.005503 
+L 239.553853 207.072793 
+L 240.477951 206.141874 
+L 241.401015 205.212587 
+L 242.323119 204.28479 
+L 243.244332 203.358358 
+L 244.164715 202.433181 
+L 245.084324 201.50916 
+L 246.003209 200.586206 
+L 246.921418 199.664241 
+L 247.838992 198.743192 
+L 248.755969 197.822996 
+L 249.672384 196.903594 
+L 250.588271 195.984935 
+L 251.503658 195.066969 
+L 252.418572 194.149655 
+L 253.33304 193.232951 
+L 254.141152 193.830348 
+L 254.939276 194.441025 
+L 255.727194 195.064815 
+L 256.504691 195.701547 
+L 257.271554 196.351046 
+L 258.027574 197.013137 
+L 258.772543 197.687636 
+L 259.506258 198.374361 
+L 260.228518 199.073123 
+L 260.939127 199.783732 
+L 261.637889 200.505992 
+L 262.324614 201.239707 
+L 262.999113 201.984676 
+L 263.661204 202.740696 
+L 264.310703 203.507559 
+L 264.947435 204.285056 
+L 265.571225 205.072974 
+L 266.181902 205.871098 
+L 266.779299 206.67921 
+L 265.862595 207.593678 
+L 264.945281 208.508592 
+L 264.027315 209.423979 
+L 263.108656 210.339866 
+L 262.189254 211.256281 
+L 261.269058 212.173258 
+L 260.348009 213.090832 
+L 259.426044 214.009041 
+L 258.50309 214.927926 
+L 257.579069 215.847535 
+L 256.653892 216.767918 
+L 255.72746 217.689131 
+L 254.799663 218.611235 
+L 253.870376 219.534299 
+L 252.939457 220.458397 
+L 252.006747 221.383613 
+L 251.072065 222.31004 
+L 250.135203 223.237782 
+L 249.195923 224.166954 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_184">
+    <path d="M 270.645571 175.89724 
+L 269.856409 175.275493 
+L 269.059959 174.663109 
+L 268.256333 174.060175 
+L 267.445642 173.466773 
+L 266.627999 172.882987 
+L 265.803518 172.308899 
+L 264.972315 171.744587 
+L 264.134505 171.190132 
+L 263.290206 170.64561 
+L 262.439534 170.111098 
+L 261.582609 169.58667 
+L 260.71955 169.072398 
+L 259.850478 168.568355 
+L 258.975513 168.074612 
+L 258.094778 167.591236 
+L 257.208396 167.118296 
+L 256.31649 166.655857 
+L 255.419185 166.203984 
+L 254.516606 165.76274 
+L 255.458398 164.799434 
+L 256.399231 163.838058 
+L 257.339136 162.878528 
+L 258.278141 161.920763 
+L 259.216274 160.96469 
+L 260.153562 160.010238 
+L 261.090029 159.057341 
+L 262.0257 158.105936 
+L 262.960599 157.155964 
+L 263.894748 156.207368 
+L 264.828168 155.260097 
+L 265.76088 154.3141 
+L 266.692903 153.369331 
+L 267.624257 152.425743 
+L 268.55496 151.483295 
+L 269.485029 150.541946 
+L 270.414481 149.601659 
+L 271.343331 148.662396 
+L 272.271597 147.724123 
+L 273.139005 148.230247 
+L 274.001727 148.744318 
+L 274.85969 149.266292 
+L 275.712823 149.796125 
+L 276.561052 150.333772 
+L 277.404307 150.879188 
+L 278.242517 151.432328 
+L 279.075609 151.993143 
+L 279.903516 152.561588 
+L 280.726165 153.137613 
+L 281.543489 153.721171 
+L 282.355418 154.312212 
+L 283.161883 154.910687 
+L 283.962817 155.516544 
+L 284.758152 156.129733 
+L 285.547821 156.750202 
+L 286.331756 157.377898 
+L 287.109893 158.012769 
+L 287.882165 158.654761 
+L 286.976333 159.56069 
+L 286.070363 160.466773 
+L 285.164256 161.373014 
+L 284.258008 162.279415 
+L 283.351618 163.185979 
+L 282.445083 164.09271 
+L 281.5384 164.99961 
+L 280.631567 165.906684 
+L 279.724582 166.813935 
+L 278.817441 167.721368 
+L 277.910142 168.628986 
+L 277.00268 169.536794 
+L 276.095052 170.444798 
+L 275.187254 171.353002 
+L 274.279283 172.261412 
+L 273.371134 173.170035 
+L 272.462802 174.078875 
+L 271.554283 174.987941 
+L 270.645571 175.89724 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_185">
+    <path d="M 253.33304 193.232951 
+L 252.515161 192.648997 
+L 251.687739 192.078645 
+L 250.850999 191.522052 
+L 250.005172 190.979369 
+L 249.150487 190.450746 
+L 248.287179 189.936326 
+L 247.415483 189.43625 
+L 246.535639 188.950655 
+L 245.647886 188.479674 
+L 244.752467 188.023435 
+L 243.849627 187.582064 
+L 242.939613 187.15568 
+L 242.022673 186.744401 
+L 241.099059 186.348338 
+L 240.169023 185.967601 
+L 239.232818 185.602293 
+L 238.290702 185.252514 
+L 237.342931 184.91836 
+L 236.389765 184.599921 
+L 237.357465 183.572869 
+L 238.323346 182.551189 
+L 239.287466 181.53455 
+L 240.249884 180.522647 
+L 241.210656 179.515198 
+L 242.169837 178.511944 
+L 243.127482 177.512646 
+L 244.083642 176.517082 
+L 245.038367 175.525047 
+L 245.991707 174.536349 
+L 246.943708 173.550812 
+L 247.894416 172.568272 
+L 248.843874 171.588576 
+L 249.792124 170.61158 
+L 250.739206 169.637152 
+L 251.685159 168.665166 
+L 252.63002 167.695507 
+L 253.573824 166.728066 
+L 254.516606 165.76274 
+L 255.419185 166.203984 
+L 256.31649 166.655857 
+L 257.208396 167.118296 
+L 258.094778 167.591236 
+L 258.975513 168.074612 
+L 259.850478 168.568355 
+L 260.71955 169.072398 
+L 261.582609 169.58667 
+L 262.439534 170.111098 
+L 263.290206 170.64561 
+L 264.134505 171.190132 
+L 264.972315 171.744587 
+L 265.803518 172.308899 
+L 266.627999 172.882987 
+L 267.445642 173.466773 
+L 268.256333 174.060175 
+L 269.059959 174.663109 
+L 269.856409 175.275493 
+L 270.645571 175.89724 
+L 269.73666 176.806779 
+L 268.827545 177.716567 
+L 267.91822 178.626612 
+L 267.008677 179.536925 
+L 266.09891 180.447515 
+L 265.18891 181.358394 
+L 264.278669 182.269573 
+L 263.368179 183.181065 
+L 262.45743 184.092884 
+L 261.546412 185.005044 
+L 260.635114 185.917562 
+L 259.723524 186.830454 
+L 258.81163 187.743739 
+L 257.899418 188.657437 
+L 256.986873 189.57157 
+L 256.073981 190.486161 
+L 255.160724 191.401236 
+L 254.247083 192.316823 
+L 253.33304 193.232951 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_186">
+    <path d="M 235.845296 210.816327 
+L 234.967987 210.325804 
+L 234.077495 209.859641 
+L 233.174496 209.418192 
+L 232.259677 209.001792 
+L 231.333731 208.610757 
+L 230.397362 208.245385 
+L 229.451281 207.905952 
+L 228.496206 207.592717 
+L 227.532863 207.305918 
+L 226.561983 207.045771 
+L 225.584304 206.812475 
+L 224.600567 206.606207 
+L 223.61152 206.427124 
+L 222.617915 206.275361 
+L 221.620505 206.151034 
+L 220.620048 206.054237 
+L 219.617304 205.985044 
+L 218.613033 205.943507 
+L 217.608 205.929658 
+L 218.613034 204.663525 
+L 219.6174 203.422418 
+L 220.620597 202.203936 
+L 221.622251 201.005964 
+L 222.62209 199.826633 
+L 223.619919 198.664289 
+L 224.615606 197.517461 
+L 225.609064 196.38484 
+L 226.600244 195.265254 
+L 227.589125 194.157656 
+L 228.575708 193.061104 
+L 229.560011 191.974752 
+L 230.542063 190.897835 
+L 231.521906 189.829661 
+L 232.499586 188.769606 
+L 233.475155 187.717099 
+L 234.448669 186.671624 
+L 235.420186 185.632708 
+L 236.389765 184.599921 
+L 237.342931 184.91836 
+L 238.290702 185.252514 
+L 239.232818 185.602293 
+L 240.169023 185.967601 
+L 241.099059 186.348338 
+L 242.022673 186.744401 
+L 242.939613 187.15568 
+L 243.849627 187.582064 
+L 244.752467 188.023435 
+L 245.647886 188.479674 
+L 246.535639 188.950655 
+L 247.415483 189.43625 
+L 248.287179 189.936326 
+L 249.150487 190.450746 
+L 250.005172 190.979369 
+L 250.850999 191.522052 
+L 251.687739 192.078645 
+L 252.515161 192.648997 
+L 253.33304 193.232951 
+L 252.418572 194.149655 
+L 251.503658 195.066969 
+L 250.588271 195.984935 
+L 249.672384 196.903594 
+L 248.755969 197.822996 
+L 247.838992 198.743192 
+L 246.921418 199.664241 
+L 246.003209 200.586206 
+L 245.084324 201.50916 
+L 244.164715 202.433181 
+L 243.244332 203.358358 
+L 242.323119 204.28479 
+L 241.401015 205.212587 
+L 240.477951 206.141874 
+L 239.553853 207.072793 
+L 238.628637 208.005503 
+L 237.70221 208.940185 
+L 236.774468 209.877047 
+L 235.845296 210.816327 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_187">
+    <path d="M 229.767389 242.40425 
+L 231.009709 241.399931 
+L 232.190081 240.399989 
+L 233.323665 239.406327 
+L 234.42116 238.419458 
+L 235.490298 237.439254 
+L 236.536786 236.465305 
+L 237.564921 235.497092 
+L 238.577992 234.53408 
+L 239.578556 233.575754 
+L 240.568629 232.62164 
+L 241.549819 231.671309 
+L 242.523425 230.724378 
+L 243.490506 229.780508 
+L 244.451934 228.839398 
+L 245.408432 227.900782 
+L 246.360607 226.964426 
+L 247.308969 226.030122 
+L 248.253951 225.097686 
+L 249.195923 224.166954 
+L 249.686446 225.044263 
+L 250.152609 225.934755 
+L 250.594058 226.837754 
+L 251.010458 227.752573 
+L 251.401493 228.678519 
+L 251.766865 229.614888 
+L 252.106298 230.560969 
+L 252.419533 231.516044 
+L 252.706332 232.479387 
+L 252.966479 233.450267 
+L 253.199775 234.427946 
+L 253.406043 235.411683 
+L 253.585126 236.40073 
+L 253.736889 237.394335 
+L 253.861216 238.391745 
+L 253.958013 239.392202 
+L 254.027206 240.394946 
+L 254.068743 241.399217 
+L 254.082592 242.40425 
+L 254.068743 243.409283 
+L 254.027206 244.413554 
+L 253.958013 245.416298 
+L 253.861216 246.416755 
+L 253.736889 247.414165 
+L 253.585126 248.40777 
+L 253.406043 249.396817 
+L 253.199775 250.380554 
+L 252.966479 251.358233 
+L 252.706332 252.329113 
+L 252.419533 253.292456 
+L 252.106298 254.247531 
+L 251.766865 255.193612 
+L 251.401493 256.129981 
+L 251.010458 257.055927 
+L 250.594058 257.970746 
+L 250.152609 258.873745 
+L 249.686446 259.764237 
+L 249.195923 260.641546 
+L 248.253951 259.710814 
+L 247.308969 258.778378 
+L 246.360607 257.844074 
+L 245.408432 256.907718 
+L 244.451934 255.969102 
+L 243.490506 255.027992 
+L 242.523425 254.084122 
+L 241.549819 253.137191 
+L 240.568629 252.18686 
+L 239.578556 251.232746 
+L 238.577992 250.27442 
+L 237.564921 249.311408 
+L 236.536786 248.343195 
+L 235.490298 247.369246 
+L 234.42116 246.389042 
+L 233.323665 245.402173 
+L 232.190081 244.408511 
+L 231.009709 243.408569 
+L 229.767389 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_188">
+    <path d="M 217.608 254.563639 
+L 218.612114 254.522108 
+L 219.60937 254.397801 
+L 220.592953 254.191565 
+L 221.556147 253.90481 
+L 222.492371 253.539494 
+L 223.395229 253.098113 
+L 224.258555 252.583683 
+L 225.076451 251.999716 
+L 225.84333 251.350203 
+L 226.553953 250.63958 
+L 227.203466 249.872701 
+L 227.787433 249.054805 
+L 228.301863 248.191479 
+L 228.743244 247.288621 
+L 229.10856 246.352397 
+L 229.395315 245.389203 
+L 229.601551 244.40562 
+L 229.725858 243.408364 
+L 229.767389 242.40425 
+L 231.009709 243.408569 
+L 232.190081 244.408511 
+L 233.323665 245.402173 
+L 234.42116 246.389042 
+L 235.490298 247.369246 
+L 236.536786 248.343195 
+L 237.564921 249.311408 
+L 238.577992 250.27442 
+L 239.578556 251.232746 
+L 240.568629 252.18686 
+L 241.549819 253.137191 
+L 242.523425 254.084122 
+L 243.490506 255.027992 
+L 244.451934 255.969102 
+L 245.408432 256.907718 
+L 246.360607 257.844074 
+L 247.308969 258.778378 
+L 248.253951 259.710814 
+L 249.195923 260.641546 
+L 248.681413 261.505006 
+L 248.143306 262.353961 
+L 247.58201 263.187766 
+L 246.997953 264.005789 
+L 246.391578 264.807408 
+L 245.763345 265.592014 
+L 245.113731 266.359012 
+L 244.443229 267.107819 
+L 243.75235 267.837866 
+L 243.041616 268.5486 
+L 242.311569 269.239479 
+L 241.562762 269.909981 
+L 240.795764 270.559595 
+L 240.011158 271.187828 
+L 239.209539 271.794203 
+L 238.391516 272.37826 
+L 237.557711 272.939556 
+L 236.708756 273.477663 
+L 235.845296 273.992173 
+L 234.914564 273.050201 
+L 233.982128 272.105219 
+L 233.047824 271.156857 
+L 232.111468 270.204682 
+L 231.172852 269.248184 
+L 230.231742 268.286756 
+L 229.287872 267.319675 
+L 228.340941 266.346069 
+L 227.39061 265.364879 
+L 226.436496 264.374806 
+L 225.47817 263.374242 
+L 224.515158 262.361171 
+L 223.546945 261.333036 
+L 222.572996 260.286548 
+L 221.592792 259.21741 
+L 220.605923 258.119915 
+L 219.612261 256.986331 
+L 218.612319 255.805959 
+L 217.608 254.563639 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_189">
+    <path d="M 217.608 254.563639 
+L 218.612319 255.805959 
+L 219.612261 256.986331 
+L 220.605923 258.119915 
+L 221.592792 259.21741 
+L 222.572996 260.286548 
+L 223.546945 261.333036 
+L 224.515158 262.361171 
+L 225.47817 263.374242 
+L 226.436496 264.374806 
+L 227.39061 265.364879 
+L 228.340941 266.346069 
+L 229.287872 267.319675 
+L 230.231742 268.286756 
+L 231.172852 269.248184 
+L 232.111468 270.204682 
+L 233.047824 271.156857 
+L 233.982128 272.105219 
+L 234.914564 273.050201 
+L 235.845296 273.992173 
+L 234.967987 274.482696 
+L 234.077495 274.948859 
+L 233.174496 275.390308 
+L 232.259677 275.806708 
+L 231.333731 276.197743 
+L 230.397362 276.563115 
+L 229.451281 276.902548 
+L 228.496206 277.215783 
+L 227.532863 277.502582 
+L 226.561983 277.762729 
+L 225.584304 277.996025 
+L 224.600567 278.202293 
+L 223.61152 278.381376 
+L 222.617915 278.533139 
+L 221.620505 278.657466 
+L 220.620048 278.754263 
+L 219.617304 278.823456 
+L 218.613033 278.864993 
+L 217.608 278.878842 
+L 216.602967 278.864993 
+L 215.598696 278.823456 
+L 214.595952 278.754263 
+L 213.595495 278.657466 
+L 212.598085 278.533139 
+L 211.60448 278.381376 
+L 210.615433 278.202293 
+L 209.631696 277.996025 
+L 208.654017 277.762729 
+L 207.683137 277.502582 
+L 206.719794 277.215783 
+L 205.764719 276.902548 
+L 204.818638 276.563115 
+L 203.882269 276.197743 
+L 202.956323 275.806708 
+L 202.041504 275.390308 
+L 201.138505 274.948859 
+L 200.248013 274.482696 
+L 199.370704 273.992173 
+L 200.301436 273.050201 
+L 201.233872 272.105219 
+L 202.168176 271.156857 
+L 203.104532 270.204682 
+L 204.043148 269.248184 
+L 204.984258 268.286756 
+L 205.928128 267.319675 
+L 206.875059 266.346069 
+L 207.82539 265.364879 
+L 208.779504 264.374806 
+L 209.73783 263.374242 
+L 210.700842 262.361171 
+L 211.669055 261.333036 
+L 212.643004 260.286548 
+L 213.623208 259.21741 
+L 214.610077 258.119915 
+L 215.603739 256.986331 
+L 216.603681 255.805959 
+L 217.608 254.563639 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_190">
+    <path d="M 229.767389 242.40425 
+L 229.725858 241.400136 
+L 229.601551 240.40288 
+L 229.395315 239.419297 
+L 229.10856 238.456103 
+L 228.743244 237.519879 
+L 228.301863 236.617021 
+L 227.787433 235.753695 
+L 227.203466 234.935799 
+L 226.553953 234.16892 
+L 225.84333 233.458297 
+L 225.076451 232.808784 
+L 224.258555 232.224817 
+L 223.395229 231.710387 
+L 222.492371 231.269006 
+L 221.556147 230.90369 
+L 220.592953 230.616935 
+L 219.60937 230.410699 
+L 218.612114 230.286392 
+L 217.608 230.244861 
+L 218.612319 229.002541 
+L 219.612261 227.822169 
+L 220.605923 226.688585 
+L 221.592792 225.59109 
+L 222.572996 224.521952 
+L 223.546945 223.475464 
+L 224.515158 222.447329 
+L 225.47817 221.434258 
+L 226.436496 220.433694 
+L 227.39061 219.443621 
+L 228.340941 218.462431 
+L 229.287872 217.488825 
+L 230.231742 216.521744 
+L 231.172852 215.560316 
+L 232.111468 214.603818 
+L 233.047824 213.651643 
+L 233.982128 212.703281 
+L 234.914564 211.758299 
+L 235.845296 210.816327 
+L 236.708756 211.330837 
+L 237.557711 211.868944 
+L 238.391516 212.43024 
+L 239.209539 213.014297 
+L 240.011158 213.620672 
+L 240.795764 214.248905 
+L 241.562762 214.898519 
+L 242.311569 215.569021 
+L 243.041616 216.2599 
+L 243.75235 216.970634 
+L 244.443229 217.700681 
+L 245.113731 218.449488 
+L 245.763345 219.216486 
+L 246.391578 220.001092 
+L 246.997953 220.802711 
+L 247.58201 221.620734 
+L 248.143306 222.454539 
+L 248.681413 223.303494 
+L 249.195923 224.166954 
+L 248.253951 225.097686 
+L 247.308969 226.030122 
+L 246.360607 226.964426 
+L 245.408432 227.900782 
+L 244.451934 228.839398 
+L 243.490506 229.780508 
+L 242.523425 230.724378 
+L 241.549819 231.671309 
+L 240.568629 232.62164 
+L 239.578556 233.575754 
+L 238.577992 234.53408 
+L 237.564921 235.497092 
+L 236.536786 236.465305 
+L 235.490298 237.439254 
+L 234.42116 238.419458 
+L 233.323665 239.406327 
+L 232.190081 240.399989 
+L 231.009709 241.399931 
+L 229.767389 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_191">
+    <path d="M 229.767389 242.40425 
+L 229.725858 243.408364 
+L 229.601551 244.40562 
+L 229.395315 245.389203 
+L 229.10856 246.352397 
+L 228.743244 247.288621 
+L 228.301863 248.191479 
+L 227.787433 249.054805 
+L 227.203466 249.872701 
+L 226.553953 250.63958 
+L 225.84333 251.350203 
+L 225.076451 251.999716 
+L 224.258555 252.583683 
+L 223.395229 253.098113 
+L 222.492371 253.539494 
+L 221.556147 253.90481 
+L 220.592953 254.191565 
+L 219.60937 254.397801 
+L 218.612114 254.522108 
+L 217.608 254.563639 
+L 216.603886 254.522108 
+L 215.60663 254.397801 
+L 214.623047 254.191565 
+L 213.659853 253.90481 
+L 212.723629 253.539494 
+L 211.820771 253.098113 
+L 210.957445 252.583683 
+L 210.139549 251.999716 
+L 209.37267 251.350203 
+L 208.662047 250.63958 
+L 208.012534 249.872701 
+L 207.428567 249.054805 
+L 206.914137 248.191479 
+L 206.472756 247.288621 
+L 206.10744 246.352397 
+L 205.820685 245.389203 
+L 205.614449 244.40562 
+L 205.490142 243.408364 
+L 205.448611 242.40425 
+L 205.490142 241.400136 
+L 205.614449 240.40288 
+L 205.820685 239.419297 
+L 206.10744 238.456103 
+L 206.472756 237.519879 
+L 206.914137 236.617021 
+L 207.428567 235.753695 
+L 208.012534 234.935799 
+L 208.662047 234.16892 
+L 209.37267 233.458297 
+L 210.139549 232.808784 
+L 210.957445 232.224817 
+L 211.820771 231.710387 
+L 212.723629 231.269006 
+L 213.659853 230.90369 
+L 214.623047 230.616935 
+L 215.60663 230.410699 
+L 216.603886 230.286392 
+L 217.608 230.244861 
+L 218.612114 230.286392 
+L 219.60937 230.410699 
+L 220.592953 230.616935 
+L 221.556147 230.90369 
+L 222.492371 231.269006 
+L 223.395229 231.710387 
+L 224.258555 232.224817 
+L 225.076451 232.808784 
+L 225.84333 233.458297 
+L 226.553953 234.16892 
+L 227.203466 234.935799 
+L 227.787433 235.753695 
+L 228.301863 236.617021 
+L 228.743244 237.519879 
+L 229.10856 238.456103 
+L 229.395315 239.419297 
+L 229.601551 240.40288 
+L 229.725858 241.400136 
+L 229.767389 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_192">
+    <path d="M 205.448611 242.40425 
+L 205.490142 243.408364 
+L 205.614449 244.40562 
+L 205.820685 245.389203 
+L 206.10744 246.352397 
+L 206.472756 247.288621 
+L 206.914137 248.191479 
+L 207.428567 249.054805 
+L 208.012534 249.872701 
+L 208.662047 250.63958 
+L 209.37267 251.350203 
+L 210.139549 251.999716 
+L 210.957445 252.583683 
+L 211.820771 253.098113 
+L 212.723629 253.539494 
+L 213.659853 253.90481 
+L 214.623047 254.191565 
+L 215.60663 254.397801 
+L 216.603886 254.522108 
+L 217.608 254.563639 
+L 216.603681 255.805959 
+L 215.603739 256.986331 
+L 214.610077 258.119915 
+L 213.623208 259.21741 
+L 212.643004 260.286548 
+L 211.669055 261.333036 
+L 210.700842 262.361171 
+L 209.73783 263.374242 
+L 208.779504 264.374806 
+L 207.82539 265.364879 
+L 206.875059 266.346069 
+L 205.928128 267.319675 
+L 204.984258 268.286756 
+L 204.043148 269.248184 
+L 203.104532 270.204682 
+L 202.168176 271.156857 
+L 201.233872 272.105219 
+L 200.301436 273.050201 
+L 199.370704 273.992173 
+L 198.507244 273.477663 
+L 197.658289 272.939556 
+L 196.824484 272.37826 
+L 196.006461 271.794203 
+L 195.204842 271.187828 
+L 194.420236 270.559595 
+L 193.653238 269.909981 
+L 192.904431 269.239479 
+L 192.174384 268.5486 
+L 191.46365 267.837866 
+L 190.772771 267.107819 
+L 190.102269 266.359012 
+L 189.452655 265.592014 
+L 188.824422 264.807408 
+L 188.218047 264.005789 
+L 187.63399 263.187766 
+L 187.072694 262.353961 
+L 186.534587 261.505006 
+L 186.020077 260.641546 
+L 186.962049 259.710814 
+L 187.907031 258.778378 
+L 188.855393 257.844074 
+L 189.807568 256.907718 
+L 190.764066 255.969102 
+L 191.725494 255.027992 
+L 192.692575 254.084122 
+L 193.666181 253.137191 
+L 194.647371 252.18686 
+L 195.637444 251.232746 
+L 196.638008 250.27442 
+L 197.651079 249.311408 
+L 198.679214 248.343195 
+L 199.725702 247.369246 
+L 200.79484 246.389042 
+L 201.892335 245.402173 
+L 203.025919 244.408511 
+L 204.206291 243.408569 
+L 205.448611 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_193">
+    <path d="M 217.608 230.244861 
+L 216.603681 229.002541 
+L 215.603739 227.822169 
+L 214.610077 226.688585 
+L 213.623208 225.59109 
+L 212.643004 224.521952 
+L 211.669055 223.475464 
+L 210.700842 222.447329 
+L 209.73783 221.434258 
+L 208.779504 220.433694 
+L 207.82539 219.443621 
+L 206.875059 218.462431 
+L 205.928128 217.488825 
+L 204.984258 216.521744 
+L 204.043148 215.560316 
+L 203.104532 214.603818 
+L 202.168176 213.651643 
+L 201.233872 212.703281 
+L 200.301436 211.758299 
+L 199.370704 210.816327 
+L 200.248013 210.325804 
+L 201.138505 209.859641 
+L 202.041504 209.418192 
+L 202.956323 209.001792 
+L 203.882269 208.610757 
+L 204.818638 208.245385 
+L 205.764719 207.905952 
+L 206.719794 207.592717 
+L 207.683137 207.305918 
+L 208.654017 207.045771 
+L 209.631696 206.812475 
+L 210.615433 206.606207 
+L 211.60448 206.427124 
+L 212.598085 206.275361 
+L 213.595495 206.151034 
+L 214.595952 206.054237 
+L 215.598696 205.985044 
+L 216.602967 205.943507 
+L 217.608 205.929658 
+L 218.613033 205.943507 
+L 219.617304 205.985044 
+L 220.620048 206.054237 
+L 221.620505 206.151034 
+L 222.617915 206.275361 
+L 223.61152 206.427124 
+L 224.600567 206.606207 
+L 225.584304 206.812475 
+L 226.561983 207.045771 
+L 227.532863 207.305918 
+L 228.496206 207.592717 
+L 229.451281 207.905952 
+L 230.397362 208.245385 
+L 231.333731 208.610757 
+L 232.259677 209.001792 
+L 233.174496 209.418192 
+L 234.077495 209.859641 
+L 234.967987 210.325804 
+L 235.845296 210.816327 
+L 234.914564 211.758299 
+L 233.982128 212.703281 
+L 233.047824 213.651643 
+L 232.111468 214.603818 
+L 231.172852 215.560316 
+L 230.231742 216.521744 
+L 229.287872 217.488825 
+L 228.340941 218.462431 
+L 227.39061 219.443621 
+L 226.436496 220.433694 
+L 225.47817 221.434258 
+L 224.515158 222.447329 
+L 223.546945 223.475464 
+L 222.572996 224.521952 
+L 221.592792 225.59109 
+L 220.605923 226.688585 
+L 219.612261 227.822169 
+L 218.612319 229.002541 
+L 217.608 230.244861 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_194">
+    <path d="M 217.608 230.244861 
+L 216.603886 230.286392 
+L 215.60663 230.410699 
+L 214.623047 230.616935 
+L 213.659853 230.90369 
+L 212.723629 231.269006 
+L 211.820771 231.710387 
+L 210.957445 232.224817 
+L 210.139549 232.808784 
+L 209.37267 233.458297 
+L 208.662047 234.16892 
+L 208.012534 234.935799 
+L 207.428567 235.753695 
+L 206.914137 236.617021 
+L 206.472756 237.519879 
+L 206.10744 238.456103 
+L 205.820685 239.419297 
+L 205.614449 240.40288 
+L 205.490142 241.400136 
+L 205.448611 242.40425 
+L 204.206291 241.399931 
+L 203.025919 240.399989 
+L 201.892335 239.406327 
+L 200.79484 238.419458 
+L 199.725702 237.439254 
+L 198.679214 236.465305 
+L 197.651079 235.497092 
+L 196.638008 234.53408 
+L 195.637444 233.575754 
+L 194.647371 232.62164 
+L 193.666181 231.671309 
+L 192.692575 230.724378 
+L 191.725494 229.780508 
+L 190.764066 228.839398 
+L 189.807568 227.900782 
+L 188.855393 226.964426 
+L 187.907031 226.030122 
+L 186.962049 225.097686 
+L 186.020077 224.166954 
+L 186.534587 223.303494 
+L 187.072694 222.454539 
+L 187.63399 221.620734 
+L 188.218047 220.802711 
+L 188.824422 220.001092 
+L 189.452655 219.216486 
+L 190.102269 218.449488 
+L 190.772771 217.700681 
+L 191.46365 216.970634 
+L 192.174384 216.2599 
+L 192.904431 215.569021 
+L 193.653238 214.898519 
+L 194.420236 214.248905 
+L 195.204842 213.620672 
+L 196.006461 213.014297 
+L 196.824484 212.43024 
+L 197.658289 211.868944 
+L 198.507244 211.330837 
+L 199.370704 210.816327 
+L 200.301436 211.758299 
+L 201.233872 212.703281 
+L 202.168176 213.651643 
+L 203.104532 214.603818 
+L 204.043148 215.560316 
+L 204.984258 216.521744 
+L 205.928128 217.488825 
+L 206.875059 218.462431 
+L 207.82539 219.443621 
+L 208.779504 220.433694 
+L 209.73783 221.434258 
+L 210.700842 222.447329 
+L 211.669055 223.475464 
+L 212.643004 224.521952 
+L 213.623208 225.59109 
+L 214.610077 226.688585 
+L 215.603739 227.822169 
+L 216.603681 229.002541 
+L 217.608 230.244861 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_195">
+    <path d="M 205.448611 242.40425 
+L 204.206291 243.408569 
+L 203.025919 244.408511 
+L 201.892335 245.402173 
+L 200.79484 246.389042 
+L 199.725702 247.369246 
+L 198.679214 248.343195 
+L 197.651079 249.311408 
+L 196.638008 250.27442 
+L 195.637444 251.232746 
+L 194.647371 252.18686 
+L 193.666181 253.137191 
+L 192.692575 254.084122 
+L 191.725494 255.027992 
+L 190.764066 255.969102 
+L 189.807568 256.907718 
+L 188.855393 257.844074 
+L 187.907031 258.778378 
+L 186.962049 259.710814 
+L 186.020077 260.641546 
+L 185.529554 259.764237 
+L 185.063391 258.873745 
+L 184.621942 257.970746 
+L 184.205542 257.055927 
+L 183.814507 256.129981 
+L 183.449135 255.193612 
+L 183.109702 254.247531 
+L 182.796467 253.292456 
+L 182.509668 252.329113 
+L 182.249521 251.358233 
+L 182.016225 250.380554 
+L 181.809957 249.396817 
+L 181.630874 248.40777 
+L 181.479111 247.414165 
+L 181.354784 246.416755 
+L 181.257987 245.416298 
+L 181.188794 244.413554 
+L 181.147257 243.409283 
+L 181.133408 242.40425 
+L 181.147257 241.399217 
+L 181.188794 240.394946 
+L 181.257987 239.392202 
+L 181.354784 238.391745 
+L 181.479111 237.394335 
+L 181.630874 236.40073 
+L 181.809957 235.411683 
+L 182.016225 234.427946 
+L 182.249521 233.450267 
+L 182.509668 232.479387 
+L 182.796467 231.516044 
+L 183.109702 230.560969 
+L 183.449135 229.614888 
+L 183.814507 228.678519 
+L 184.205542 227.752573 
+L 184.621942 226.837754 
+L 185.063391 225.934755 
+L 185.529554 225.044263 
+L 186.020077 224.166954 
+L 186.962049 225.097686 
+L 187.907031 226.030122 
+L 188.855393 226.964426 
+L 189.807568 227.900782 
+L 190.764066 228.839398 
+L 191.725494 229.780508 
+L 192.692575 230.724378 
+L 193.666181 231.671309 
+L 194.647371 232.62164 
+L 195.637444 233.575754 
+L 196.638008 234.53408 
+L 197.651079 235.497092 
+L 198.679214 236.465305 
+L 199.725702 237.439254 
+L 200.79484 238.419458 
+L 201.892335 239.406327 
+L 203.025919 240.399989 
+L 204.206291 241.399931 
+L 205.448611 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_196">
+    <path d="M 199.370704 273.992173 
+L 200.248013 274.482696 
+L 201.138505 274.948859 
+L 202.041504 275.390308 
+L 202.956323 275.806708 
+L 203.882269 276.197743 
+L 204.818638 276.563115 
+L 205.764719 276.902548 
+L 206.719794 277.215783 
+L 207.683137 277.502582 
+L 208.654017 277.762729 
+L 209.631696 277.996025 
+L 210.615433 278.202293 
+L 211.60448 278.381376 
+L 212.598085 278.533139 
+L 213.595495 278.657466 
+L 214.595952 278.754263 
+L 215.598696 278.823456 
+L 216.602967 278.864993 
+L 217.608 278.878842 
+L 216.602966 280.144975 
+L 215.5986 281.386082 
+L 214.595403 282.604564 
+L 213.593749 283.802536 
+L 212.59391 284.981867 
+L 211.596081 286.144211 
+L 210.600394 287.291039 
+L 209.606936 288.42366 
+L 208.615756 289.543246 
+L 207.626875 290.650844 
+L 206.640292 291.747396 
+L 205.655989 292.833748 
+L 204.673937 293.910665 
+L 203.694094 294.978839 
+L 202.716414 296.038894 
+L 201.740845 297.091401 
+L 200.767331 298.136876 
+L 199.795814 299.175792 
+L 198.826235 300.208579 
+L 197.873069 299.89014 
+L 196.925298 299.555986 
+L 195.983182 299.206207 
+L 195.046977 298.840899 
+L 194.116941 298.460162 
+L 193.193327 298.064099 
+L 192.276387 297.65282 
+L 191.366373 297.226436 
+L 190.463533 296.785065 
+L 189.568114 296.328826 
+L 188.680361 295.857845 
+L 187.800517 295.37225 
+L 186.928821 294.872174 
+L 186.065513 294.357754 
+L 185.210828 293.829131 
+L 184.365001 293.286448 
+L 183.528261 292.729855 
+L 182.700839 292.159503 
+L 181.88296 291.575549 
+L 182.797428 290.658845 
+L 183.712342 289.741531 
+L 184.627729 288.823565 
+L 185.543616 287.904906 
+L 186.460031 286.985504 
+L 187.377008 286.065308 
+L 188.294582 285.144259 
+L 189.212791 284.222294 
+L 190.131676 283.29934 
+L 191.051285 282.375319 
+L 191.971668 281.450142 
+L 192.892881 280.52371 
+L 193.814985 279.595913 
+L 194.738049 278.666626 
+L 195.662147 277.735707 
+L 196.587363 276.802997 
+L 197.51379 275.868315 
+L 198.441532 274.931453 
+L 199.370704 273.992173 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_197">
+    <path d="M 181.88296 291.575549 
+L 182.700839 292.159503 
+L 183.528261 292.729855 
+L 184.365001 293.286448 
+L 185.210828 293.829131 
+L 186.065513 294.357754 
+L 186.928821 294.872174 
+L 187.800517 295.37225 
+L 188.680361 295.857845 
+L 189.568114 296.328826 
+L 190.463533 296.785065 
+L 191.366373 297.226436 
+L 192.276387 297.65282 
+L 193.193327 298.064099 
+L 194.116941 298.460162 
+L 195.046977 298.840899 
+L 195.983182 299.206207 
+L 196.925298 299.555986 
+L 197.873069 299.89014 
+L 198.826235 300.208579 
+L 197.858535 301.235631 
+L 196.892654 302.257311 
+L 195.928534 303.27395 
+L 194.966116 304.285853 
+L 194.005344 305.293302 
+L 193.046163 306.296556 
+L 192.088518 307.295854 
+L 191.132358 308.291418 
+L 190.177633 309.283453 
+L 189.224293 310.272151 
+L 188.272292 311.257688 
+L 187.321584 312.240228 
+L 186.372126 313.219924 
+L 185.423876 314.19692 
+L 184.476794 315.171348 
+L 183.530841 316.143334 
+L 182.58598 317.112993 
+L 181.642176 318.080434 
+L 180.699394 319.04576 
+L 179.796815 318.604516 
+L 178.89951 318.152643 
+L 178.007604 317.690204 
+L 177.121222 317.217264 
+L 176.240487 316.733888 
+L 175.365522 316.240145 
+L 174.49645 315.736102 
+L 173.633391 315.22183 
+L 172.776466 314.697402 
+L 171.925794 314.16289 
+L 171.081495 313.618368 
+L 170.243685 313.063913 
+L 169.412482 312.499601 
+L 168.588001 311.925513 
+L 167.770358 311.341727 
+L 166.959667 310.748325 
+L 166.156041 310.145391 
+L 165.359591 309.533007 
+L 164.570429 308.91126 
+L 165.47934 308.001721 
+L 166.388455 307.091933 
+L 167.29778 306.181888 
+L 168.207323 305.271575 
+L 169.11709 304.360985 
+L 170.02709 303.450106 
+L 170.937331 302.538927 
+L 171.847821 301.627435 
+L 172.75857 300.715616 
+L 173.669588 299.803456 
+L 174.580886 298.890938 
+L 175.492476 297.978046 
+L 176.40437 297.064761 
+L 177.316582 296.151063 
+L 178.229127 295.23693 
+L 179.142019 294.322339 
+L 180.055276 293.407264 
+L 180.968917 292.491677 
+L 181.88296 291.575549 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_198">
+    <path d="M 164.570429 308.91126 
+L 165.359591 309.533007 
+L 166.156041 310.145391 
+L 166.959667 310.748325 
+L 167.770358 311.341727 
+L 168.588001 311.925513 
+L 169.412482 312.499601 
+L 170.243685 313.063913 
+L 171.081495 313.618368 
+L 171.925794 314.16289 
+L 172.776466 314.697402 
+L 173.633391 315.22183 
+L 174.49645 315.736102 
+L 175.365522 316.240145 
+L 176.240487 316.733888 
+L 177.121222 317.217264 
+L 178.007604 317.690204 
+L 178.89951 318.152643 
+L 179.796815 318.604516 
+L 180.699394 319.04576 
+L 179.757602 320.009066 
+L 178.816769 320.970442 
+L 177.876864 321.929972 
+L 176.937859 322.887737 
+L 175.999726 323.84381 
+L 175.062438 324.798262 
+L 174.125971 325.751159 
+L 173.1903 326.702564 
+L 172.255401 327.652536 
+L 171.321252 328.601132 
+L 170.387832 329.548403 
+L 169.45512 330.4944 
+L 168.523097 331.439169 
+L 167.591743 332.382757 
+L 166.66104 333.325205 
+L 165.730971 334.266554 
+L 164.801519 335.206841 
+L 163.872669 336.146104 
+L 162.944403 337.084377 
+L 162.076995 336.578253 
+L 161.214273 336.064182 
+L 160.35631 335.542208 
+L 159.503177 335.012375 
+L 158.654948 334.474728 
+L 157.811693 333.929312 
+L 156.973483 333.376172 
+L 156.140391 332.815357 
+L 155.312484 332.246912 
+L 154.489835 331.670887 
+L 153.672511 331.087329 
+L 152.860582 330.496288 
+L 152.054117 329.897813 
+L 151.253183 329.291956 
+L 150.457848 328.678767 
+L 149.668179 328.058298 
+L 148.884244 327.430602 
+L 148.106107 326.795731 
+L 147.333835 326.153739 
+L 148.239667 325.24781 
+L 149.145637 324.341727 
+L 150.051744 323.435486 
+L 150.957992 322.529085 
+L 151.864382 321.622521 
+L 152.770917 320.71579 
+L 153.6776 319.80889 
+L 154.584433 318.901816 
+L 155.491418 317.994565 
+L 156.398559 317.087132 
+L 157.305858 316.179514 
+L 158.21332 315.271706 
+L 159.120948 314.363702 
+L 160.028746 313.455498 
+L 160.936717 312.547088 
+L 161.844866 311.638465 
+L 162.753198 310.729625 
+L 163.661717 309.820559 
+L 164.570429 308.91126 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_199">
+    <path d="M 186.020077 260.641546 
+L 186.534587 261.505006 
+L 187.072694 262.353961 
+L 187.63399 263.187766 
+L 188.218047 264.005789 
+L 188.824422 264.807408 
+L 189.452655 265.592014 
+L 190.102269 266.359012 
+L 190.772771 267.107819 
+L 191.46365 267.837866 
+L 192.174384 268.5486 
+L 192.904431 269.239479 
+L 193.653238 269.909981 
+L 194.420236 270.559595 
+L 195.204842 271.187828 
+L 196.006461 271.794203 
+L 196.824484 272.37826 
+L 197.658289 272.939556 
+L 198.507244 273.477663 
+L 199.370704 273.992173 
+L 198.441532 274.931453 
+L 197.51379 275.868315 
+L 196.587363 276.802997 
+L 195.662147 277.735707 
+L 194.738049 278.666626 
+L 193.814985 279.595913 
+L 192.892881 280.52371 
+L 191.971668 281.450142 
+L 191.051285 282.375319 
+L 190.131676 283.29934 
+L 189.212791 284.222294 
+L 188.294582 285.144259 
+L 187.377008 286.065308 
+L 186.460031 286.985504 
+L 185.543616 287.904906 
+L 184.627729 288.823565 
+L 183.712342 289.741531 
+L 182.797428 290.658845 
+L 181.88296 291.575549 
+L 181.074848 290.978152 
+L 180.276724 290.367475 
+L 179.488806 289.743685 
+L 178.711309 289.106953 
+L 177.944446 288.457454 
+L 177.188426 287.795363 
+L 176.443457 287.120864 
+L 175.709742 286.434139 
+L 174.987482 285.735377 
+L 174.276873 285.024768 
+L 173.578111 284.302508 
+L 172.891386 283.568793 
+L 172.216887 282.823824 
+L 171.554796 282.067804 
+L 170.905297 281.300941 
+L 170.268565 280.523444 
+L 169.644775 279.735526 
+L 169.034098 278.937402 
+L 168.436701 278.12929 
+L 169.353405 277.214822 
+L 170.270719 276.299908 
+L 171.188685 275.384521 
+L 172.107344 274.468634 
+L 173.026746 273.552219 
+L 173.946942 272.635242 
+L 174.867991 271.717668 
+L 175.789956 270.799459 
+L 176.71291 269.880574 
+L 177.636931 268.960965 
+L 178.562108 268.040582 
+L 179.48854 267.119369 
+L 180.416337 266.197265 
+L 181.345624 265.274201 
+L 182.276543 264.350103 
+L 183.209253 263.424887 
+L 184.143935 262.49846 
+L 185.080797 261.570718 
+L 186.020077 260.641546 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_200">
+    <path d="M 168.436701 278.12929 
+L 169.034098 278.937402 
+L 169.644775 279.735526 
+L 170.268565 280.523444 
+L 170.905297 281.300941 
+L 171.554796 282.067804 
+L 172.216887 282.823824 
+L 172.891386 283.568793 
+L 173.578111 284.302508 
+L 174.276873 285.024768 
+L 174.987482 285.735377 
+L 175.709742 286.434139 
+L 176.443457 287.120864 
+L 177.188426 287.795363 
+L 177.944446 288.457454 
+L 178.711309 289.106953 
+L 179.488806 289.743685 
+L 180.276724 290.367475 
+L 181.074848 290.978152 
+L 181.88296 291.575549 
+L 180.968917 292.491677 
+L 180.055276 293.407264 
+L 179.142019 294.322339 
+L 178.229127 295.23693 
+L 177.316582 296.151063 
+L 176.40437 297.064761 
+L 175.492476 297.978046 
+L 174.580886 298.890938 
+L 173.669588 299.803456 
+L 172.75857 300.715616 
+L 171.847821 301.627435 
+L 170.937331 302.538927 
+L 170.02709 303.450106 
+L 169.11709 304.360985 
+L 168.207323 305.271575 
+L 167.29778 306.181888 
+L 166.388455 307.091933 
+L 165.47934 308.001721 
+L 164.570429 308.91126 
+L 163.788666 308.280236 
+L 163.014409 307.640023 
+L 162.247768 306.990711 
+L 161.488848 306.33239 
+L 160.737756 305.665151 
+L 159.994597 304.989089 
+L 159.259474 304.304297 
+L 158.53249 303.610871 
+L 157.813746 302.908907 
+L 157.103343 302.198504 
+L 156.401379 301.47976 
+L 155.707953 300.752776 
+L 155.023161 300.017653 
+L 154.347099 299.274494 
+L 153.67986 298.523402 
+L 153.021539 297.764482 
+L 152.372227 296.997841 
+L 151.732014 296.223584 
+L 151.10099 295.441821 
+L 152.010529 294.53291 
+L 152.920317 293.623795 
+L 153.830362 292.71447 
+L 154.740675 291.804927 
+L 155.651265 290.89516 
+L 156.562144 289.98516 
+L 157.473323 289.074919 
+L 158.384815 288.164429 
+L 159.296634 287.25368 
+L 160.208794 286.342662 
+L 161.121312 285.431364 
+L 162.034204 284.519774 
+L 162.947489 283.60788 
+L 163.861187 282.695668 
+L 164.77532 281.783123 
+L 165.689911 280.870231 
+L 166.604986 279.956974 
+L 167.520573 279.043333 
+L 168.436701 278.12929 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_201">
+    <path d="M 151.10099 295.441821 
+L 151.732014 296.223584 
+L 152.372227 296.997841 
+L 153.021539 297.764482 
+L 153.67986 298.523402 
+L 154.347099 299.274494 
+L 155.023161 300.017653 
+L 155.707953 300.752776 
+L 156.401379 301.47976 
+L 157.103343 302.198504 
+L 157.813746 302.908907 
+L 158.53249 303.610871 
+L 159.259474 304.304297 
+L 159.994597 304.989089 
+L 160.737756 305.665151 
+L 161.488848 306.33239 
+L 162.247768 306.990711 
+L 163.014409 307.640023 
+L 163.788666 308.280236 
+L 164.570429 308.91126 
+L 163.661717 309.820559 
+L 162.753198 310.729625 
+L 161.844866 311.638465 
+L 160.936717 312.547088 
+L 160.028746 313.455498 
+L 159.120948 314.363702 
+L 158.21332 315.271706 
+L 157.305858 316.179514 
+L 156.398559 317.087132 
+L 155.491418 317.994565 
+L 154.584433 318.901816 
+L 153.6776 319.80889 
+L 152.770917 320.71579 
+L 151.864382 321.622521 
+L 150.957992 322.529085 
+L 150.051744 323.435486 
+L 149.145637 324.341727 
+L 148.239667 325.24781 
+L 147.333835 326.153739 
+L 146.567492 325.50468 
+L 145.807144 324.848609 
+L 145.052855 324.185582 
+L 144.304688 323.515653 
+L 143.562707 322.83888 
+L 142.826973 322.15532 
+L 142.09755 321.465031 
+L 141.374498 320.768071 
+L 140.657879 320.064498 
+L 139.947752 319.354371 
+L 139.244179 318.637752 
+L 138.547219 317.9147 
+L 137.85693 317.185277 
+L 137.17337 316.449543 
+L 136.496597 315.707562 
+L 135.826668 314.959395 
+L 135.163641 314.205106 
+L 134.50757 313.444758 
+L 133.858511 312.678415 
+L 134.76444 311.772583 
+L 135.670523 310.866613 
+L 136.576764 309.960506 
+L 137.483165 309.054258 
+L 138.389729 308.147868 
+L 139.29646 307.241333 
+L 140.20336 306.33465 
+L 141.110434 305.427817 
+L 142.017685 304.520832 
+L 142.925118 303.613691 
+L 143.832736 302.706392 
+L 144.740544 301.79893 
+L 145.648548 300.891302 
+L 146.556752 299.983504 
+L 147.465162 299.075533 
+L 148.373785 298.167384 
+L 149.282625 297.259052 
+L 150.191691 296.350533 
+L 151.10099 295.441821 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_202">
+    <path d="M 181.133408 242.40425 
+L 181.147257 243.409283 
+L 181.188794 244.413554 
+L 181.257987 245.416298 
+L 181.354784 246.416755 
+L 181.479111 247.414165 
+L 181.630874 248.40777 
+L 181.809957 249.396817 
+L 182.016225 250.380554 
+L 182.249521 251.358233 
+L 182.509668 252.329113 
+L 182.796467 253.292456 
+L 183.109702 254.247531 
+L 183.449135 255.193612 
+L 183.814507 256.129981 
+L 184.205542 257.055927 
+L 184.621942 257.970746 
+L 185.063391 258.873745 
+L 185.529554 259.764237 
+L 186.020077 260.641546 
+L 185.080797 261.570718 
+L 184.143935 262.49846 
+L 183.209253 263.424887 
+L 182.276543 264.350103 
+L 181.345624 265.274201 
+L 180.416337 266.197265 
+L 179.48854 267.119369 
+L 178.562108 268.040582 
+L 177.636931 268.960965 
+L 176.71291 269.880574 
+L 175.789956 270.799459 
+L 174.867991 271.717668 
+L 173.946942 272.635242 
+L 173.026746 273.552219 
+L 172.107344 274.468634 
+L 171.188685 275.384521 
+L 170.270719 276.299908 
+L 169.353405 277.214822 
+L 168.436701 278.12929 
+L 167.852747 277.311411 
+L 167.282395 276.483989 
+L 166.725802 275.647249 
+L 166.183119 274.801422 
+L 165.654496 273.946737 
+L 165.140076 273.083429 
+L 164.64 272.211733 
+L 164.154405 271.331889 
+L 163.683424 270.444136 
+L 163.227185 269.548717 
+L 162.785814 268.645877 
+L 162.35943 267.735863 
+L 161.948151 266.818923 
+L 161.552088 265.895309 
+L 161.171351 264.965273 
+L 160.806043 264.029068 
+L 160.456264 263.086952 
+L 160.12211 262.139181 
+L 159.803671 261.186015 
+L 160.836458 260.216436 
+L 161.875374 259.244919 
+L 162.920849 258.271405 
+L 163.973356 257.295836 
+L 165.033411 256.318156 
+L 166.101585 255.338313 
+L 167.178502 254.356261 
+L 168.264854 253.371958 
+L 169.361406 252.385375 
+L 170.469004 251.396494 
+L 171.58859 250.405314 
+L 172.721211 249.411856 
+L 173.868039 248.416169 
+L 175.030383 247.41834 
+L 176.209714 246.418501 
+L 177.407686 245.416847 
+L 178.626168 244.41365 
+L 179.867275 243.409284 
+L 181.133408 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_203">
+    <path d="M 159.803671 261.186015 
+L 160.12211 262.139181 
+L 160.456264 263.086952 
+L 160.806043 264.029068 
+L 161.171351 264.965273 
+L 161.552088 265.895309 
+L 161.948151 266.818923 
+L 162.35943 267.735863 
+L 162.785814 268.645877 
+L 163.227185 269.548717 
+L 163.683424 270.444136 
+L 164.154405 271.331889 
+L 164.64 272.211733 
+L 165.140076 273.083429 
+L 165.654496 273.946737 
+L 166.183119 274.801422 
+L 166.725802 275.647249 
+L 167.282395 276.483989 
+L 167.852747 277.311411 
+L 168.436701 278.12929 
+L 167.520573 279.043333 
+L 166.604986 279.956974 
+L 165.689911 280.870231 
+L 164.77532 281.783123 
+L 163.861187 282.695668 
+L 162.947489 283.60788 
+L 162.034204 284.519774 
+L 161.121312 285.431364 
+L 160.208794 286.342662 
+L 159.296634 287.25368 
+L 158.384815 288.164429 
+L 157.473323 289.074919 
+L 156.562144 289.98516 
+L 155.651265 290.89516 
+L 154.740675 291.804927 
+L 153.830362 292.71447 
+L 152.920317 293.623795 
+L 152.010529 294.53291 
+L 151.10099 295.441821 
+L 150.479243 294.652659 
+L 149.866859 293.856209 
+L 149.263925 293.052583 
+L 148.670523 292.241892 
+L 148.086737 291.424249 
+L 147.512649 290.599768 
+L 146.948337 289.768565 
+L 146.393882 288.930755 
+L 145.84936 288.086456 
+L 145.314848 287.235784 
+L 144.79042 286.378859 
+L 144.276148 285.5158 
+L 143.772105 284.646728 
+L 143.278362 283.771763 
+L 142.794986 282.891028 
+L 142.322046 282.004646 
+L 141.859607 281.11274 
+L 141.407734 280.215435 
+L 140.96649 279.312856 
+L 141.931816 278.370074 
+L 142.899257 277.42627 
+L 143.868916 276.481409 
+L 144.840902 275.535456 
+L 145.81533 274.588374 
+L 146.792326 273.640124 
+L 147.772022 272.690666 
+L 148.754562 271.739958 
+L 149.740099 270.787957 
+L 150.728797 269.834617 
+L 151.720832 268.879892 
+L 152.716396 267.923732 
+L 153.715694 266.966087 
+L 154.718948 266.006906 
+L 155.726397 265.046134 
+L 156.7383 264.083716 
+L 157.754939 263.119596 
+L 158.776619 262.153715 
+L 159.803671 261.186015 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_204">
+    <path d="M 140.96649 279.312856 
+L 141.407734 280.215435 
+L 141.859607 281.11274 
+L 142.322046 282.004646 
+L 142.794986 282.891028 
+L 143.278362 283.771763 
+L 143.772105 284.646728 
+L 144.276148 285.5158 
+L 144.79042 286.378859 
+L 145.314848 287.235784 
+L 145.84936 288.086456 
+L 146.393882 288.930755 
+L 146.948337 289.768565 
+L 147.512649 290.599768 
+L 148.086737 291.424249 
+L 148.670523 292.241892 
+L 149.263925 293.052583 
+L 149.866859 293.856209 
+L 150.479243 294.652659 
+L 151.10099 295.441821 
+L 150.191691 296.350533 
+L 149.282625 297.259052 
+L 148.373785 298.167384 
+L 147.465162 299.075533 
+L 146.556752 299.983504 
+L 145.648548 300.891302 
+L 144.740544 301.79893 
+L 143.832736 302.706392 
+L 142.925118 303.613691 
+L 142.017685 304.520832 
+L 141.110434 305.427817 
+L 140.20336 306.33465 
+L 139.29646 307.241333 
+L 138.389729 308.147868 
+L 137.483165 309.054258 
+L 136.576764 309.960506 
+L 135.670523 310.866613 
+L 134.76444 311.772583 
+L 133.858511 312.678415 
+L 133.216519 311.906143 
+L 132.581648 311.128006 
+L 131.953952 310.344071 
+L 131.333483 309.554402 
+L 130.720294 308.759067 
+L 130.114437 307.958133 
+L 129.515962 307.151668 
+L 128.924921 306.339739 
+L 128.341363 305.522415 
+L 127.765338 304.699766 
+L 127.196893 303.871859 
+L 126.636078 303.038767 
+L 126.082938 302.200557 
+L 125.537522 301.357302 
+L 124.999875 300.509073 
+L 124.470042 299.65594 
+L 123.948068 298.797977 
+L 123.433997 297.935255 
+L 122.927873 297.067847 
+L 123.866146 296.139581 
+L 124.805409 295.210731 
+L 125.745696 294.281279 
+L 126.687045 293.35121 
+L 127.629493 292.420507 
+L 128.573081 291.489153 
+L 129.51785 290.55713 
+L 130.463847 289.624418 
+L 131.411118 288.690998 
+L 132.359714 287.756849 
+L 133.309686 286.82195 
+L 134.261091 285.886279 
+L 135.213988 284.949812 
+L 136.16844 284.012524 
+L 137.124513 283.074391 
+L 138.082278 282.135386 
+L 139.041808 281.195481 
+L 140.003184 280.254648 
+L 140.96649 279.312856 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_205">
+    <path d="M 254.516606 165.76274 
+L 253.608878 165.332186 
+L 252.696129 164.912383 
+L 251.778486 164.503389 
+L 250.856076 164.105261 
+L 249.929029 163.718054 
+L 248.997473 163.341824 
+L 248.061539 162.976621 
+L 247.121357 162.622497 
+L 246.177058 162.279502 
+L 245.228774 161.947683 
+L 244.276638 161.627087 
+L 243.320781 161.317758 
+L 242.361338 161.01974 
+L 241.398443 160.733073 
+L 240.432229 160.457799 
+L 239.462831 160.193955 
+L 238.490385 159.941578 
+L 237.515026 159.700704 
+L 236.53689 159.471365 
+L 237.520128 158.388375 
+L 238.50199 157.311082 
+L 239.482489 156.239232 
+L 240.461641 155.172587 
+L 241.439461 154.110922 
+L 242.415968 153.054025 
+L 243.39118 152.001696 
+L 244.365116 150.953746 
+L 245.337797 149.909996 
+L 246.309242 148.870277 
+L 247.279473 147.834428 
+L 248.24851 146.802297 
+L 249.216375 145.773741 
+L 250.183088 144.748624 
+L 251.14867 143.726815 
+L 252.113141 142.708191 
+L 253.076524 141.692636 
+L 254.038838 140.680039 
+L 255.000102 139.670293 
+L 255.94222 140.018104 
+L 256.881103 140.374555 
+L 257.816671 140.739615 
+L 258.748848 141.113254 
+L 259.677552 141.49544 
+L 260.602707 141.88614 
+L 261.524233 142.285322 
+L 262.442054 142.692953 
+L 263.356092 143.108997 
+L 264.26627 143.53342 
+L 265.17251 143.966185 
+L 266.074738 144.407257 
+L 266.972875 144.856598 
+L 267.866847 145.31417 
+L 268.756578 145.779935 
+L 269.641993 146.253853 
+L 270.523017 146.735884 
+L 271.399576 147.225988 
+L 272.271597 147.724123 
+L 271.343331 148.662396 
+L 270.414481 149.601659 
+L 269.485029 150.541946 
+L 268.55496 151.483295 
+L 267.624257 152.425743 
+L 266.692903 153.369331 
+L 265.76088 154.3141 
+L 264.828168 155.260097 
+L 263.894748 156.207368 
+L 262.960599 157.155964 
+L 262.0257 158.105936 
+L 261.090029 159.057341 
+L 260.153562 160.010238 
+L 259.216274 160.96469 
+L 258.278141 161.920763 
+L 257.339136 162.878528 
+L 256.399231 163.838058 
+L 255.458398 164.799434 
+L 254.516606 165.76274 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_206">
+    <path d="M 236.389765 184.599921 
+L 235.431464 184.297286 
+L 234.46829 184.010537 
+L 233.500507 183.739752 
+L 232.528379 183.485005 
+L 231.552172 183.246367 
+L 230.572153 183.023901 
+L 229.588589 182.817669 
+L 228.60175 182.627728 
+L 227.611906 182.454129 
+L 226.619326 182.29692 
+L 225.624283 182.156144 
+L 224.627049 182.031839 
+L 223.627895 181.924039 
+L 222.627096 181.832773 
+L 221.624924 181.758068 
+L 220.621654 181.699942 
+L 219.617561 181.658413 
+L 218.612918 181.63349 
+L 217.608 181.625182 
+L 218.612907 180.354569 
+L 219.617537 179.09962 
+L 220.621677 177.859402 
+L 221.625145 176.633054 
+L 222.627792 175.419775 
+L 223.629492 174.218825 
+L 224.630139 173.029516 
+L 225.629648 171.851209 
+L 226.627949 170.683309 
+L 227.624986 169.525263 
+L 228.620715 168.376554 
+L 229.615101 167.236702 
+L 230.608119 166.105256 
+L 231.599751 164.981797 
+L 232.589986 163.865931 
+L 233.578816 162.757289 
+L 234.566241 161.655527 
+L 235.552264 160.560321 
+L 236.53689 159.471365 
+L 237.515026 159.700704 
+L 238.490385 159.941578 
+L 239.462831 160.193955 
+L 240.432229 160.457799 
+L 241.398443 160.733073 
+L 242.361338 161.01974 
+L 243.320781 161.317758 
+L 244.276638 161.627087 
+L 245.228774 161.947683 
+L 246.177058 162.279502 
+L 247.121357 162.622497 
+L 248.061539 162.976621 
+L 248.997473 163.341824 
+L 249.929029 163.718054 
+L 250.856076 164.105261 
+L 251.778486 164.503389 
+L 252.696129 164.912383 
+L 253.608878 165.332186 
+L 254.516606 165.76274 
+L 253.573824 166.728066 
+L 252.63002 167.695507 
+L 251.685159 168.665166 
+L 250.739206 169.637152 
+L 249.792124 170.61158 
+L 248.843874 171.588576 
+L 247.894416 172.568272 
+L 246.943708 173.550812 
+L 245.991707 174.536349 
+L 245.038367 175.525047 
+L 244.083642 176.517082 
+L 243.127482 177.512646 
+L 242.169837 178.511944 
+L 241.210656 179.515198 
+L 240.249884 180.522647 
+L 239.287466 181.53455 
+L 238.323346 182.551189 
+L 237.357465 183.572869 
+L 236.389765 184.599921 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_207">
+    <path d="M 217.608 205.929658 
+L 216.602966 204.663525 
+L 215.5986 203.422418 
+L 214.595403 202.203936 
+L 213.593749 201.005964 
+L 212.59391 199.826633 
+L 211.596081 198.664289 
+L 210.600394 197.517461 
+L 209.606936 196.38484 
+L 208.615756 195.265254 
+L 207.626875 194.157656 
+L 206.640292 193.061104 
+L 205.655989 191.974752 
+L 204.673937 190.897835 
+L 203.694094 189.829661 
+L 202.716414 188.769606 
+L 201.740845 187.717099 
+L 200.767331 186.671624 
+L 199.795814 185.632708 
+L 198.826235 184.599921 
+L 199.784536 184.297286 
+L 200.74771 184.010537 
+L 201.715493 183.739752 
+L 202.687621 183.485005 
+L 203.663828 183.246367 
+L 204.643847 183.023901 
+L 205.627411 182.817669 
+L 206.61425 182.627728 
+L 207.604094 182.454129 
+L 208.596674 182.29692 
+L 209.591717 182.156144 
+L 210.588951 182.031839 
+L 211.588105 181.924039 
+L 212.588904 181.832773 
+L 213.591076 181.758068 
+L 214.594346 181.699942 
+L 215.598439 181.658413 
+L 216.603082 181.63349 
+L 217.608 181.625182 
+L 218.612918 181.63349 
+L 219.617561 181.658413 
+L 220.621654 181.699942 
+L 221.624924 181.758068 
+L 222.627096 181.832773 
+L 223.627895 181.924039 
+L 224.627049 182.031839 
+L 225.624283 182.156144 
+L 226.619326 182.29692 
+L 227.611906 182.454129 
+L 228.60175 182.627728 
+L 229.588589 182.817669 
+L 230.572153 183.023901 
+L 231.552172 183.246367 
+L 232.528379 183.485005 
+L 233.500507 183.739752 
+L 234.46829 184.010537 
+L 235.431464 184.297286 
+L 236.389765 184.599921 
+L 235.420186 185.632708 
+L 234.448669 186.671624 
+L 233.475155 187.717099 
+L 232.499586 188.769606 
+L 231.521906 189.829661 
+L 230.542063 190.897835 
+L 229.560011 191.974752 
+L 228.575708 193.061104 
+L 227.589125 194.157656 
+L 226.600244 195.265254 
+L 225.609064 196.38484 
+L 224.615606 197.517461 
+L 223.619919 198.664289 
+L 222.62209 199.826633 
+L 221.622251 201.005964 
+L 220.620597 202.203936 
+L 219.6174 203.422418 
+L 218.613034 204.663525 
+L 217.608 205.929658 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_208">
+    <path d="M 236.53689 159.471365 
+L 235.556114 159.253595 
+L 234.572834 159.047423 
+L 233.587188 158.852878 
+L 232.599313 158.669987 
+L 231.609347 158.498776 
+L 230.617428 158.339269 
+L 229.623695 158.191488 
+L 228.628285 158.055453 
+L 227.631338 157.931184 
+L 226.632993 157.818697 
+L 225.63339 157.718009 
+L 224.632666 157.629134 
+L 223.630963 157.552083 
+L 222.62842 157.486869 
+L 221.625177 157.433499 
+L 220.621373 157.391981 
+L 219.617149 157.362322 
+L 218.612644 157.344524 
+L 217.608 157.338591 
+L 218.612627 156.066826 
+L 219.617086 154.806478 
+L 220.621259 153.557056 
+L 221.625042 152.318095 
+L 222.628343 151.089155 
+L 223.631081 149.869822 
+L 224.633183 148.659699 
+L 225.634587 147.458414 
+L 226.635239 146.265613 
+L 227.635089 145.080959 
+L 228.634097 143.904134 
+L 229.632227 142.734835 
+L 230.629447 141.572774 
+L 231.625732 140.417678 
+L 232.621059 139.269286 
+L 233.61541 138.12735 
+L 234.608769 136.991636 
+L 235.601125 135.861918 
+L 236.592468 134.737982 
+L 237.580669 134.916913 
+L 238.567185 135.104913 
+L 239.551933 135.301967 
+L 240.534829 135.508058 
+L 241.51579 135.72317 
+L 242.494734 135.947283 
+L 243.471578 136.18038 
+L 244.446239 136.42244 
+L 245.418636 136.673442 
+L 246.388686 136.933366 
+L 247.356308 137.20219 
+L 248.32142 137.479891 
+L 249.283939 137.766446 
+L 250.243787 138.06183 
+L 251.20088 138.366018 
+L 252.155138 138.678986 
+L 253.106482 139.000705 
+L 254.05483 139.33115 
+L 255.000102 139.670293 
+L 254.038838 140.680039 
+L 253.076524 141.692636 
+L 252.113141 142.708191 
+L 251.14867 143.726815 
+L 250.183088 144.748624 
+L 249.216375 145.773741 
+L 248.24851 146.802297 
+L 247.279473 147.834428 
+L 246.309242 148.870277 
+L 245.337797 149.909996 
+L 244.365116 150.953746 
+L 243.39118 152.001696 
+L 242.415968 153.054025 
+L 241.439461 154.110922 
+L 240.461641 155.172587 
+L 239.482489 156.239232 
+L 238.50199 157.311082 
+L 237.520128 158.388375 
+L 236.53689 159.471365 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_209">
+    <path d="M 217.608 181.625182 
+L 216.603093 180.354569 
+L 215.598463 179.09962 
+L 214.594323 177.859402 
+L 213.590855 176.633054 
+L 212.588208 175.419775 
+L 211.586508 174.218825 
+L 210.585861 173.029516 
+L 209.586352 171.851209 
+L 208.588051 170.683309 
+L 207.591014 169.525263 
+L 206.595285 168.376554 
+L 205.600899 167.236702 
+L 204.607881 166.105256 
+L 203.616249 164.981797 
+L 202.626014 163.865931 
+L 201.637184 162.757289 
+L 200.649759 161.655527 
+L 199.663736 160.560321 
+L 198.67911 159.471365 
+L 199.659886 159.253595 
+L 200.643166 159.047423 
+L 201.628812 158.852878 
+L 202.616687 158.669987 
+L 203.606653 158.498776 
+L 204.598572 158.339269 
+L 205.592305 158.191488 
+L 206.587715 158.055453 
+L 207.584662 157.931184 
+L 208.583007 157.818697 
+L 209.58261 157.718009 
+L 210.583334 157.629134 
+L 211.585037 157.552083 
+L 212.58758 157.486869 
+L 213.590823 157.433499 
+L 214.594627 157.391981 
+L 215.598851 157.362322 
+L 216.603356 157.344524 
+L 217.608 157.338591 
+L 218.612644 157.344524 
+L 219.617149 157.362322 
+L 220.621373 157.391981 
+L 221.625177 157.433499 
+L 222.62842 157.486869 
+L 223.630963 157.552083 
+L 224.632666 157.629134 
+L 225.63339 157.718009 
+L 226.632993 157.818697 
+L 227.631338 157.931184 
+L 228.628285 158.055453 
+L 229.623695 158.191488 
+L 230.617428 158.339269 
+L 231.609347 158.498776 
+L 232.599313 158.669987 
+L 233.587188 158.852878 
+L 234.572834 159.047423 
+L 235.556114 159.253595 
+L 236.53689 159.471365 
+L 235.552264 160.560321 
+L 234.566241 161.655527 
+L 233.578816 162.757289 
+L 232.589986 163.865931 
+L 231.599751 164.981797 
+L 230.608119 166.105256 
+L 229.615101 167.236702 
+L 228.620715 168.376554 
+L 227.624986 169.525263 
+L 226.627949 170.683309 
+L 225.629648 171.851209 
+L 224.630139 173.029516 
+L 223.629492 174.218825 
+L 222.627792 175.419775 
+L 221.625145 176.633054 
+L 220.621677 177.859402 
+L 219.617537 179.09962 
+L 218.612907 180.354569 
+L 217.608 181.625182 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_210">
+    <path d="M 217.608 181.625182 
+L 216.603082 181.63349 
+L 215.598439 181.658413 
+L 214.594346 181.699942 
+L 213.591076 181.758068 
+L 212.588904 181.832773 
+L 211.588105 181.924039 
+L 210.588951 182.031839 
+L 209.591717 182.156144 
+L 208.596674 182.29692 
+L 207.604094 182.454129 
+L 206.61425 182.627728 
+L 205.627411 182.817669 
+L 204.643847 183.023901 
+L 203.663828 183.246367 
+L 202.687621 183.485005 
+L 201.715493 183.739752 
+L 200.74771 184.010537 
+L 199.784536 184.297286 
+L 198.826235 184.599921 
+L 197.858535 183.572869 
+L 196.892654 182.551189 
+L 195.928534 181.53455 
+L 194.966116 180.522647 
+L 194.005344 179.515198 
+L 193.046163 178.511944 
+L 192.088518 177.512646 
+L 191.132358 176.517082 
+L 190.177633 175.525047 
+L 189.224293 174.536349 
+L 188.272292 173.550812 
+L 187.321584 172.568272 
+L 186.372126 171.588576 
+L 185.423876 170.61158 
+L 184.476794 169.637152 
+L 183.530841 168.665166 
+L 182.58598 167.695507 
+L 181.642176 166.728066 
+L 180.699394 165.76274 
+L 181.607122 165.332186 
+L 182.519871 164.912383 
+L 183.437514 164.503389 
+L 184.359924 164.105261 
+L 185.286971 163.718054 
+L 186.218527 163.341824 
+L 187.154461 162.976621 
+L 188.094643 162.622497 
+L 189.038942 162.279502 
+L 189.987226 161.947683 
+L 190.939362 161.627087 
+L 191.895219 161.317758 
+L 192.854662 161.01974 
+L 193.817557 160.733073 
+L 194.783771 160.457799 
+L 195.753169 160.193955 
+L 196.725615 159.941578 
+L 197.700974 159.700704 
+L 198.67911 159.471365 
+L 199.663736 160.560321 
+L 200.649759 161.655527 
+L 201.637184 162.757289 
+L 202.626014 163.865931 
+L 203.616249 164.981797 
+L 204.607881 166.105256 
+L 205.600899 167.236702 
+L 206.595285 168.376554 
+L 207.591014 169.525263 
+L 208.588051 170.683309 
+L 209.586352 171.851209 
+L 210.585861 173.029516 
+L 211.586508 174.218825 
+L 212.588208 175.419775 
+L 213.590855 176.633054 
+L 214.594323 177.859402 
+L 215.598463 179.09962 
+L 216.603093 180.354569 
+L 217.608 181.625182 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_211">
+    <path d="M 217.608 157.338591 
+L 216.603373 156.066826 
+L 215.598914 154.806478 
+L 214.594741 153.557056 
+L 213.590958 152.318095 
+L 212.587657 151.089155 
+L 211.584919 149.869822 
+L 210.582817 148.659699 
+L 209.581413 147.458414 
+L 208.580761 146.265613 
+L 207.580911 145.080959 
+L 206.581903 143.904134 
+L 205.583773 142.734835 
+L 204.586553 141.572774 
+L 203.590268 140.417678 
+L 202.594941 139.269286 
+L 201.60059 138.12735 
+L 200.607231 136.991636 
+L 199.614875 135.861918 
+L 198.623532 134.737982 
+L 199.613335 134.568137 
+L 200.604657 134.407391 
+L 201.597414 134.255758 
+L 202.591521 134.11325 
+L 203.586896 133.979881 
+L 204.583453 133.85566 
+L 205.58111 133.740599 
+L 206.579781 133.634706 
+L 207.579384 133.537992 
+L 208.579832 133.450464 
+L 209.581042 133.37213 
+L 210.58293 133.302996 
+L 211.58541 133.243068 
+L 212.588398 133.192351 
+L 213.59181 133.15085 
+L 214.595561 133.118567 
+L 215.599566 133.095506 
+L 216.603741 133.081669 
+L 217.608 133.077056 
+L 218.612259 133.081669 
+L 219.616434 133.095506 
+L 220.620439 133.118567 
+L 221.62419 133.15085 
+L 222.627602 133.192351 
+L 223.63059 133.243068 
+L 224.63307 133.302996 
+L 225.634958 133.37213 
+L 226.636168 133.450464 
+L 227.636616 133.537992 
+L 228.636219 133.634706 
+L 229.63489 133.740599 
+L 230.632547 133.85566 
+L 231.629104 133.979881 
+L 232.624479 134.11325 
+L 233.618586 134.255758 
+L 234.611343 134.407391 
+L 235.602665 134.568137 
+L 236.592468 134.737982 
+L 235.601125 135.861918 
+L 234.608769 136.991636 
+L 233.61541 138.12735 
+L 232.621059 139.269286 
+L 231.625732 140.417678 
+L 230.629447 141.572774 
+L 229.632227 142.734835 
+L 228.634097 143.904134 
+L 227.635089 145.080959 
+L 226.635239 146.265613 
+L 225.634587 147.458414 
+L 224.633183 148.659699 
+L 223.631081 149.869822 
+L 222.628343 151.089155 
+L 221.625042 152.318095 
+L 220.621259 153.557056 
+L 219.617086 154.806478 
+L 218.612627 156.066826 
+L 217.608 157.338591 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_212">
+    <path d="M 217.608 157.338591 
+L 216.603356 157.344524 
+L 215.598851 157.362322 
+L 214.594627 157.391981 
+L 213.590823 157.433499 
+L 212.58758 157.486869 
+L 211.585037 157.552083 
+L 210.583334 157.629134 
+L 209.58261 157.718009 
+L 208.583007 157.818697 
+L 207.584662 157.931184 
+L 206.587715 158.055453 
+L 205.592305 158.191488 
+L 204.598572 158.339269 
+L 203.606653 158.498776 
+L 202.616687 158.669987 
+L 201.628812 158.852878 
+L 200.643166 159.047423 
+L 199.659886 159.253595 
+L 198.67911 159.471365 
+L 197.695872 158.388375 
+L 196.71401 157.311082 
+L 195.733511 156.239232 
+L 194.754359 155.172587 
+L 193.776539 154.110922 
+L 192.800032 153.054025 
+L 191.82482 152.001696 
+L 190.850884 150.953746 
+L 189.878203 149.909996 
+L 188.906758 148.870277 
+L 187.936527 147.834428 
+L 186.96749 146.802297 
+L 185.999625 145.773741 
+L 185.032912 144.748624 
+L 184.06733 143.726815 
+L 183.102859 142.708191 
+L 182.139476 141.692636 
+L 181.177162 140.680039 
+L 180.215898 139.670293 
+L 181.16117 139.33115 
+L 182.109518 139.000705 
+L 183.060862 138.678986 
+L 184.01512 138.366018 
+L 184.972213 138.06183 
+L 185.932061 137.766446 
+L 186.89458 137.479891 
+L 187.859692 137.20219 
+L 188.827314 136.933366 
+L 189.797364 136.673442 
+L 190.769761 136.42244 
+L 191.744422 136.18038 
+L 192.721266 135.947283 
+L 193.70021 135.72317 
+L 194.681171 135.508058 
+L 195.664067 135.301967 
+L 196.648815 135.104913 
+L 197.635331 134.916913 
+L 198.623532 134.737982 
+L 199.614875 135.861918 
+L 200.607231 136.991636 
+L 201.60059 138.12735 
+L 202.594941 139.269286 
+L 203.590268 140.417678 
+L 204.586553 141.572774 
+L 205.583773 142.734835 
+L 206.581903 143.904134 
+L 207.580911 145.080959 
+L 208.580761 146.265613 
+L 209.581413 147.458414 
+L 210.582817 148.659699 
+L 211.584919 149.869822 
+L 212.587657 151.089155 
+L 213.590958 152.318095 
+L 214.594741 153.557056 
+L 215.598914 154.806478 
+L 216.603373 156.066826 
+L 217.608 157.338591 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_213">
+    <path d="M 198.67911 159.471365 
+L 197.700974 159.700704 
+L 196.725615 159.941578 
+L 195.753169 160.193955 
+L 194.783771 160.457799 
+L 193.817557 160.733073 
+L 192.854662 161.01974 
+L 191.895219 161.317758 
+L 190.939362 161.627087 
+L 189.987226 161.947683 
+L 189.038942 162.279502 
+L 188.094643 162.622497 
+L 187.154461 162.976621 
+L 186.218527 163.341824 
+L 185.286971 163.718054 
+L 184.359924 164.105261 
+L 183.437514 164.503389 
+L 182.519871 164.912383 
+L 181.607122 165.332186 
+L 180.699394 165.76274 
+L 179.757602 164.799434 
+L 178.816769 163.838058 
+L 177.876864 162.878528 
+L 176.937859 161.920763 
+L 175.999726 160.96469 
+L 175.062438 160.010238 
+L 174.125971 159.057341 
+L 173.1903 158.105936 
+L 172.255401 157.155964 
+L 171.321252 156.207368 
+L 170.387832 155.260097 
+L 169.45512 154.3141 
+L 168.523097 153.369331 
+L 167.591743 152.425743 
+L 166.66104 151.483295 
+L 165.730971 150.541946 
+L 164.801519 149.601659 
+L 163.872669 148.662396 
+L 162.944403 147.724123 
+L 163.816424 147.225988 
+L 164.692983 146.735884 
+L 165.574007 146.253853 
+L 166.459422 145.779935 
+L 167.349153 145.31417 
+L 168.243125 144.856598 
+L 169.141262 144.407257 
+L 170.04349 143.966185 
+L 170.94973 143.53342 
+L 171.859908 143.108997 
+L 172.773946 142.692953 
+L 173.691767 142.285322 
+L 174.613293 141.88614 
+L 175.538448 141.49544 
+L 176.467152 141.113254 
+L 177.399329 140.739615 
+L 178.334897 140.374555 
+L 179.27378 140.018104 
+L 180.215898 139.670293 
+L 181.177162 140.680039 
+L 182.139476 141.692636 
+L 183.102859 142.708191 
+L 184.06733 143.726815 
+L 185.032912 144.748624 
+L 185.999625 145.773741 
+L 186.96749 146.802297 
+L 187.936527 147.834428 
+L 188.906758 148.870277 
+L 189.878203 149.909996 
+L 190.850884 150.953746 
+L 191.82482 152.001696 
+L 192.800032 153.054025 
+L 193.776539 154.110922 
+L 194.754359 155.172587 
+L 195.733511 156.239232 
+L 196.71401 157.311082 
+L 197.695872 158.388375 
+L 198.67911 159.471365 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_214">
+    <path d="M 217.608 205.929658 
+L 216.602967 205.943507 
+L 215.598696 205.985044 
+L 214.595952 206.054237 
+L 213.595495 206.151034 
+L 212.598085 206.275361 
+L 211.60448 206.427124 
+L 210.615433 206.606207 
+L 209.631696 206.812475 
+L 208.654017 207.045771 
+L 207.683137 207.305918 
+L 206.719794 207.592717 
+L 205.764719 207.905952 
+L 204.818638 208.245385 
+L 203.882269 208.610757 
+L 202.956323 209.001792 
+L 202.041504 209.418192 
+L 201.138505 209.859641 
+L 200.248013 210.325804 
+L 199.370704 210.816327 
+L 198.441532 209.877047 
+L 197.51379 208.940185 
+L 196.587363 208.005503 
+L 195.662147 207.072793 
+L 194.738049 206.141874 
+L 193.814985 205.212587 
+L 192.892881 204.28479 
+L 191.971668 203.358358 
+L 191.051285 202.433181 
+L 190.131676 201.50916 
+L 189.212791 200.586206 
+L 188.294582 199.664241 
+L 187.377008 198.743192 
+L 186.460031 197.822996 
+L 185.543616 196.903594 
+L 184.627729 195.984935 
+L 183.712342 195.066969 
+L 182.797428 194.149655 
+L 181.88296 193.232951 
+L 182.700839 192.648997 
+L 183.528261 192.078645 
+L 184.365001 191.522052 
+L 185.210828 190.979369 
+L 186.065513 190.450746 
+L 186.928821 189.936326 
+L 187.800517 189.43625 
+L 188.680361 188.950655 
+L 189.568114 188.479674 
+L 190.463533 188.023435 
+L 191.366373 187.582064 
+L 192.276387 187.15568 
+L 193.193327 186.744401 
+L 194.116941 186.348338 
+L 195.046977 185.967601 
+L 195.983182 185.602293 
+L 196.925298 185.252514 
+L 197.873069 184.91836 
+L 198.826235 184.599921 
+L 199.795814 185.632708 
+L 200.767331 186.671624 
+L 201.740845 187.717099 
+L 202.716414 188.769606 
+L 203.694094 189.829661 
+L 204.673937 190.897835 
+L 205.655989 191.974752 
+L 206.640292 193.061104 
+L 207.626875 194.157656 
+L 208.615756 195.265254 
+L 209.606936 196.38484 
+L 210.600394 197.517461 
+L 211.596081 198.664289 
+L 212.59391 199.826633 
+L 213.593749 201.005964 
+L 214.595403 202.203936 
+L 215.5986 203.422418 
+L 216.602966 204.663525 
+L 217.608 205.929658 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_215">
+    <path d="M 199.370704 210.816327 
+L 198.507244 211.330837 
+L 197.658289 211.868944 
+L 196.824484 212.43024 
+L 196.006461 213.014297 
+L 195.204842 213.620672 
+L 194.420236 214.248905 
+L 193.653238 214.898519 
+L 192.904431 215.569021 
+L 192.174384 216.2599 
+L 191.46365 216.970634 
+L 190.772771 217.700681 
+L 190.102269 218.449488 
+L 189.452655 219.216486 
+L 188.824422 220.001092 
+L 188.218047 220.802711 
+L 187.63399 221.620734 
+L 187.072694 222.454539 
+L 186.534587 223.303494 
+L 186.020077 224.166954 
+L 185.080797 223.237782 
+L 184.143935 222.31004 
+L 183.209253 221.383613 
+L 182.276543 220.458397 
+L 181.345624 219.534299 
+L 180.416337 218.611235 
+L 179.48854 217.689131 
+L 178.562108 216.767918 
+L 177.636931 215.847535 
+L 176.71291 214.927926 
+L 175.789956 214.009041 
+L 174.867991 213.090832 
+L 173.946942 212.173258 
+L 173.026746 211.256281 
+L 172.107344 210.339866 
+L 171.188685 209.423979 
+L 170.270719 208.508592 
+L 169.353405 207.593678 
+L 168.436701 206.67921 
+L 169.034098 205.871098 
+L 169.644775 205.072974 
+L 170.268565 204.285056 
+L 170.905297 203.507559 
+L 171.554796 202.740696 
+L 172.216887 201.984676 
+L 172.891386 201.239707 
+L 173.578111 200.505992 
+L 174.276873 199.783732 
+L 174.987482 199.073123 
+L 175.709742 198.374361 
+L 176.443457 197.687636 
+L 177.188426 197.013137 
+L 177.944446 196.351046 
+L 178.711309 195.701547 
+L 179.488806 195.064815 
+L 180.276724 194.441025 
+L 181.074848 193.830348 
+L 181.88296 193.232951 
+L 182.797428 194.149655 
+L 183.712342 195.066969 
+L 184.627729 195.984935 
+L 185.543616 196.903594 
+L 186.460031 197.822996 
+L 187.377008 198.743192 
+L 188.294582 199.664241 
+L 189.212791 200.586206 
+L 190.131676 201.50916 
+L 191.051285 202.433181 
+L 191.971668 203.358358 
+L 192.892881 204.28479 
+L 193.814985 205.212587 
+L 194.738049 206.141874 
+L 195.662147 207.072793 
+L 196.587363 208.005503 
+L 197.51379 208.940185 
+L 198.441532 209.877047 
+L 199.370704 210.816327 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_216">
+    <path d="M 186.020077 224.166954 
+L 185.529554 225.044263 
+L 185.063391 225.934755 
+L 184.621942 226.837754 
+L 184.205542 227.752573 
+L 183.814507 228.678519 
+L 183.449135 229.614888 
+L 183.109702 230.560969 
+L 182.796467 231.516044 
+L 182.509668 232.479387 
+L 182.249521 233.450267 
+L 182.016225 234.427946 
+L 181.809957 235.411683 
+L 181.630874 236.40073 
+L 181.479111 237.394335 
+L 181.354784 238.391745 
+L 181.257987 239.392202 
+L 181.188794 240.394946 
+L 181.147257 241.399217 
+L 181.133408 242.40425 
+L 179.867275 241.399216 
+L 178.626168 240.39485 
+L 177.407686 239.391653 
+L 176.209714 238.389999 
+L 175.030383 237.39016 
+L 173.868039 236.392331 
+L 172.721211 235.396644 
+L 171.58859 234.403186 
+L 170.469004 233.412006 
+L 169.361406 232.423125 
+L 168.264854 231.436542 
+L 167.178502 230.452239 
+L 166.101585 229.470187 
+L 165.033411 228.490344 
+L 163.973356 227.512664 
+L 162.920849 226.537095 
+L 161.875374 225.563581 
+L 160.836458 224.592064 
+L 159.803671 223.622485 
+L 160.12211 222.669319 
+L 160.456264 221.721548 
+L 160.806043 220.779432 
+L 161.171351 219.843227 
+L 161.552088 218.913191 
+L 161.948151 217.989577 
+L 162.35943 217.072637 
+L 162.785814 216.162623 
+L 163.227185 215.259783 
+L 163.683424 214.364364 
+L 164.154405 213.476611 
+L 164.64 212.596767 
+L 165.140076 211.725071 
+L 165.654496 210.861763 
+L 166.183119 210.007078 
+L 166.725802 209.161251 
+L 167.282395 208.324511 
+L 167.852747 207.497089 
+L 168.436701 206.67921 
+L 169.353405 207.593678 
+L 170.270719 208.508592 
+L 171.188685 209.423979 
+L 172.107344 210.339866 
+L 173.026746 211.256281 
+L 173.946942 212.173258 
+L 174.867991 213.090832 
+L 175.789956 214.009041 
+L 176.71291 214.927926 
+L 177.636931 215.847535 
+L 178.562108 216.767918 
+L 179.48854 217.689131 
+L 180.416337 218.611235 
+L 181.345624 219.534299 
+L 182.276543 220.458397 
+L 183.209253 221.383613 
+L 184.143935 222.31004 
+L 185.080797 223.237782 
+L 186.020077 224.166954 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_217">
+    <path d="M 198.826235 184.599921 
+L 197.873069 184.91836 
+L 196.925298 185.252514 
+L 195.983182 185.602293 
+L 195.046977 185.967601 
+L 194.116941 186.348338 
+L 193.193327 186.744401 
+L 192.276387 187.15568 
+L 191.366373 187.582064 
+L 190.463533 188.023435 
+L 189.568114 188.479674 
+L 188.680361 188.950655 
+L 187.800517 189.43625 
+L 186.928821 189.936326 
+L 186.065513 190.450746 
+L 185.210828 190.979369 
+L 184.365001 191.522052 
+L 183.528261 192.078645 
+L 182.700839 192.648997 
+L 181.88296 193.232951 
+L 180.968917 192.316823 
+L 180.055276 191.401236 
+L 179.142019 190.486161 
+L 178.229127 189.57157 
+L 177.316582 188.657437 
+L 176.40437 187.743739 
+L 175.492476 186.830454 
+L 174.580886 185.917562 
+L 173.669588 185.005044 
+L 172.75857 184.092884 
+L 171.847821 183.181065 
+L 170.937331 182.269573 
+L 170.02709 181.358394 
+L 169.11709 180.447515 
+L 168.207323 179.536925 
+L 167.29778 178.626612 
+L 166.388455 177.716567 
+L 165.47934 176.806779 
+L 164.570429 175.89724 
+L 165.359591 175.275493 
+L 166.156041 174.663109 
+L 166.959667 174.060175 
+L 167.770358 173.466773 
+L 168.588001 172.882987 
+L 169.412482 172.308899 
+L 170.243685 171.744587 
+L 171.081495 171.190132 
+L 171.925794 170.64561 
+L 172.776466 170.111098 
+L 173.633391 169.58667 
+L 174.49645 169.072398 
+L 175.365522 168.568355 
+L 176.240487 168.074612 
+L 177.121222 167.591236 
+L 178.007604 167.118296 
+L 178.89951 166.655857 
+L 179.796815 166.203984 
+L 180.699394 165.76274 
+L 181.642176 166.728066 
+L 182.58598 167.695507 
+L 183.530841 168.665166 
+L 184.476794 169.637152 
+L 185.423876 170.61158 
+L 186.372126 171.588576 
+L 187.321584 172.568272 
+L 188.272292 173.550812 
+L 189.224293 174.536349 
+L 190.177633 175.525047 
+L 191.132358 176.517082 
+L 192.088518 177.512646 
+L 193.046163 178.511944 
+L 194.005344 179.515198 
+L 194.966116 180.522647 
+L 195.928534 181.53455 
+L 196.892654 182.551189 
+L 197.858535 183.572869 
+L 198.826235 184.599921 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_218">
+    <path d="M 181.88296 193.232951 
+L 181.074848 193.830348 
+L 180.276724 194.441025 
+L 179.488806 195.064815 
+L 178.711309 195.701547 
+L 177.944446 196.351046 
+L 177.188426 197.013137 
+L 176.443457 197.687636 
+L 175.709742 198.374361 
+L 174.987482 199.073123 
+L 174.276873 199.783732 
+L 173.578111 200.505992 
+L 172.891386 201.239707 
+L 172.216887 201.984676 
+L 171.554796 202.740696 
+L 170.905297 203.507559 
+L 170.268565 204.285056 
+L 169.644775 205.072974 
+L 169.034098 205.871098 
+L 168.436701 206.67921 
+L 167.520573 205.765167 
+L 166.604986 204.851526 
+L 165.689911 203.938269 
+L 164.77532 203.025377 
+L 163.861187 202.112832 
+L 162.947489 201.20062 
+L 162.034204 200.288726 
+L 161.121312 199.377136 
+L 160.208794 198.465838 
+L 159.296634 197.55482 
+L 158.384815 196.644071 
+L 157.473323 195.733581 
+L 156.562144 194.82334 
+L 155.651265 193.91334 
+L 154.740675 193.003573 
+L 153.830362 192.09403 
+L 152.920317 191.184705 
+L 152.010529 190.27559 
+L 151.10099 189.366679 
+L 151.732014 188.584916 
+L 152.372227 187.810659 
+L 153.021539 187.044018 
+L 153.67986 186.285098 
+L 154.347099 185.534006 
+L 155.023161 184.790847 
+L 155.707953 184.055724 
+L 156.401379 183.32874 
+L 157.103343 182.609996 
+L 157.813746 181.899593 
+L 158.53249 181.197629 
+L 159.259474 180.504203 
+L 159.994597 179.819411 
+L 160.737756 179.143349 
+L 161.488848 178.47611 
+L 162.247768 177.817789 
+L 163.014409 177.168477 
+L 163.788666 176.528264 
+L 164.570429 175.89724 
+L 165.47934 176.806779 
+L 166.388455 177.716567 
+L 167.29778 178.626612 
+L 168.207323 179.536925 
+L 169.11709 180.447515 
+L 170.02709 181.358394 
+L 170.937331 182.269573 
+L 171.847821 183.181065 
+L 172.75857 184.092884 
+L 173.669588 185.005044 
+L 174.580886 185.917562 
+L 175.492476 186.830454 
+L 176.40437 187.743739 
+L 177.316582 188.657437 
+L 178.229127 189.57157 
+L 179.142019 190.486161 
+L 180.055276 191.401236 
+L 180.968917 192.316823 
+L 181.88296 193.232951 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_219">
+    <path d="M 168.436701 206.67921 
+L 167.852747 207.497089 
+L 167.282395 208.324511 
+L 166.725802 209.161251 
+L 166.183119 210.007078 
+L 165.654496 210.861763 
+L 165.140076 211.725071 
+L 164.64 212.596767 
+L 164.154405 213.476611 
+L 163.683424 214.364364 
+L 163.227185 215.259783 
+L 162.785814 216.162623 
+L 162.35943 217.072637 
+L 161.948151 217.989577 
+L 161.552088 218.913191 
+L 161.171351 219.843227 
+L 160.806043 220.779432 
+L 160.456264 221.721548 
+L 160.12211 222.669319 
+L 159.803671 223.622485 
+L 158.776619 222.654785 
+L 157.754939 221.688904 
+L 156.7383 220.724784 
+L 155.726397 219.762366 
+L 154.718948 218.801594 
+L 153.715694 217.842413 
+L 152.716396 216.884768 
+L 151.720832 215.928608 
+L 150.728797 214.973883 
+L 149.740099 214.020543 
+L 148.754562 213.068542 
+L 147.772022 212.117834 
+L 146.792326 211.168376 
+L 145.81533 210.220126 
+L 144.840902 209.273044 
+L 143.868916 208.327091 
+L 142.899257 207.38223 
+L 141.931816 206.438426 
+L 140.96649 205.495644 
+L 141.407734 204.593065 
+L 141.859607 203.69576 
+L 142.322046 202.803854 
+L 142.794986 201.917472 
+L 143.278362 201.036737 
+L 143.772105 200.161772 
+L 144.276148 199.2927 
+L 144.79042 198.429641 
+L 145.314848 197.572716 
+L 145.84936 196.722044 
+L 146.393882 195.877745 
+L 146.948337 195.039935 
+L 147.512649 194.208732 
+L 148.086737 193.384251 
+L 148.670523 192.566608 
+L 149.263925 191.755917 
+L 149.866859 190.952291 
+L 150.479243 190.155841 
+L 151.10099 189.366679 
+L 152.010529 190.27559 
+L 152.920317 191.184705 
+L 153.830362 192.09403 
+L 154.740675 193.003573 
+L 155.651265 193.91334 
+L 156.562144 194.82334 
+L 157.473323 195.733581 
+L 158.384815 196.644071 
+L 159.296634 197.55482 
+L 160.208794 198.465838 
+L 161.121312 199.377136 
+L 162.034204 200.288726 
+L 162.947489 201.20062 
+L 163.861187 202.112832 
+L 164.77532 203.025377 
+L 165.689911 203.938269 
+L 166.604986 204.851526 
+L 167.520573 205.765167 
+L 168.436701 206.67921 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_220">
+    <path d="M 180.699394 165.76274 
+L 179.796815 166.203984 
+L 178.89951 166.655857 
+L 178.007604 167.118296 
+L 177.121222 167.591236 
+L 176.240487 168.074612 
+L 175.365522 168.568355 
+L 174.49645 169.072398 
+L 173.633391 169.58667 
+L 172.776466 170.111098 
+L 171.925794 170.64561 
+L 171.081495 171.190132 
+L 170.243685 171.744587 
+L 169.412482 172.308899 
+L 168.588001 172.882987 
+L 167.770358 173.466773 
+L 166.959667 174.060175 
+L 166.156041 174.663109 
+L 165.359591 175.275493 
+L 164.570429 175.89724 
+L 163.661717 174.987941 
+L 162.753198 174.078875 
+L 161.844866 173.170035 
+L 160.936717 172.261412 
+L 160.028746 171.353002 
+L 159.120948 170.444798 
+L 158.21332 169.536794 
+L 157.305858 168.628986 
+L 156.398559 167.721368 
+L 155.491418 166.813935 
+L 154.584433 165.906684 
+L 153.6776 164.99961 
+L 152.770917 164.09271 
+L 151.864382 163.185979 
+L 150.957992 162.279415 
+L 150.051744 161.373014 
+L 149.145637 160.466773 
+L 148.239667 159.56069 
+L 147.333835 158.654761 
+L 148.106107 158.012769 
+L 148.884244 157.377898 
+L 149.668179 156.750202 
+L 150.457848 156.129733 
+L 151.253183 155.516544 
+L 152.054117 154.910687 
+L 152.860582 154.312212 
+L 153.672511 153.721171 
+L 154.489835 153.137613 
+L 155.312484 152.561588 
+L 156.140391 151.993143 
+L 156.973483 151.432328 
+L 157.811693 150.879188 
+L 158.654948 150.333772 
+L 159.503177 149.796125 
+L 160.35631 149.266292 
+L 161.214273 148.744318 
+L 162.076995 148.230247 
+L 162.944403 147.724123 
+L 163.872669 148.662396 
+L 164.801519 149.601659 
+L 165.730971 150.541946 
+L 166.66104 151.483295 
+L 167.591743 152.425743 
+L 168.523097 153.369331 
+L 169.45512 154.3141 
+L 170.387832 155.260097 
+L 171.321252 156.207368 
+L 172.255401 157.155964 
+L 173.1903 158.105936 
+L 174.125971 159.057341 
+L 175.062438 160.010238 
+L 175.999726 160.96469 
+L 176.937859 161.920763 
+L 177.876864 162.878528 
+L 178.816769 163.838058 
+L 179.757602 164.799434 
+L 180.699394 165.76274 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_221">
+    <path d="M 164.570429 175.89724 
+L 163.788666 176.528264 
+L 163.014409 177.168477 
+L 162.247768 177.817789 
+L 161.488848 178.47611 
+L 160.737756 179.143349 
+L 159.994597 179.819411 
+L 159.259474 180.504203 
+L 158.53249 181.197629 
+L 157.813746 181.899593 
+L 157.103343 182.609996 
+L 156.401379 183.32874 
+L 155.707953 184.055724 
+L 155.023161 184.790847 
+L 154.347099 185.534006 
+L 153.67986 186.285098 
+L 153.021539 187.044018 
+L 152.372227 187.810659 
+L 151.732014 188.584916 
+L 151.10099 189.366679 
+L 150.191691 188.457967 
+L 149.282625 187.549448 
+L 148.373785 186.641116 
+L 147.465162 185.732967 
+L 146.556752 184.824996 
+L 145.648548 183.917198 
+L 144.740544 183.00957 
+L 143.832736 182.102108 
+L 142.925118 181.194809 
+L 142.017685 180.287668 
+L 141.110434 179.380683 
+L 140.20336 178.47385 
+L 139.29646 177.567167 
+L 138.389729 176.660632 
+L 137.483165 175.754242 
+L 136.576764 174.847994 
+L 135.670523 173.941887 
+L 134.76444 173.035917 
+L 133.858511 172.130085 
+L 134.50757 171.363742 
+L 135.163641 170.603394 
+L 135.826668 169.849105 
+L 136.496597 169.100938 
+L 137.17337 168.358957 
+L 137.85693 167.623223 
+L 138.547219 166.8938 
+L 139.244179 166.170748 
+L 139.947752 165.454129 
+L 140.657879 164.744002 
+L 141.374498 164.040429 
+L 142.09755 163.343469 
+L 142.826973 162.65318 
+L 143.562707 161.96962 
+L 144.304688 161.292847 
+L 145.052855 160.622918 
+L 145.807144 159.959891 
+L 146.567492 159.30382 
+L 147.333835 158.654761 
+L 148.239667 159.56069 
+L 149.145637 160.466773 
+L 150.051744 161.373014 
+L 150.957992 162.279415 
+L 151.864382 163.185979 
+L 152.770917 164.09271 
+L 153.6776 164.99961 
+L 154.584433 165.906684 
+L 155.491418 166.813935 
+L 156.398559 167.721368 
+L 157.305858 168.628986 
+L 158.21332 169.536794 
+L 159.120948 170.444798 
+L 160.028746 171.353002 
+L 160.936717 172.261412 
+L 161.844866 173.170035 
+L 162.753198 174.078875 
+L 163.661717 174.987941 
+L 164.570429 175.89724 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_222">
+    <path d="M 151.10099 189.366679 
+L 150.479243 190.155841 
+L 149.866859 190.952291 
+L 149.263925 191.755917 
+L 148.670523 192.566608 
+L 148.086737 193.384251 
+L 147.512649 194.208732 
+L 146.948337 195.039935 
+L 146.393882 195.877745 
+L 145.84936 196.722044 
+L 145.314848 197.572716 
+L 144.79042 198.429641 
+L 144.276148 199.2927 
+L 143.772105 200.161772 
+L 143.278362 201.036737 
+L 142.794986 201.917472 
+L 142.322046 202.803854 
+L 141.859607 203.69576 
+L 141.407734 204.593065 
+L 140.96649 205.495644 
+L 140.003184 204.553852 
+L 139.041808 203.613019 
+L 138.082278 202.673114 
+L 137.124513 201.734109 
+L 136.16844 200.795976 
+L 135.213988 199.858688 
+L 134.261091 198.922221 
+L 133.309686 197.98655 
+L 132.359714 197.051651 
+L 131.411118 196.117502 
+L 130.463847 195.184082 
+L 129.51785 194.25137 
+L 128.573081 193.319347 
+L 127.629493 192.387993 
+L 126.687045 191.45729 
+L 125.745696 190.527221 
+L 124.805409 189.597769 
+L 123.866146 188.668919 
+L 122.927873 187.740653 
+L 123.433997 186.873245 
+L 123.948068 186.010523 
+L 124.470042 185.15256 
+L 124.999875 184.299427 
+L 125.537522 183.451198 
+L 126.082938 182.607943 
+L 126.636078 181.769733 
+L 127.196893 180.936641 
+L 127.765338 180.108734 
+L 128.341363 179.286085 
+L 128.924921 178.468761 
+L 129.515962 177.656832 
+L 130.114437 176.850367 
+L 130.720294 176.049433 
+L 131.333483 175.254098 
+L 131.953952 174.464429 
+L 132.581648 173.680494 
+L 133.216519 172.902357 
+L 133.858511 172.130085 
+L 134.76444 173.035917 
+L 135.670523 173.941887 
+L 136.576764 174.847994 
+L 137.483165 175.754242 
+L 138.389729 176.660632 
+L 139.29646 177.567167 
+L 140.20336 178.47385 
+L 141.110434 179.380683 
+L 142.017685 180.287668 
+L 142.925118 181.194809 
+L 143.832736 182.102108 
+L 144.740544 183.00957 
+L 145.648548 183.917198 
+L 146.556752 184.824996 
+L 147.465162 185.732967 
+L 148.373785 186.641116 
+L 149.282625 187.549448 
+L 150.191691 188.457967 
+L 151.10099 189.366679 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_223">
+    <path d="M 181.133408 242.40425 
+L 179.867275 243.409284 
+L 178.626168 244.41365 
+L 177.407686 245.416847 
+L 176.209714 246.418501 
+L 175.030383 247.41834 
+L 173.868039 248.416169 
+L 172.721211 249.411856 
+L 171.58859 250.405314 
+L 170.469004 251.396494 
+L 169.361406 252.385375 
+L 168.264854 253.371958 
+L 167.178502 254.356261 
+L 166.101585 255.338313 
+L 165.033411 256.318156 
+L 163.973356 257.295836 
+L 162.920849 258.271405 
+L 161.875374 259.244919 
+L 160.836458 260.216436 
+L 159.803671 261.186015 
+L 159.501036 260.227714 
+L 159.214287 259.26454 
+L 158.943502 258.296757 
+L 158.688755 257.324629 
+L 158.450117 256.348422 
+L 158.227651 255.368403 
+L 158.021419 254.384839 
+L 157.831478 253.398 
+L 157.657879 252.408156 
+L 157.50067 251.415576 
+L 157.359894 250.420533 
+L 157.235589 249.423299 
+L 157.127789 248.424145 
+L 157.036523 247.423346 
+L 156.961818 246.421174 
+L 156.903692 245.417904 
+L 156.862163 244.413811 
+L 156.83724 243.409168 
+L 156.828932 242.40425 
+L 156.83724 241.399332 
+L 156.862163 240.394689 
+L 156.903692 239.390596 
+L 156.961818 238.387326 
+L 157.036523 237.385154 
+L 157.127789 236.384355 
+L 157.235589 235.385201 
+L 157.359894 234.387967 
+L 157.50067 233.392924 
+L 157.657879 232.400344 
+L 157.831478 231.4105 
+L 158.021419 230.423661 
+L 158.227651 229.440097 
+L 158.450117 228.460078 
+L 158.688755 227.483871 
+L 158.943502 226.511743 
+L 159.214287 225.54396 
+L 159.501036 224.580786 
+L 159.803671 223.622485 
+L 160.836458 224.592064 
+L 161.875374 225.563581 
+L 162.920849 226.537095 
+L 163.973356 227.512664 
+L 165.033411 228.490344 
+L 166.101585 229.470187 
+L 167.178502 230.452239 
+L 168.264854 231.436542 
+L 169.361406 232.423125 
+L 170.469004 233.412006 
+L 171.58859 234.403186 
+L 172.721211 235.396644 
+L 173.868039 236.392331 
+L 175.030383 237.39016 
+L 176.209714 238.389999 
+L 177.407686 239.391653 
+L 178.626168 240.39485 
+L 179.867275 241.399216 
+L 181.133408 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_224">
+    <path d="M 156.828932 242.40425 
+L 156.83724 243.409168 
+L 156.862163 244.413811 
+L 156.903692 245.417904 
+L 156.961818 246.421174 
+L 157.036523 247.423346 
+L 157.127789 248.424145 
+L 157.235589 249.423299 
+L 157.359894 250.420533 
+L 157.50067 251.415576 
+L 157.657879 252.408156 
+L 157.831478 253.398 
+L 158.021419 254.384839 
+L 158.227651 255.368403 
+L 158.450117 256.348422 
+L 158.688755 257.324629 
+L 158.943502 258.296757 
+L 159.214287 259.26454 
+L 159.501036 260.227714 
+L 159.803671 261.186015 
+L 158.776619 262.153715 
+L 157.754939 263.119596 
+L 156.7383 264.083716 
+L 155.726397 265.046134 
+L 154.718948 266.006906 
+L 153.715694 266.966087 
+L 152.716396 267.923732 
+L 151.720832 268.879892 
+L 150.728797 269.834617 
+L 149.740099 270.787957 
+L 148.754562 271.739958 
+L 147.772022 272.690666 
+L 146.792326 273.640124 
+L 145.81533 274.588374 
+L 144.840902 275.535456 
+L 143.868916 276.481409 
+L 142.899257 277.42627 
+L 141.931816 278.370074 
+L 140.96649 279.312856 
+L 140.535936 278.405128 
+L 140.116133 277.492379 
+L 139.707139 276.574736 
+L 139.309011 275.652326 
+L 138.921804 274.725279 
+L 138.545574 273.793723 
+L 138.180371 272.857789 
+L 137.826247 271.917607 
+L 137.483252 270.973308 
+L 137.151433 270.025024 
+L 136.830837 269.072888 
+L 136.521508 268.117031 
+L 136.22349 267.157588 
+L 135.936823 266.194693 
+L 135.661549 265.228479 
+L 135.397705 264.259081 
+L 135.145328 263.286635 
+L 134.904454 262.311276 
+L 134.675115 261.33314 
+L 135.764071 260.348514 
+L 136.859277 259.362491 
+L 137.961039 258.375066 
+L 139.069681 257.386236 
+L 140.185547 256.396001 
+L 141.309006 255.404369 
+L 142.440452 254.411351 
+L 143.580304 253.416965 
+L 144.729013 252.421236 
+L 145.887059 251.424199 
+L 147.054959 250.425898 
+L 148.233266 249.426389 
+L 149.422575 248.425742 
+L 150.623525 247.424042 
+L 151.836804 246.421395 
+L 153.063152 245.417927 
+L 154.30337 244.413787 
+L 155.558319 243.409157 
+L 156.828932 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_225">
+    <path d="M 134.675115 261.33314 
+L 134.904454 262.311276 
+L 135.145328 263.286635 
+L 135.397705 264.259081 
+L 135.661549 265.228479 
+L 135.936823 266.194693 
+L 136.22349 267.157588 
+L 136.521508 268.117031 
+L 136.830837 269.072888 
+L 137.151433 270.025024 
+L 137.483252 270.973308 
+L 137.826247 271.917607 
+L 138.180371 272.857789 
+L 138.545574 273.793723 
+L 138.921804 274.725279 
+L 139.309011 275.652326 
+L 139.707139 276.574736 
+L 140.116133 277.492379 
+L 140.535936 278.405128 
+L 140.96649 279.312856 
+L 140.003184 280.254648 
+L 139.041808 281.195481 
+L 138.082278 282.135386 
+L 137.124513 283.074391 
+L 136.16844 284.012524 
+L 135.213988 284.949812 
+L 134.261091 285.886279 
+L 133.309686 286.82195 
+L 132.359714 287.756849 
+L 131.411118 288.690998 
+L 130.463847 289.624418 
+L 129.51785 290.55713 
+L 128.573081 291.489153 
+L 127.629493 292.420507 
+L 126.687045 293.35121 
+L 125.745696 294.281279 
+L 124.805409 295.210731 
+L 123.866146 296.139581 
+L 122.927873 297.067847 
+L 122.429738 296.195826 
+L 121.939634 295.319267 
+L 121.457603 294.438243 
+L 120.983685 293.552828 
+L 120.51792 292.663097 
+L 120.060348 291.769125 
+L 119.611007 290.870988 
+L 119.169935 289.96876 
+L 118.73717 289.06252 
+L 118.312747 288.152342 
+L 117.896703 287.238304 
+L 117.489072 286.320483 
+L 117.08989 285.398957 
+L 116.69919 284.473802 
+L 116.317004 283.545098 
+L 115.943365 282.612921 
+L 115.578305 281.677353 
+L 115.221854 280.73847 
+L 114.874043 279.796352 
+L 115.883789 278.835088 
+L 116.896386 277.872774 
+L 117.911941 276.909391 
+L 118.930565 275.94492 
+L 119.952374 274.979338 
+L 120.977491 274.012625 
+L 122.006047 273.04476 
+L 123.038178 272.075723 
+L 124.074027 271.105492 
+L 125.113746 270.134047 
+L 126.157496 269.161366 
+L 127.205446 268.18743 
+L 128.257775 267.212218 
+L 129.314672 266.235711 
+L 130.376337 265.257891 
+L 131.442982 264.278739 
+L 132.514832 263.29824 
+L 133.592125 262.316378 
+L 134.675115 261.33314 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_226">
+    <path d="M 159.803671 223.622485 
+L 159.501036 224.580786 
+L 159.214287 225.54396 
+L 158.943502 226.511743 
+L 158.688755 227.483871 
+L 158.450117 228.460078 
+L 158.227651 229.440097 
+L 158.021419 230.423661 
+L 157.831478 231.4105 
+L 157.657879 232.400344 
+L 157.50067 233.392924 
+L 157.359894 234.387967 
+L 157.235589 235.385201 
+L 157.127789 236.384355 
+L 157.036523 237.385154 
+L 156.961818 238.387326 
+L 156.903692 239.390596 
+L 156.862163 240.394689 
+L 156.83724 241.399332 
+L 156.828932 242.40425 
+L 155.558319 241.399343 
+L 154.30337 240.394713 
+L 153.063152 239.390573 
+L 151.836804 238.387105 
+L 150.623525 237.384458 
+L 149.422575 236.382758 
+L 148.233266 235.382111 
+L 147.054959 234.382602 
+L 145.887059 233.384301 
+L 144.729013 232.387264 
+L 143.580304 231.391535 
+L 142.440452 230.397149 
+L 141.309006 229.404131 
+L 140.185547 228.412499 
+L 139.069681 227.422264 
+L 137.961039 226.433434 
+L 136.859277 225.446009 
+L 135.764071 224.459986 
+L 134.675115 223.47536 
+L 134.904454 222.497224 
+L 135.145328 221.521865 
+L 135.397705 220.549419 
+L 135.661549 219.580021 
+L 135.936823 218.613807 
+L 136.22349 217.650912 
+L 136.521508 216.691469 
+L 136.830837 215.735612 
+L 137.151433 214.783476 
+L 137.483252 213.835192 
+L 137.826247 212.890893 
+L 138.180371 211.950711 
+L 138.545574 211.014777 
+L 138.921804 210.083221 
+L 139.309011 209.156174 
+L 139.707139 208.233764 
+L 140.116133 207.316121 
+L 140.535936 206.403372 
+L 140.96649 205.495644 
+L 141.931816 206.438426 
+L 142.899257 207.38223 
+L 143.868916 208.327091 
+L 144.840902 209.273044 
+L 145.81533 210.220126 
+L 146.792326 211.168376 
+L 147.772022 212.117834 
+L 148.754562 213.068542 
+L 149.740099 214.020543 
+L 150.728797 214.973883 
+L 151.720832 215.928608 
+L 152.716396 216.884768 
+L 153.715694 217.842413 
+L 154.718948 218.801594 
+L 155.726397 219.762366 
+L 156.7383 220.724784 
+L 157.754939 221.688904 
+L 158.776619 222.654785 
+L 159.803671 223.622485 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_227">
+    <path d="M 156.828932 242.40425 
+L 155.558319 243.409157 
+L 154.30337 244.413787 
+L 153.063152 245.417927 
+L 151.836804 246.421395 
+L 150.623525 247.424042 
+L 149.422575 248.425742 
+L 148.233266 249.426389 
+L 147.054959 250.425898 
+L 145.887059 251.424199 
+L 144.729013 252.421236 
+L 143.580304 253.416965 
+L 142.440452 254.411351 
+L 141.309006 255.404369 
+L 140.185547 256.396001 
+L 139.069681 257.386236 
+L 137.961039 258.375066 
+L 136.859277 259.362491 
+L 135.764071 260.348514 
+L 134.675115 261.33314 
+L 134.457345 260.352364 
+L 134.251173 259.369084 
+L 134.056628 258.383438 
+L 133.873737 257.395563 
+L 133.702526 256.405597 
+L 133.543019 255.413678 
+L 133.395238 254.419945 
+L 133.259203 253.424535 
+L 133.134934 252.427588 
+L 133.022447 251.429243 
+L 132.921759 250.42964 
+L 132.832884 249.428916 
+L 132.755833 248.427213 
+L 132.690619 247.42467 
+L 132.637249 246.421427 
+L 132.595731 245.417623 
+L 132.566072 244.413399 
+L 132.548274 243.408894 
+L 132.542341 242.40425 
+L 132.548274 241.399606 
+L 132.566072 240.395101 
+L 132.595731 239.390877 
+L 132.637249 238.387073 
+L 132.690619 237.38383 
+L 132.755833 236.381287 
+L 132.832884 235.379584 
+L 132.921759 234.37886 
+L 133.022447 233.379257 
+L 133.134934 232.380912 
+L 133.259203 231.383965 
+L 133.395238 230.388555 
+L 133.543019 229.394822 
+L 133.702526 228.402903 
+L 133.873737 227.412937 
+L 134.056628 226.425062 
+L 134.251173 225.439416 
+L 134.457345 224.456136 
+L 134.675115 223.47536 
+L 135.764071 224.459986 
+L 136.859277 225.446009 
+L 137.961039 226.433434 
+L 139.069681 227.422264 
+L 140.185547 228.412499 
+L 141.309006 229.404131 
+L 142.440452 230.397149 
+L 143.580304 231.391535 
+L 144.729013 232.387264 
+L 145.887059 233.384301 
+L 147.054959 234.382602 
+L 148.233266 235.382111 
+L 149.422575 236.382758 
+L 150.623525 237.384458 
+L 151.836804 238.387105 
+L 153.063152 239.390573 
+L 154.30337 240.394713 
+L 155.558319 241.399343 
+L 156.828932 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_228">
+    <path d="M 132.542341 242.40425 
+L 132.548274 243.408894 
+L 132.566072 244.413399 
+L 132.595731 245.417623 
+L 132.637249 246.421427 
+L 132.690619 247.42467 
+L 132.755833 248.427213 
+L 132.832884 249.428916 
+L 132.921759 250.42964 
+L 133.022447 251.429243 
+L 133.134934 252.427588 
+L 133.259203 253.424535 
+L 133.395238 254.419945 
+L 133.543019 255.413678 
+L 133.702526 256.405597 
+L 133.873737 257.395563 
+L 134.056628 258.383438 
+L 134.251173 259.369084 
+L 134.457345 260.352364 
+L 134.675115 261.33314 
+L 133.592125 262.316378 
+L 132.514832 263.29824 
+L 131.442982 264.278739 
+L 130.376337 265.257891 
+L 129.314672 266.235711 
+L 128.257775 267.212218 
+L 127.205446 268.18743 
+L 126.157496 269.161366 
+L 125.113746 270.134047 
+L 124.074027 271.105492 
+L 123.038178 272.075723 
+L 122.006047 273.04476 
+L 120.977491 274.012625 
+L 119.952374 274.979338 
+L 118.930565 275.94492 
+L 117.911941 276.909391 
+L 116.896386 277.872774 
+L 115.883789 278.835088 
+L 114.874043 279.796352 
+L 114.5349 278.85108 
+L 114.204455 277.902732 
+L 113.882736 276.951388 
+L 113.569768 275.99713 
+L 113.26558 275.040037 
+L 112.970196 274.080189 
+L 112.683641 273.11767 
+L 112.40594 272.152558 
+L 112.137116 271.184936 
+L 111.877192 270.214886 
+L 111.62619 269.242489 
+L 111.38413 268.267828 
+L 111.151033 267.290984 
+L 110.92692 266.31204 
+L 110.711808 265.331079 
+L 110.505717 264.348183 
+L 110.308663 263.363435 
+L 110.120663 262.376919 
+L 109.941732 261.388718 
+L 111.065668 260.397375 
+L 112.195386 259.405019 
+L 113.3311 258.41166 
+L 114.473036 257.417309 
+L 115.621428 256.421982 
+L 116.776524 255.425697 
+L 117.938585 254.428477 
+L 119.107884 253.430347 
+L 120.284709 252.431339 
+L 121.469363 251.431489 
+L 122.662164 250.430837 
+L 123.863449 249.429433 
+L 125.073572 248.427331 
+L 126.292905 247.424593 
+L 127.521845 246.421292 
+L 128.760806 245.417509 
+L 130.010228 244.413336 
+L 131.270576 243.408877 
+L 132.542341 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_229">
+    <path d="M 140.96649 205.495644 
+L 140.535936 206.403372 
+L 140.116133 207.316121 
+L 139.707139 208.233764 
+L 139.309011 209.156174 
+L 138.921804 210.083221 
+L 138.545574 211.014777 
+L 138.180371 211.950711 
+L 137.826247 212.890893 
+L 137.483252 213.835192 
+L 137.151433 214.783476 
+L 136.830837 215.735612 
+L 136.521508 216.691469 
+L 136.22349 217.650912 
+L 135.936823 218.613807 
+L 135.661549 219.580021 
+L 135.397705 220.549419 
+L 135.145328 221.521865 
+L 134.904454 222.497224 
+L 134.675115 223.47536 
+L 133.592125 222.492122 
+L 132.514832 221.51026 
+L 131.442982 220.529761 
+L 130.376337 219.550609 
+L 129.314672 218.572789 
+L 128.257775 217.596282 
+L 127.205446 216.62107 
+L 126.157496 215.647134 
+L 125.113746 214.674453 
+L 124.074027 213.703008 
+L 123.038178 212.732777 
+L 122.006047 211.76374 
+L 120.977491 210.795875 
+L 119.952374 209.829162 
+L 118.930565 208.86358 
+L 117.911941 207.899109 
+L 116.896386 206.935726 
+L 115.883789 205.973412 
+L 114.874043 205.012148 
+L 115.221854 204.07003 
+L 115.578305 203.131147 
+L 115.943365 202.195579 
+L 116.317004 201.263402 
+L 116.69919 200.334698 
+L 117.08989 199.409543 
+L 117.489072 198.488017 
+L 117.896703 197.570196 
+L 118.312747 196.656158 
+L 118.73717 195.74598 
+L 119.169935 194.83974 
+L 119.611007 193.937512 
+L 120.060348 193.039375 
+L 120.51792 192.145403 
+L 120.983685 191.255672 
+L 121.457603 190.370257 
+L 121.939634 189.489233 
+L 122.429738 188.612674 
+L 122.927873 187.740653 
+L 123.866146 188.668919 
+L 124.805409 189.597769 
+L 125.745696 190.527221 
+L 126.687045 191.45729 
+L 127.629493 192.387993 
+L 128.573081 193.319347 
+L 129.51785 194.25137 
+L 130.463847 195.184082 
+L 131.411118 196.117502 
+L 132.359714 197.051651 
+L 133.309686 197.98655 
+L 134.261091 198.922221 
+L 135.213988 199.858688 
+L 136.16844 200.795976 
+L 137.124513 201.734109 
+L 138.082278 202.673114 
+L 139.041808 203.613019 
+L 140.003184 204.553852 
+L 140.96649 205.495644 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_230">
+    <path d="M 134.675115 223.47536 
+L 134.457345 224.456136 
+L 134.251173 225.439416 
+L 134.056628 226.425062 
+L 133.873737 227.412937 
+L 133.702526 228.402903 
+L 133.543019 229.394822 
+L 133.395238 230.388555 
+L 133.259203 231.383965 
+L 133.134934 232.380912 
+L 133.022447 233.379257 
+L 132.921759 234.37886 
+L 132.832884 235.379584 
+L 132.755833 236.381287 
+L 132.690619 237.38383 
+L 132.637249 238.387073 
+L 132.595731 239.390877 
+L 132.566072 240.395101 
+L 132.548274 241.399606 
+L 132.542341 242.40425 
+L 131.270576 241.399623 
+L 130.010228 240.395164 
+L 128.760806 239.390991 
+L 127.521845 238.387208 
+L 126.292905 237.383907 
+L 125.073572 236.381169 
+L 123.863449 235.379067 
+L 122.662164 234.377663 
+L 121.469363 233.377011 
+L 120.284709 232.377161 
+L 119.107884 231.378153 
+L 117.938585 230.380023 
+L 116.776524 229.382803 
+L 115.621428 228.386518 
+L 114.473036 227.391191 
+L 113.3311 226.39684 
+L 112.195386 225.403481 
+L 111.065668 224.411125 
+L 109.941732 223.419782 
+L 110.120663 222.431581 
+L 110.308663 221.445065 
+L 110.505717 220.460317 
+L 110.711808 219.477421 
+L 110.92692 218.49646 
+L 111.151033 217.517516 
+L 111.38413 216.540672 
+L 111.62619 215.566011 
+L 111.877192 214.593614 
+L 112.137116 213.623564 
+L 112.40594 212.655942 
+L 112.683641 211.69083 
+L 112.970196 210.728311 
+L 113.26558 209.768463 
+L 113.569768 208.81137 
+L 113.882736 207.857112 
+L 114.204455 206.905768 
+L 114.5349 205.95742 
+L 114.874043 205.012148 
+L 115.883789 205.973412 
+L 116.896386 206.935726 
+L 117.911941 207.899109 
+L 118.930565 208.86358 
+L 119.952374 209.829162 
+L 120.977491 210.795875 
+L 122.006047 211.76374 
+L 123.038178 212.732777 
+L 124.074027 213.703008 
+L 125.113746 214.674453 
+L 126.157496 215.647134 
+L 127.205446 216.62107 
+L 128.257775 217.596282 
+L 129.314672 218.572789 
+L 130.376337 219.550609 
+L 131.442982 220.529761 
+L 132.514832 221.51026 
+L 133.592125 222.492122 
+L 134.675115 223.47536 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_231">
+    <path d="M 132.542341 242.40425 
+L 131.270576 243.408877 
+L 130.010228 244.413336 
+L 128.760806 245.417509 
+L 127.521845 246.421292 
+L 126.292905 247.424593 
+L 125.073572 248.427331 
+L 123.863449 249.429433 
+L 122.662164 250.430837 
+L 121.469363 251.431489 
+L 120.284709 252.431339 
+L 119.107884 253.430347 
+L 117.938585 254.428477 
+L 116.776524 255.425697 
+L 115.621428 256.421982 
+L 114.473036 257.417309 
+L 113.3311 258.41166 
+L 112.195386 259.405019 
+L 111.065668 260.397375 
+L 109.941732 261.388718 
+L 109.771887 260.398915 
+L 109.611141 259.407593 
+L 109.459508 258.414836 
+L 109.317 257.420729 
+L 109.183631 256.425354 
+L 109.05941 255.428797 
+L 108.944349 254.43114 
+L 108.838456 253.432469 
+L 108.741742 252.432866 
+L 108.654214 251.432418 
+L 108.57588 250.431208 
+L 108.506746 249.42932 
+L 108.446818 248.42684 
+L 108.396101 247.423852 
+L 108.3546 246.42044 
+L 108.322317 245.416689 
+L 108.299256 244.412684 
+L 108.285419 243.408509 
+L 108.280806 242.40425 
+L 108.285419 241.399991 
+L 108.299256 240.395816 
+L 108.322317 239.391811 
+L 108.3546 238.38806 
+L 108.396101 237.384648 
+L 108.446818 236.38166 
+L 108.506746 235.37918 
+L 108.57588 234.377292 
+L 108.654214 233.376082 
+L 108.741742 232.375634 
+L 108.838456 231.376031 
+L 108.944349 230.37736 
+L 109.05941 229.379703 
+L 109.183631 228.383146 
+L 109.317 227.387771 
+L 109.459508 226.393664 
+L 109.611141 225.400907 
+L 109.771887 224.409585 
+L 109.941732 223.419782 
+L 111.065668 224.411125 
+L 112.195386 225.403481 
+L 113.3311 226.39684 
+L 114.473036 227.391191 
+L 115.621428 228.386518 
+L 116.776524 229.382803 
+L 117.938585 230.380023 
+L 119.107884 231.378153 
+L 120.284709 232.377161 
+L 121.469363 233.377011 
+L 122.662164 234.377663 
+L 123.863449 235.379067 
+L 125.073572 236.381169 
+L 126.292905 237.383907 
+L 127.521845 238.387208 
+L 128.760806 239.390991 
+L 130.010228 240.395164 
+L 131.270576 241.399623 
+L 132.542341 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-opacity: 0.45; stroke-width: 0.35; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_232">
+    <path d="M 166.041075 190.839564 
+L 169.816336 190.371648 
+L 173.535682 190.128514 
+L 177.186951 190.104452 
+L 180.918621 190.306653 
+L 184.550058 190.733436 
+L 188.068837 191.37618 
+L 191.463108 192.225611 
+L 194.721627 193.271839 
+L 197.833789 194.504386 
+L 200.789653 195.91223 
+L 203.579975 197.483843 
+L 206.196229 199.207229 
+L 208.630633 201.069965 
+L 210.876166 203.059246 
+L 212.926587 205.161928 
+L 214.776456 207.364568 
+L 216.42114 209.653476 
+L 217.134052 210.774615 
+L 217.134052 210.774615 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #222222; stroke-width: 1.8; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_233">
+    <path d="M 217.134052 210.774615 
+L 214.801811 209.648409 
+L 212.309135 208.699812 
+L 209.669891 207.945776 
+L 206.899537 207.402151 
+L 204.259321 207.101169 
+L 201.537258 206.999527 
+L 198.748355 207.106419 
+L 195.90846 207.429914 
+L 193.034172 207.976888 
+L 190.142756 208.752962 
+L 187.252046 209.762442 
+L 184.380351 211.008271 
+L 181.546345 212.49199 
+L 178.768971 214.213698 
+L 176.067322 216.172029 
+L 173.693096 218.155295 
+L 171.411605 220.328566 
+L 169.237066 222.687608 
+L 167.183504 225.227164 
+L 165.264688 227.94097 
+L 163.494056 230.821763 
+L 161.884644 233.861297 
+L 160.449022 237.050374 
+L 159.199222 240.378861 
+L 158.146672 243.835729 
+L 157.302137 247.409089 
+L 156.675651 251.086229 
+L 156.276463 254.853662 
+L 156.112975 258.697175 
+L 156.192696 262.601885 
+L 156.47783 266.155645 
+L 156.969386 269.734738 
+L 157.670783 273.327149 
+L 158.584742 276.920576 
+L 159.713262 280.502472 
+L 161.057604 284.060084 
+L 162.618274 287.580495 
+L 164.395013 291.050676 
+L 166.154904 294.082519 
+L 166.154904 294.082519 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #222222; stroke-width: 1.8; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_234">
+    <path d="M 166.154904 294.082519 
+L 163.398457 291.183242 
+L 160.805145 288.137173 
+L 158.382772 284.953479 
+L 156.138626 281.641741 
+L 154.079462 278.211924 
+L 152.211477 274.674349 
+L 150.54029 271.039664 
+L 149.070933 267.318805 
+L 147.807826 263.52297 
+L 146.754771 259.663582 
+L 145.914936 255.752255 
+L 145.29085 251.800759 
+L 144.884389 247.820986 
+L 144.696778 243.824913 
+L 144.684151 242.824756 
+L 144.684151 242.824756 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #222222; stroke-width: 1.8; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_235">
+    <path d="M 144.684151 242.824756 
+L 143.955608 238.827149 
+L 143.462687 234.898574 
+L 143.181273 230.908825 
+L 143.116402 226.869387 
+L 143.272485 222.792103 
+L 143.653278 218.68914 
+L 144.261865 214.572953 
+L 145.100636 210.456247 
+L 146.17127 206.351939 
+L 147.422287 202.423579 
+L 148.8894 198.530656 
+L 150.572164 194.685053 
+L 152.469485 190.898694 
+L 154.579608 187.18351 
+L 156.807013 183.68942 
+L 156.807013 183.68942 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #222222; stroke-width: 1.8; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_236">
+    <path d="M 254.082592 242.40425 
+L 258.844981 238.525715 
+L 264.406745 233.714156 
+L 271.725204 227.065959 
+L 281.619069 217.728715 
+L 294.87017 204.888955 
+L 312.288127 187.740653 
+L 314.619712 191.994301 
+L 316.760318 196.347187 
+L 318.705731 200.790741 
+L 320.45212 205.316217 
+L 321.996049 209.914705 
+L 323.334477 214.577152 
+L 324.46477 219.294381 
+L 325.384702 224.057104 
+L 326.092463 228.855946 
+L 326.586659 233.681459 
+L 326.866318 238.524144 
+L 326.930888 243.374468 
+L 326.780244 248.222881 
+L 326.41468 253.05984 
+L 325.834918 257.875822 
+L 325.042097 262.661346 
+L 324.03778 267.406992 
+L 322.823943 272.103417 
+L 321.402976 276.741375 
+L 319.777676 281.311737 
+L 317.951242 285.805505 
+L 315.927271 290.213832 
+L 313.709747 294.52804 
+L 312.288127 297.067847 
+L 290.193614 275.358968 
+L 276.734299 262.432204 
+L 267.596772 253.95614 
+L 261.112854 248.213391 
+L 255.30623 243.375223 
+L 254.082592 242.40425 
+L 254.082592 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_237">
+    <path d="M 217.608 278.878842 
+L 220.518166 278.762561 
+L 223.409776 278.41446 
+L 226.264394 277.836759 
+L 229.06382 277.03314 
+L 231.790203 276.008728 
+L 234.426161 274.770055 
+L 236.954886 273.325017 
+L 239.360256 271.682829 
+L 241.626934 269.853962 
+L 243.740467 267.850075 
+L 245.68738 265.683946 
+L 247.45526 263.369386 
+L 249.032833 260.921153 
+L 250.410043 258.354856 
+L 251.578107 255.686858 
+L 252.529578 252.934171 
+L 253.25839 250.114345 
+L 253.759895 247.245359 
+L 254.030896 244.345507 
+L 254.082592 242.40425 
+L 258.844981 246.282785 
+L 264.406745 251.094344 
+L 271.725204 257.742541 
+L 281.619069 267.079785 
+L 294.87017 279.919545 
+L 312.288127 297.067847 
+L 309.770153 301.213883 
+L 307.070746 305.244144 
+L 304.195221 309.150698 
+L 301.149239 312.925854 
+L 297.938796 316.562179 
+L 294.570212 320.052516 
+L 291.050118 323.389992 
+L 287.385445 326.568039 
+L 283.583407 329.580399 
+L 279.651488 332.421142 
+L 275.597429 335.084676 
+L 272.271597 337.084377 
+L 250.562718 314.989864 
+L 237.635954 301.530549 
+L 229.15989 292.393022 
+L 223.417141 285.909104 
+L 218.578973 280.10248 
+L 217.608 278.878842 
+L 217.608 278.878842 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_238">
+    <path d="M 217.608 278.878842 
+L 221.486535 283.641231 
+L 226.298094 289.202995 
+L 232.946291 296.521454 
+L 242.283535 306.415319 
+L 255.123295 319.66642 
+L 272.271597 337.084377 
+L 268.017949 339.415962 
+L 263.665063 341.556568 
+L 259.221509 343.501981 
+L 254.696033 345.24837 
+L 250.097545 346.792299 
+L 245.435098 348.130727 
+L 240.717869 349.26102 
+L 235.955146 350.180952 
+L 231.156304 350.888713 
+L 226.330791 351.382909 
+L 221.488106 351.662568 
+L 216.637782 351.727138 
+L 211.789369 351.576494 
+L 206.95241 351.21093 
+L 202.136428 350.631168 
+L 197.350904 349.838347 
+L 192.605258 348.83403 
+L 187.908833 347.620193 
+L 183.270875 346.199226 
+L 178.700513 344.573926 
+L 174.206745 342.747492 
+L 169.798418 340.723521 
+L 165.48421 338.505997 
+L 162.944403 337.084377 
+L 184.653282 314.989864 
+L 197.580046 301.530549 
+L 206.05611 292.393022 
+L 211.798859 285.909104 
+L 216.637027 280.10248 
+L 217.608 278.878842 
+L 217.608 278.878842 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_239">
+    <path d="M 254.082592 242.40425 
+L 253.966311 239.494084 
+L 253.61821 236.602474 
+L 253.040509 233.747856 
+L 252.23689 230.94843 
+L 251.212478 228.222047 
+L 249.973805 225.586089 
+L 248.528767 223.057364 
+L 246.886579 220.651994 
+L 245.057712 218.385316 
+L 243.053825 216.271783 
+L 240.887696 214.32487 
+L 238.573136 212.55699 
+L 236.124903 210.979417 
+L 233.558606 209.602207 
+L 230.890608 208.434143 
+L 228.137921 207.482672 
+L 225.318095 206.75386 
+L 222.449109 206.252355 
+L 219.549257 205.981354 
+L 217.608 205.929658 
+L 221.486535 201.167269 
+L 226.298094 195.605505 
+L 232.946291 188.287046 
+L 242.283535 178.393181 
+L 255.123295 165.14208 
+L 272.271597 147.724123 
+L 276.417633 150.242097 
+L 280.447894 152.941504 
+L 284.354448 155.817029 
+L 288.129604 158.863011 
+L 291.765929 162.073454 
+L 295.256266 165.442038 
+L 298.593742 168.962132 
+L 301.771789 172.626805 
+L 304.784149 176.428843 
+L 307.624892 180.360762 
+L 310.288426 184.414821 
+L 312.288127 187.740653 
+L 290.193614 209.449532 
+L 276.734299 222.376296 
+L 267.596772 230.85236 
+L 261.112854 236.595109 
+L 255.30623 241.433277 
+L 254.082592 242.40425 
+L 254.082592 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_240">
+    <path d="M 254.082592 242.40425 
+L 253.966311 245.314416 
+L 253.61821 248.206026 
+L 253.040509 251.060644 
+L 252.23689 253.86007 
+L 251.212478 256.586453 
+L 249.973805 259.222411 
+L 248.528767 261.751136 
+L 246.886579 264.156506 
+L 245.057712 266.423184 
+L 243.053825 268.536717 
+L 240.887696 270.48363 
+L 238.573136 272.25151 
+L 236.124903 273.829083 
+L 233.558606 275.206293 
+L 230.890608 276.374357 
+L 228.137921 277.325828 
+L 225.318095 278.05464 
+L 222.449109 278.556145 
+L 219.549257 278.827146 
+L 216.637027 278.865916 
+L 213.730989 278.672206 
+L 210.849669 278.247252 
+L 208.011441 277.593764 
+L 205.234401 276.715908 
+L 202.536254 275.619282 
+L 199.934205 274.310876 
+L 197.444843 272.799035 
+L 195.084042 271.093397 
+L 192.866853 269.204837 
+L 190.807413 267.145397 
+L 188.918853 264.928208 
+L 187.213215 262.567407 
+L 185.701374 260.078045 
+L 184.392968 257.475996 
+L 183.296342 254.777849 
+L 182.418486 252.000809 
+L 181.764998 249.162581 
+L 181.340044 246.281261 
+L 181.146334 243.375223 
+L 181.185104 240.462993 
+L 181.456105 237.563141 
+L 181.95761 234.694155 
+L 182.686422 231.874329 
+L 183.637893 229.121642 
+L 184.805957 226.453644 
+L 186.183167 223.887347 
+L 187.76074 221.439114 
+L 189.52862 219.124554 
+L 191.475533 216.958425 
+L 193.589066 214.954538 
+L 195.855744 213.125671 
+L 198.261114 211.483483 
+L 200.789839 210.038445 
+L 203.425797 208.799772 
+L 206.15218 207.77536 
+L 208.951606 206.971741 
+L 211.806224 206.39404 
+L 214.697834 206.045939 
+L 217.608 205.929658 
+L 220.518166 206.045939 
+L 223.409776 206.39404 
+L 226.264394 206.971741 
+L 229.06382 207.77536 
+L 231.790203 208.799772 
+L 234.426161 210.038445 
+L 236.954886 211.483483 
+L 239.360256 213.125671 
+L 241.626934 214.954538 
+L 243.740467 216.958425 
+L 245.68738 219.124554 
+L 247.45526 221.439114 
+L 249.032833 223.887347 
+L 250.410043 226.453644 
+L 251.578107 229.121642 
+L 252.529578 231.874329 
+L 253.25839 234.694155 
+L 253.759895 237.563141 
+L 254.030896 240.462993 
+L 254.082592 242.40425 
+L 254.082592 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_241">
+    <path d="M 181.133408 242.40425 
+L 181.249689 245.314416 
+L 181.59779 248.206026 
+L 182.175491 251.060644 
+L 182.97911 253.86007 
+L 184.003522 256.586453 
+L 185.242195 259.222411 
+L 186.687233 261.751136 
+L 188.329421 264.156506 
+L 190.158288 266.423184 
+L 192.162175 268.536717 
+L 194.328304 270.48363 
+L 196.642864 272.25151 
+L 199.091097 273.829083 
+L 201.657394 275.206293 
+L 204.325392 276.374357 
+L 207.078079 277.325828 
+L 209.897905 278.05464 
+L 212.766891 278.556145 
+L 215.666743 278.827146 
+L 217.608 278.878842 
+L 213.729465 283.641231 
+L 208.917906 289.202995 
+L 202.269709 296.521454 
+L 192.932465 306.415319 
+L 180.092705 319.66642 
+L 162.944403 337.084377 
+L 158.798367 334.566403 
+L 154.768106 331.866996 
+L 150.861552 328.991471 
+L 147.086396 325.945489 
+L 143.450071 322.735046 
+L 139.959734 319.366462 
+L 136.622258 315.846368 
+L 133.444211 312.181695 
+L 130.431851 308.379657 
+L 127.591108 304.447738 
+L 124.927574 300.393679 
+L 122.927873 297.067847 
+L 145.022386 275.358968 
+L 158.481701 262.432204 
+L 167.619228 253.95614 
+L 174.103146 248.213391 
+L 179.90977 243.375223 
+L 181.133408 242.40425 
+L 181.133408 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_242">
+    <path d="M 217.608 205.929658 
+L 213.729465 201.167269 
+L 208.917906 195.605505 
+L 202.269709 188.287046 
+L 192.932465 178.393181 
+L 180.092705 165.14208 
+L 162.944403 147.724123 
+L 167.198051 145.392538 
+L 171.550937 143.251932 
+L 175.994491 141.306519 
+L 180.519967 139.56013 
+L 185.118455 138.016201 
+L 189.780902 136.677773 
+L 194.498131 135.54748 
+L 199.260854 134.627548 
+L 204.059696 133.919787 
+L 208.885209 133.425591 
+L 213.727894 133.145932 
+L 218.578218 133.081362 
+L 223.426631 133.232006 
+L 228.26359 133.59757 
+L 233.079572 134.177332 
+L 237.865096 134.970153 
+L 242.610742 135.97447 
+L 247.307167 137.188307 
+L 251.945125 138.609274 
+L 256.515487 140.234574 
+L 261.009255 142.061008 
+L 265.417582 144.084979 
+L 269.73179 146.302503 
+L 272.271597 147.724123 
+L 250.562718 169.818636 
+L 237.635954 183.277951 
+L 229.15989 192.415478 
+L 223.417141 198.899396 
+L 218.578973 204.70602 
+L 217.608 205.929658 
+L 217.608 205.929658 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_243">
+    <path d="M 217.608 205.929658 
+L 214.697834 206.045939 
+L 211.806224 206.39404 
+L 208.951606 206.971741 
+L 206.15218 207.77536 
+L 203.425797 208.799772 
+L 200.789839 210.038445 
+L 198.261114 211.483483 
+L 195.855744 213.125671 
+L 193.589066 214.954538 
+L 191.475533 216.958425 
+L 189.52862 219.124554 
+L 187.76074 221.439114 
+L 186.183167 223.887347 
+L 184.805957 226.453644 
+L 183.637893 229.121642 
+L 182.686422 231.874329 
+L 181.95761 234.694155 
+L 181.456105 237.563141 
+L 181.185104 240.462993 
+L 181.133408 242.40425 
+L 176.371019 238.525715 
+L 170.809255 233.714156 
+L 163.490796 227.065959 
+L 153.596931 217.728715 
+L 140.34583 204.888955 
+L 122.927873 187.740653 
+L 125.445847 183.594617 
+L 128.145254 179.564356 
+L 131.020779 175.657802 
+L 134.066761 171.882646 
+L 137.277204 168.246321 
+L 140.645788 164.755984 
+L 144.165882 161.418508 
+L 147.830555 158.240461 
+L 151.632593 155.228101 
+L 155.564512 152.387358 
+L 159.618571 149.723824 
+L 162.944403 147.724123 
+L 184.653282 169.818636 
+L 197.580046 183.277951 
+L 206.05611 192.415478 
+L 211.798859 198.899396 
+L 216.637027 204.70602 
+L 217.608 205.929658 
+L 217.608 205.929658 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_244">
+    <path d="M 181.133408 242.40425 
+L 176.371019 246.282785 
+L 170.809255 251.094344 
+L 163.490796 257.742541 
+L 153.596931 267.079785 
+L 140.34583 279.919545 
+L 122.927873 297.067847 
+L 120.596288 292.814199 
+L 118.455682 288.461313 
+L 116.510269 284.017759 
+L 114.76388 279.492283 
+L 113.219951 274.893795 
+L 111.881523 270.231348 
+L 110.75123 265.514119 
+L 109.831298 260.751396 
+L 109.123537 255.952554 
+L 108.629341 251.127041 
+L 108.349682 246.284356 
+L 108.285112 241.434032 
+L 108.435756 236.585619 
+L 108.80132 231.74866 
+L 109.381082 226.932678 
+L 110.173903 222.147154 
+L 111.17822 217.401508 
+L 112.392057 212.705083 
+L 113.813024 208.067125 
+L 115.438324 203.496763 
+L 117.264758 199.002995 
+L 119.288729 194.594668 
+L 121.506253 190.28046 
+L 122.927873 187.740653 
+L 145.022386 209.449532 
+L 158.481701 222.376296 
+L 167.619228 230.85236 
+L 174.103146 236.595109 
+L 179.90977 241.433277 
+L 181.133408 242.40425 
+L 181.133408 242.40425 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #e5735c; stroke-width: 1.2; stroke-linecap: square"/>
+   </g>
+   <g id="text_1">
+    <!-- linetrace across the north polar cap (resolution 3, view from above the pole) -->
+    <g transform="translate(26.361906 14.798437) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2c" d="M 750 794 
+L 1409 794 
+L 1409 256 
+L 897 -744 
+L 494 -744 
+L 750 256 
+L 750 794 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-76" d="M 191 3500 
+L 800 3500 
+L 1894 563 
+L 2988 3500 
+L 3597 3500 
+L 2284 0 
+L 1503 0 
+L 191 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-77" d="M 269 3500 
+L 844 3500 
+L 1563 769 
+L 2278 3500 
+L 2956 3500 
+L 3675 769 
+L 4391 3500 
+L 4966 3500 
+L 4050 0 
+L 3372 0 
+L 2619 2869 
+L 1863 0 
+L 1184 0 
+L 269 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863 
+L 2375 4384 
+L 1825 4384 
+Q 1516 4384 1395 4259 
+Q 1275 4134 1275 3809 
+L 1275 3500 
+L 2222 3500 
+L 2222 3053 
+L 1275 3053 
+L 1275 0 
+L 697 0 
+L 697 3053 
+L 147 3053 
+L 147 3500 
+L 697 3500 
+L 697 3744 
+Q 697 4328 969 4595 
+Q 1241 4863 1831 4863 
+L 2375 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+M 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2969 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-6c"/>
+     <use xlink:href="#DejaVuSans-69" x="27.783203"/>
+     <use xlink:href="#DejaVuSans-6e" x="55.566406"/>
+     <use xlink:href="#DejaVuSans-65" x="118.945312"/>
+     <use xlink:href="#DejaVuSans-74" x="180.46875"/>
+     <use xlink:href="#DejaVuSans-72" x="219.677734"/>
+     <use xlink:href="#DejaVuSans-61" x="260.791016"/>
+     <use xlink:href="#DejaVuSans-63" x="322.070312"/>
+     <use xlink:href="#DejaVuSans-65" x="377.050781"/>
+     <use xlink:href="#DejaVuSans-20" x="438.574219"/>
+     <use xlink:href="#DejaVuSans-61" x="470.361328"/>
+     <use xlink:href="#DejaVuSans-63" x="531.640625"/>
+     <use xlink:href="#DejaVuSans-72" x="586.621094"/>
+     <use xlink:href="#DejaVuSans-6f" x="625.484375"/>
+     <use xlink:href="#DejaVuSans-73" x="686.666016"/>
+     <use xlink:href="#DejaVuSans-73" x="738.765625"/>
+     <use xlink:href="#DejaVuSans-20" x="790.865234"/>
+     <use xlink:href="#DejaVuSans-74" x="822.652344"/>
+     <use xlink:href="#DejaVuSans-68" x="861.861328"/>
+     <use xlink:href="#DejaVuSans-65" x="925.240234"/>
+     <use xlink:href="#DejaVuSans-20" x="986.763672"/>
+     <use xlink:href="#DejaVuSans-6e" x="1018.550781"/>
+     <use xlink:href="#DejaVuSans-6f" x="1081.929688"/>
+     <use xlink:href="#DejaVuSans-72" x="1143.111328"/>
+     <use xlink:href="#DejaVuSans-74" x="1184.224609"/>
+     <use xlink:href="#DejaVuSans-68" x="1223.433594"/>
+     <use xlink:href="#DejaVuSans-20" x="1286.8125"/>
+     <use xlink:href="#DejaVuSans-70" x="1318.599609"/>
+     <use xlink:href="#DejaVuSans-6f" x="1382.076172"/>
+     <use xlink:href="#DejaVuSans-6c" x="1443.257812"/>
+     <use xlink:href="#DejaVuSans-61" x="1471.041016"/>
+     <use xlink:href="#DejaVuSans-72" x="1532.320312"/>
+     <use xlink:href="#DejaVuSans-20" x="1573.433594"/>
+     <use xlink:href="#DejaVuSans-63" x="1605.220703"/>
+     <use xlink:href="#DejaVuSans-61" x="1660.201172"/>
+     <use xlink:href="#DejaVuSans-70" x="1721.480469"/>
+     <use xlink:href="#DejaVuSans-20" x="1784.957031"/>
+     <use xlink:href="#DejaVuSans-28" x="1816.744141"/>
+     <use xlink:href="#DejaVuSans-72" x="1855.757812"/>
+     <use xlink:href="#DejaVuSans-65" x="1894.621094"/>
+     <use xlink:href="#DejaVuSans-73" x="1956.144531"/>
+     <use xlink:href="#DejaVuSans-6f" x="2008.244141"/>
+     <use xlink:href="#DejaVuSans-6c" x="2069.425781"/>
+     <use xlink:href="#DejaVuSans-75" x="2097.208984"/>
+     <use xlink:href="#DejaVuSans-74" x="2160.587891"/>
+     <use xlink:href="#DejaVuSans-69" x="2199.796875"/>
+     <use xlink:href="#DejaVuSans-6f" x="2227.580078"/>
+     <use xlink:href="#DejaVuSans-6e" x="2288.761719"/>
+     <use xlink:href="#DejaVuSans-20" x="2352.140625"/>
+     <use xlink:href="#DejaVuSans-33" x="2383.927734"/>
+     <use xlink:href="#DejaVuSans-2c" x="2447.550781"/>
+     <use xlink:href="#DejaVuSans-20" x="2479.337891"/>
+     <use xlink:href="#DejaVuSans-76" x="2511.125"/>
+     <use xlink:href="#DejaVuSans-69" x="2570.304688"/>
+     <use xlink:href="#DejaVuSans-65" x="2598.087891"/>
+     <use xlink:href="#DejaVuSans-77" x="2659.611328"/>
+     <use xlink:href="#DejaVuSans-20" x="2741.398438"/>
+     <use xlink:href="#DejaVuSans-66" x="2773.185547"/>
+     <use xlink:href="#DejaVuSans-72" x="2808.390625"/>
+     <use xlink:href="#DejaVuSans-6f" x="2847.253906"/>
+     <use xlink:href="#DejaVuSans-6d" x="2908.435547"/>
+     <use xlink:href="#DejaVuSans-20" x="3005.847656"/>
+     <use xlink:href="#DejaVuSans-61" x="3037.634766"/>
+     <use xlink:href="#DejaVuSans-62" x="3098.914062"/>
+     <use xlink:href="#DejaVuSans-6f" x="3162.390625"/>
+     <use xlink:href="#DejaVuSans-76" x="3223.572266"/>
+     <use xlink:href="#DejaVuSans-65" x="3282.751953"/>
+     <use xlink:href="#DejaVuSans-20" x="3344.275391"/>
+     <use xlink:href="#DejaVuSans-74" x="3376.0625"/>
+     <use xlink:href="#DejaVuSans-68" x="3415.271484"/>
+     <use xlink:href="#DejaVuSans-65" x="3478.650391"/>
+     <use xlink:href="#DejaVuSans-20" x="3540.173828"/>
+     <use xlink:href="#DejaVuSans-70" x="3571.960938"/>
+     <use xlink:href="#DejaVuSans-6f" x="3635.4375"/>
+     <use xlink:href="#DejaVuSans-6c" x="3696.619141"/>
+     <use xlink:href="#DejaVuSans-65" x="3724.402344"/>
+     <use xlink:href="#DejaVuSans-29" x="3785.925781"/>
+    </g>
+    <!-- traced: N447 → N444 → N447 → N448 → N445 → N448 → N447 -->
+    <g transform="translate(61.056437 25.99625) scale(0.1 -0.1)">
+     <defs>
+      <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-3a" d="M 750 794 
+L 1409 794 
+L 1409 0 
+L 750 0 
+L 750 794 
+z
+M 750 3309 
+L 1409 3309 
+L 1409 2516 
+L 750 2516 
+L 750 3309 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2192" d="M 5050 2147 
+L 5050 1866 
+L 3822 638 
+L 3447 1013 
+L 4175 1741 
+L 366 1741 
+L 366 2272 
+L 4175 2272 
+L 3447 3000 
+L 3822 3375 
+L 5050 2147 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-74"/>
+     <use xlink:href="#DejaVuSans-72" x="39.208984"/>
+     <use xlink:href="#DejaVuSans-61" x="80.322266"/>
+     <use xlink:href="#DejaVuSans-63" x="141.601562"/>
+     <use xlink:href="#DejaVuSans-65" x="196.582031"/>
+     <use xlink:href="#DejaVuSans-64" x="258.105469"/>
+     <use xlink:href="#DejaVuSans-3a" x="321.582031"/>
+     <use xlink:href="#DejaVuSans-20" x="355.273438"/>
+     <use xlink:href="#DejaVuSans-4e" x="387.060547"/>
+     <use xlink:href="#DejaVuSans-34" x="461.865234"/>
+     <use xlink:href="#DejaVuSans-34" x="525.488281"/>
+     <use xlink:href="#DejaVuSans-37" x="589.111328"/>
+     <use xlink:href="#DejaVuSans-20" x="652.734375"/>
+     <use xlink:href="#DejaVuSans-2192" x="684.521484"/>
+     <use xlink:href="#DejaVuSans-20" x="768.310547"/>
+     <use xlink:href="#DejaVuSans-4e" x="800.097656"/>
+     <use xlink:href="#DejaVuSans-34" x="874.902344"/>
+     <use xlink:href="#DejaVuSans-34" x="938.525391"/>
+     <use xlink:href="#DejaVuSans-34" x="1002.148438"/>
+     <use xlink:href="#DejaVuSans-20" x="1065.771484"/>
+     <use xlink:href="#DejaVuSans-2192" x="1097.558594"/>
+     <use xlink:href="#DejaVuSans-20" x="1181.347656"/>
+     <use xlink:href="#DejaVuSans-4e" x="1213.134766"/>
+     <use xlink:href="#DejaVuSans-34" x="1287.939453"/>
+     <use xlink:href="#DejaVuSans-34" x="1351.5625"/>
+     <use xlink:href="#DejaVuSans-37" x="1415.185547"/>
+     <use xlink:href="#DejaVuSans-20" x="1478.808594"/>
+     <use xlink:href="#DejaVuSans-2192" x="1510.595703"/>
+     <use xlink:href="#DejaVuSans-20" x="1594.384766"/>
+     <use xlink:href="#DejaVuSans-4e" x="1626.171875"/>
+     <use xlink:href="#DejaVuSans-34" x="1700.976562"/>
+     <use xlink:href="#DejaVuSans-34" x="1764.599609"/>
+     <use xlink:href="#DejaVuSans-38" x="1828.222656"/>
+     <use xlink:href="#DejaVuSans-20" x="1891.845703"/>
+     <use xlink:href="#DejaVuSans-2192" x="1923.632812"/>
+     <use xlink:href="#DejaVuSans-20" x="2007.421875"/>
+     <use xlink:href="#DejaVuSans-4e" x="2039.208984"/>
+     <use xlink:href="#DejaVuSans-34" x="2114.013672"/>
+     <use xlink:href="#DejaVuSans-34" x="2177.636719"/>
+     <use xlink:href="#DejaVuSans-35" x="2241.259766"/>
+     <use xlink:href="#DejaVuSans-20" x="2304.882812"/>
+     <use xlink:href="#DejaVuSans-2192" x="2336.669922"/>
+     <use xlink:href="#DejaVuSans-20" x="2420.458984"/>
+     <use xlink:href="#DejaVuSans-4e" x="2452.246094"/>
+     <use xlink:href="#DejaVuSans-34" x="2527.050781"/>
+     <use xlink:href="#DejaVuSans-34" x="2590.673828"/>
+     <use xlink:href="#DejaVuSans-38" x="2654.296875"/>
+     <use xlink:href="#DejaVuSans-20" x="2717.919922"/>
+     <use xlink:href="#DejaVuSans-2192" x="2749.707031"/>
+     <use xlink:href="#DejaVuSans-20" x="2833.496094"/>
+     <use xlink:href="#DejaVuSans-4e" x="2865.283203"/>
+     <use xlink:href="#DejaVuSans-34" x="2940.087891"/>
+     <use xlink:href="#DejaVuSans-34" x="3003.710938"/>
+     <use xlink:href="#DejaVuSans-37" x="3067.333984"/>
+    </g>
+   </g>
+   <g id="line2d_245">
+    <path d="M 166.041075 190.839564 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #222222; stroke-width: 1.5; stroke-linecap: square"/>
+    <defs>
+     <path id="m3ad432ea6a" d="M 0 2.5 
+C 0.663008 2.5 1.29895 2.236584 1.767767 1.767767 
+C 2.236584 1.29895 2.5 0.663008 2.5 0 
+C 2.5 -0.663008 2.236584 -1.29895 1.767767 -1.767767 
+C 1.29895 -2.236584 0.663008 -2.5 0 -2.5 
+C -0.663008 -2.5 -1.29895 -2.236584 -1.767767 -1.767767 
+C -2.236584 -1.29895 -2.5 -0.663008 -2.5 0 
+C -2.5 0.663008 -2.236584 1.29895 -1.767767 1.767767 
+C -1.29895 2.236584 -0.663008 2.5 0 2.5 
+z
+" style="stroke: #222222"/>
+    </defs>
+    <g clip-path="url(#p7c8276638b)">
+     <use xlink:href="#m3ad432ea6a" x="166.041075" y="190.839564" style="fill: #222222; stroke: #222222"/>
+    </g>
+   </g>
+   <g id="line2d_246">
+    <path d="M 156.807013 183.68942 
+" clip-path="url(#p7c8276638b)" style="fill: none; stroke: #222222; stroke-width: 1.5; stroke-linecap: square"/>
+    <defs>
+     <path id="m031f6a2266" d="M -2.5 2.5 
+L 2.5 2.5 
+L 2.5 -2.5 
+L -2.5 -2.5 
+z
+" style="stroke: #222222; stroke-linejoin: miter"/>
+    </defs>
+    <g clip-path="url(#p7c8276638b)">
+     <use xlink:href="#m031f6a2266" x="156.807013" y="183.68942" style="fill: #222222; stroke: #222222; stroke-linejoin: miter"/>
+    </g>
+   </g>
+   <g id="text_2">
+    <g id="patch_6">
+     <path d="M 277.587109 247.749406 
+L 303.478984 247.749406 
+L 303.478984 237.059094 
+L 277.587109 237.059094 
+z
+" style="fill: #ffffff; opacity: 0.6"/>
+    </g>
+    <!-- N440 -->
+    <g style="fill: #333333" transform="translate(278.577109 244.887688) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-34" x="74.804688"/>
+     <use xlink:href="#DejaVuSans-34" x="138.427734"/>
+     <use xlink:href="#DejaVuSans-30" x="202.050781"/>
+    </g>
+   </g>
+   <g id="text_3">
+    <g id="patch_7">
+     <path d="M 256.227858 299.315201 
+L 282.119733 299.315201 
+L 282.119733 288.624889 
+L 256.227858 288.624889 
+z
+" style="fill: #ffffff; opacity: 0.6"/>
+    </g>
+    <!-- N441 -->
+    <g style="fill: #333333" transform="translate(257.217858 296.453483) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-34" x="74.804688"/>
+     <use xlink:href="#DejaVuSans-34" x="138.427734"/>
+     <use xlink:href="#DejaVuSans-31" x="202.050781"/>
+    </g>
+   </g>
+   <g id="text_4">
+    <g id="patch_8">
+     <path d="M 204.662063 320.674453 
+L 230.553938 320.674453 
+L 230.553938 309.98414 
+L 204.662063 309.98414 
+z
+" style="fill: #ffffff; opacity: 0.6"/>
+    </g>
+    <!-- N442 -->
+    <g style="fill: #333333" transform="translate(205.652063 317.812734) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-34" x="74.804688"/>
+     <use xlink:href="#DejaVuSans-34" x="138.427734"/>
+     <use xlink:href="#DejaVuSans-32" x="202.050781"/>
+    </g>
+   </g>
+   <g id="text_5">
+    <g id="patch_9">
+     <path d="M 256.227858 196.183611 
+L 282.119733 196.183611 
+L 282.119733 185.493299 
+L 256.227858 185.493299 
+z
+" style="fill: #ffffff; opacity: 0.6"/>
+    </g>
+    <!-- N443 -->
+    <g style="fill: #333333" transform="translate(257.217858 193.321892) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-34" x="74.804688"/>
+     <use xlink:href="#DejaVuSans-34" x="138.427734"/>
+     <use xlink:href="#DejaVuSans-33" x="202.050781"/>
+    </g>
+   </g>
+   <g id="text_6">
+    <g id="patch_10">
+     <path d="M 204.662062 247.749406 
+L 230.553937 247.749406 
+L 230.553937 237.059094 
+L 204.662062 237.059094 
+z
+" style="fill: #ffffff; opacity: 0.6"/>
+    </g>
+    <!-- N444 -->
+    <g style="fill: #333333" transform="translate(205.652062 244.887687) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-34" x="74.804688"/>
+     <use xlink:href="#DejaVuSans-34" x="138.427734"/>
+     <use xlink:href="#DejaVuSans-34" x="202.050781"/>
+    </g>
+   </g>
+   <g id="text_7">
+    <g id="patch_11">
+     <path d="M 153.096267 299.315201 
+L 178.988142 299.315201 
+L 178.988142 288.624889 
+L 153.096267 288.624889 
+z
+" style="fill: #ffffff; opacity: 0.6"/>
+    </g>
+    <!-- N445 -->
+    <g style="fill: #333333" transform="translate(154.086267 296.453483) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-34" x="74.804688"/>
+     <use xlink:href="#DejaVuSans-34" x="138.427734"/>
+     <use xlink:href="#DejaVuSans-35" x="202.050781"/>
+    </g>
+   </g>
+   <g id="text_8">
+    <g id="patch_12">
+     <path d="M 204.662062 174.82436 
+L 230.553937 174.82436 
+L 230.553937 164.134047 
+L 204.662062 164.134047 
+z
+" style="fill: #ffffff; opacity: 0.6"/>
+    </g>
+    <!-- N446 -->
+    <g style="fill: #333333" transform="translate(205.652062 171.962641) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-34" x="74.804688"/>
+     <use xlink:href="#DejaVuSans-34" x="138.427734"/>
+     <use xlink:href="#DejaVuSans-36" x="202.050781"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <g id="patch_13">
+     <path d="M 153.096267 196.183611 
+L 178.988142 196.183611 
+L 178.988142 185.493299 
+L 153.096267 185.493299 
+z
+" style="fill: #ffffff; opacity: 0.6"/>
+    </g>
+    <!-- N447 -->
+    <g style="fill: #333333" transform="translate(154.086267 193.321892) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-34" x="74.804688"/>
+     <use xlink:href="#DejaVuSans-34" x="138.427734"/>
+     <use xlink:href="#DejaVuSans-37" x="202.050781"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <g id="patch_14">
+     <path d="M 131.737016 247.749406 
+L 157.628891 247.749406 
+L 157.628891 237.059094 
+L 131.737016 237.059094 
+z
+" style="fill: #ffffff; opacity: 0.6"/>
+    </g>
+    <!-- N448 -->
+    <g style="fill: #333333" transform="translate(132.727016 244.887688) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-4e"/>
+     <use xlink:href="#DejaVuSans-34" x="74.804688"/>
+     <use xlink:href="#DejaVuSans-34" x="138.427734"/>
+     <use xlink:href="#DejaVuSans-38" x="202.050781"/>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p7c8276638b">
+   <rect x="7.2" y="31.99625" width="420.816" height="420.816"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/docs/source/rhp_wrappers.rst
+++ b/docs/source/rhp_wrappers.rst
@@ -15,6 +15,24 @@ The rhp_wrappers Module
    partway down the South Island is the boundary between the equatorial
    R cells (quads) and the south polar S cells (skew quads).
 
+.. figure:: images/wrappers_cap_trace.svg
+   :alt: View from above the north pole showing the nine resolution 3
+         cells around it, with a linestring curving around the pole and
+         the cells it passes through -- including the circular cap cell
+         N444 -- drawn filled.
+   :width: 80%
+   :align: center
+
+   ``linetrace`` across the north polar cap, viewed from above the pole
+   (Arctic coastlines in grey: northern Greenland at lower left,
+   Svalbard below, Franz Josef Land at lower right; the resolution 4
+   sub-grid is drawn as a faint outline). A linestring's
+   segments are straight in longitude-latitude coordinates, so at these
+   latitudes each leg curves *around* the pole rather than hopping
+   across it, passing through the circular cap cell N444 and the dart
+   and skew-quad cells surrounding it -- the cell shapes for which no
+   longitude-latitude rectangle is a valid approximation.
+
 .. currentmodule:: rhealpixdggs.rhp_wrappers
 
 .. autosummary::

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -152,7 +152,7 @@ orient the DGGS so that the planar origin (0, 0) is on Auckland, New Zealand ::
 # *****************************************************************************
 # Import third-party modules.
 from numpy import array, base_repr, ceil, log, pi
-from shapely import LineString
+from math import asin, copysign, floor
 
 # Import standard modules.
 from itertools import product
@@ -168,7 +168,7 @@ from rhealpixdggs.ellipsoids import (
     UNIT_SPHERE,
     UNIT_SPHERE_RADIANS,
 )
-from rhealpixdggs.utils import my_round
+from rhealpixdggs.utils import auth_lat, my_round
 from numpy.testing import assert_allclose
 
 
@@ -1163,19 +1163,44 @@ class RHEALPixDGGS(object):
         lstart: tuple[float, float],
         lend: tuple[float, float],
         plane: bool = True,
+        wrap_antimeridian: bool = False,
     ) -> list[Cell]:
         """
-        Return a list of the resolution `resolution` cells along an arbitrary line
-        given by two points on the sphere or plane.
+        Return the ordered list of resolution `resolution` cells that the
+        line segment from `lstart` to `lend` passes through.
 
-        NOTE:
+        The segment is straight in the given coordinate space: planar
+        coordinates if `plane` = True, longitude-latitude coordinates
+        otherwise (so it is a plate carree straight line, not a geodesic;
+        to trace a geodesic, densify it into short segments first). In
+        particular, a longitude-latitude segment spanning more than half
+        a turn of longitude does not, by default, wrap around the
+        antimeridian: a segment from longitude 179 to longitude -179 runs
+        the long way around, through longitude 0 -- the literal planar
+        reading of the coordinates. Splitting inputs at the antimeridian
+        (as GeoJSON's RFC 7946 prescribes for data producers) avoids the
+        ambiguity entirely; alternatively, set `wrap_antimeridian` = True
+        to trace such a segment the short way, across the antimeridian,
+        which traces exactly the same cells as splitting it there. The
+        flag is meaningless (and ignored) for `plane` = True.
 
-        Cannot handle cells along a line that crosses the antimeridian.
+        The sequence is exact, computed by a sweep over the segment's
+        planar image: every parameter value where the projected segment
+        crosses a cell edge is found (the projection of a longitude-
+        latitude segment is piecewise smooth, with its pieces' boundaries
+        -- region and polar-triangle changes and the longitude wrap --
+        known in closed form, and each planar coordinate at most singly
+        non-monotone per piece, so every crossing is bracketed and solved
+        to machine precision), and each inter-crossing interval's midpoint
+        is located with `cell_from_point`, which is exact for every cell
+        shape, including polar cap cells. Cells the segment meets in a
+        single point only (passing exactly through a cell corner) are not
+        included.
 
-        TODO:
-
-        Cap cells are not handled correctly. Lines intersecting one of those may not
-        return the correct sequence of cells.
+        If either endpoint lies outside the grid (`cell_from_point`
+        returns None there), return []. If some middle stretch of a
+        *planar* segment leaves the grid's cross-shaped image, the cells
+        on both sides of the gap are still returned, in order.
 
         EXAMPLES::
 
@@ -1185,62 +1210,179 @@ class RHEALPixDGGS(object):
             ['N448', 'N447']
 
         """
-        # Turn vertex pair into dggs cells
+        if wrap_antimeridian and not plane:
+            # Take the short way in longitude: shift the end longitude by
+            # a full turn so the segment crosses the antimeridian. The
+            # projection wraps longitudes, so the out-of-range value
+            # locates to the same cells throughout.
+            full = 2 * pi if self.ellipsoid.radians else 360.0
+            dlon = lend[0] - lstart[0]
+            if abs(dlon) > full / 2:
+                lend = (lend[0] - copysign(full, dlon), lend[1])
+
         start = self.cell_from_point(resolution, lstart, plane)
         end = self.cell_from_point(resolution, lend, plane)
+        if start is None or end is None:
+            return []
+        if start == end:
+            return [start]
 
-        # Collect cells along path
-        line_cells = []
-        if start is not None and end is not None:
-            # Special case: resolution is coarse and path is short
-            if start == end:
-                line_cells = [start]
+        R = self.ellipsoid.R_A
+        w = self.cell_width(resolution)
 
-            # Line spans multiple cells
-            else:
-                # Wrap points in a shapely linestring
-                line = LineString([lstart, lend])
+        def point_at(t):
+            return (
+                lstart[0] + t * (lend[0] - lstart[0]),
+                lstart[1] + t * (lend[1] - lstart[1]),
+            )
 
-                # Work your way along the line one cell at a time
-                current = start
-                while current != end:
-                    line_cells.append(current)
+        if plane:
+            q = point_at
+        else:
+            proj = self.rhealpix
 
-                    # Grab dictionary of nearest neighbours
-                    nns = current.neighbors(plane=plane)
+            def q(t):
+                return proj(*point_at(t))
 
-                    # Find neighbour across edge crossed by line if it exists
-                    following = None
-                    for key in nns:
-                        nn = nns[key]
-                        verts = nn.vertices(plane=plane)
+        # Piece boundaries: parameter values where the planar image of
+        # the segment may kink or jump. For a planar segment there are
+        # none; for a longitude-latitude segment they are the crossings
+        # of the equatorial/polar region boundaries, the polar-triangle
+        # edges and face columns (longitude multiples of a quarter turn,
+        # relative to the ellipsoid's lon_0), and the longitude/latitude
+        # wraps -- all exact, since longitude and latitude are linear in
+        # the parameter.
+        breakpoints = {0.0, 1.0}
 
-                        # Repeat first point to close the square
-                        verts.append(verts[0])
+        def add_linear_crossings(f0, f1, targets):
+            for target in targets:
+                if f1 != f0:
+                    t = (target - f0) / (f1 - f0)
+                    if 0.0 < t < 1.0:
+                        breakpoints.add(t)
 
-                        # Turn vertices into point pairs describing cell edges
-                        edges = zip(verts, verts[1:])
+        if not plane:
+            ell = self.ellipsoid
+            half = pi if ell.radians else 180.0
+            quarter = half / 2
+            # Geodetic latitude of the region boundary (the authalic
+            # latitude arcsin(2/3)).
+            phi_reg = auth_lat(asin(2.0 / 3), ell.e, inverse=True, radians=True)
+            if not ell.radians:
+                phi_reg = phi_reg * 180 / pi
+            add_linear_crossings(
+                lstart[1],
+                lend[1],
+                [
+                    ell.lat_0 + phi_reg,
+                    ell.lat_0 - phi_reg,
+                    ell.lat_0 + quarter,
+                    ell.lat_0 - quarter,
+                ],
+            )
+            lo = min(lstart[0], lend[0]) - ell.lon_0
+            hi = max(lstart[0], lend[0]) - ell.lon_0
+            k0, k1 = int(floor(lo / quarter)), int(ceil(hi / quarter))
+            add_linear_crossings(
+                lstart[0],
+                lend[0],
+                [ell.lon_0 + k * quarter for k in range(k0, k1 + 1)],
+            )
 
-                        # Iterate over the edges to find the crossing one
-                        while (edge := next(edges, None)) is not None and not following:
-                            # Make sure both points in the edge are on the same side of the antimeridian
-                            edge = self.antimeridian_check_and_flip(edge, plane=plane)
+        # All planar cell edges of this resolution lie on one global
+        # lattice: face origins are exact multiples of the face width,
+        # which is an exact multiple of the cell width.
+        x_anchor = -pi * R
+        y_anchor = -3 * pi * R / 4
 
-                            # Wrap edge in a shapely linestring and check intersection
-                            edge_line = LineString(edge)
-                            if line.intersects(edge_line) and nn not in line_cells:
-                                following = nn
+        def lattice_lines_between(a, b, anchor):
+            lo, hi = (a, b) if a <= b else (b, a)
+            i0 = int(floor((lo - anchor) / w)) + 1
+            i1 = int(floor((hi - anchor) / w))
+            return [anchor + i * w for i in range(i0, i1 + 1)]
 
-                    # Fail safe for strange cases (to make sure the iteration ends)
-                    if not following:
-                        current = end
-                    else:
-                        current = following
+        def root(f, ta, tb, fa):
+            # Bisection to machine precision on a bracketed sign change.
+            for _ in range(120):
+                tm = 0.5 * (ta + tb)
+                if tm == ta or tm == tb:
+                    return tm
+                fm = float(f(tm))
+                if fm == 0:
+                    return tm
+                if (fa < 0) != (fm < 0):
+                    tb = tm
+                else:
+                    ta, fa = tm, fm
+            return 0.5 * (ta + tb)
 
-                # Cap the sequence
-                line_cells.append(end)
+        def monotone_runs(axis, ta, tb):
+            # Split [ta, tb] into runs on which q(t)[axis] is monotone:
+            # scan for direction flips, then pin each extremum by ternary
+            # search. Within one smooth piece each planar coordinate has
+            # the form c + l(t)*sigma(t) with l linear and sigma monotone,
+            # so it has at most one interior extremum, which a 64-point
+            # scan brackets comfortably.
+            N = 64
+            ts = [ta + (tb - ta) * i / N for i in range(N + 1)]
+            vs = [float(q(t)[axis]) for t in ts]
+            cuts = [ta]
+            direction = 0
+            for i in range(1, N + 1):
+                d = (vs[i] > vs[i - 1]) - (vs[i] < vs[i - 1])
+                if d == 0:
+                    continue
+                if direction == 0:
+                    direction = d
+                elif d != direction:
+                    lo, hi = ts[max(i - 2, 0)], ts[i]
+                    for _ in range(200):
+                        if hi - lo < 1e-14:
+                            break
+                        m1 = lo + (hi - lo) / 3
+                        m2 = hi - (hi - lo) / 3
+                        if direction * float(q(m1)[axis] - q(m2)[axis]) < 0:
+                            lo = m1
+                        else:
+                            hi = m2
+                    cuts.append(0.5 * (lo + hi))
+                    direction = d
+            cuts.append(tb)
+            return list(zip(cuts, cuts[1:]))
 
+        crossings = set()
+        for pa, pb in zip(sorted(breakpoints), sorted(breakpoints)[1:]):
+            if pb - pa < 1e-14:
+                continue
+            # Evaluate strictly inside the piece, clear of its kinks.
+            eps = (pb - pa) * 1e-12
+            ta, tb = pa + eps, pb - eps
+            for axis in (0, 1):
+                anchor = x_anchor if axis == 0 else y_anchor
+                for ra, rb in monotone_runs(axis, ta, tb):
+                    va = float(q(ra)[axis])
+                    vb = float(q(rb)[axis])
+                    for line in lattice_lines_between(va, vb, anchor):
+
+                        def f(t, line=line, axis=axis):
+                            return q(t)[axis] - line
+
+                        crossings.add(root(f, ra, rb, va - line))
+            if pb < 1.0:
+                # The piece boundary itself may be a cell change (a face
+                # jump, or a kink lying exactly on a cell edge).
+                crossings.add(pb)
+
+        ts = [0.0] + sorted(crossings) + [1.0]
+        line_cells = [start]
+        for a, b in zip(ts, ts[1:]):
+            cell = self.cell_from_point(resolution, point_at(0.5 * (a + b)), plane)
+            if cell is not None and cell != line_cells[-1]:
+                line_cells.append(cell)
+        if line_cells[-1] != end:
+            line_cells.append(end)
         return line_cells
+
 
     def cells_from_region(
         self,
@@ -1473,66 +1615,7 @@ class RHEALPixDGGS(object):
         # cover.sort(key=lambda x: (x[2], -x[1]), reverse=True)
         # return [t[0] for t in cover]
 
-    def antimeridian_check_and_flip(
-        self, vertices: list[tuple[float, float]], plane: bool = True
-    ) -> list[tuple[float, float]]:
-        """
-        Check for cell vertices on the antimeridian and make sure their sign is
-        the same as that of the other vertices.
 
-        Used by cells_from_line before checking if a given line intersects a cell
-        edge.
-
-        Returns the set of modified coordinates if sign flipping has occurred, or
-        the original set of coordinates if everything's on the same side of the
-        antimeridian already.
-        """
-        # No need to do anything in the planar case
-        if plane:
-            return vertices
-
-        # The potentially offending (absoulute) value
-        if self.ellipsoid.radians:
-            half_range = pi
-        else:
-            half_range = 180
-
-        # Extract longitudes
-        lngs = [vert[0] for vert in vertices]
-
-        # No need to do anything if no point lies on the antimeridian
-        if not half_range in lngs and not -half_range in lngs:
-            return vertices
-
-        # Check which side of the antimeridian the point of interest is on
-        if half_range in lngs:
-            check_lng = half_range
-        else:
-            check_lng = -half_range
-
-        # Check sign of point at antimeridian against the others
-        fine = True
-        count = 0
-        while fine and count < len(lngs):
-            if lngs[count] != check_lng and lngs[count] * check_lng < 0:
-                fine = False
-
-            count = count + 1
-
-        # No need to do anything else if all points are on the same side of the antimeridian
-        if fine:
-            return vertices
-
-        # Flip sign of longitudes at antimeridian
-        lngs = [lng if lng != check_lng else -lng for lng in lngs]
-
-        # Extract latitudes as separate list
-        lats = [vert[1] for vert in vertices]
-
-        # Zip up the results in a new list of tuples
-        vertices = [(lng, lat) for lng, lat in zip(lngs, lats)]
-
-        return vertices
 
 
 # Some common rHEALPix DGGSs.

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -26,7 +26,6 @@ CHILD_RESOLUTION_WARNING = "WARNING: You requested a child resolution that is lo
 CELL_CENTRE_WARNING = "WARNING: You requested a centre cell for a DGGS that has an even number of cells on a side. Returning None."
 POLYFILL_GEOMETRY_WARNING = "WARNING: Empty or missing geometry, unsupported geometry type (not Polygon or MultiPolygon), or geometry with no area. Returning None."
 LINETRACE_GEOMETRY_WARNING = "WARNING: Empty or missing line geometry, unsupported line type (not LineString or MultiLineString), or line with no length. Returning None."
-LINETRACE_WARNING = "WARNING: Implementation of linetrace is incomplete. Lines crossing one of the cap cells may not be converted to the correct sequence of cells."
 
 
 # ======== Main API ======== #
@@ -458,7 +457,11 @@ def polyfill(
     boundary is outside the exterior boundary of its polygon, or if two polygons in a
     multipolygon overlap.
 
-    TODO: decide what to do with the antimeridian (if anything)
+    Polygon edges are straight in the input coordinate space (shapely
+    geometries are planar) and do not wrap around the antimeridian; a
+    region straddling it must be split into a MultiPolygon along the
+    antimeridian by the caller first, as is standard for planar GIS
+    geometry.
 
     EXAMPLES::
         >>> from shapely import Polygon
@@ -549,6 +552,7 @@ def linetrace(
     plane: bool = True,
     verbose: bool = False,
     dggs: RHEALPixDGGS = WGS84_003,
+    wrap_antimeridian: bool = False,
 ) -> list[str] | None:
     """
     Returns the list of cell indices touched by a shapely linestring or multilinestring
@@ -565,7 +569,21 @@ def linetrace(
     Returns None if the geometry is invalid in other ways, e.g. if a linestring contains
     self intersecting segments.
 
-    TODO: decide what to do with the antimeridian (if anything)
+    A linestring's segments are straight in the input coordinate space
+    (shapely geometries are planar): planar rHEALPix coordinates if
+    `plane` = True, longitude-latitude coordinates otherwise -- so
+    longitude-latitude segments are plate carree lines, not geodesics,
+    and by default do not wrap around the antimeridian (a segment from
+    longitude 179 to -179 runs the long way around, through longitude 0
+    -- the literal planar reading). Splitting inputs at the antimeridian,
+    as GeoJSON's RFC 7946 prescribes for data producers, avoids the
+    ambiguity entirely; alternatively pass `wrap_antimeridian` = True to
+    trace segments spanning more than half a turn of longitude the short
+    way, across the antimeridian, which traces the same cells as
+    splitting them there. To trace a geodesic, densify it into short
+    segments first (e.g. with pyproj.Geod). See
+    RHEALPixDGGS.cells_from_line, which traces each segment exactly, for
+    the details.
 
     EXAMPLES::
 
@@ -574,9 +592,6 @@ def linetrace(
         >>> linetrace(line, res=9, plane=False)
         ['S001450634', 'S001450635']
     """
-    if verbose:
-        warn(LINETRACE_WARNING)
-
     # Stop early if the line geometry is malformed
     if _malformed_lines(geometry):
         if verbose:
@@ -606,7 +621,9 @@ def linetrace(
             i, j = vertex_pair
 
             # Convert line segment to cell ids
-            line_cells = dggs.cells_from_line(res, i, j, plane)
+            line_cells = dggs.cells_from_line(
+                res, i, j, plane, wrap_antimeridian=wrap_antimeridian
+            )
 
             # Convert cells to string ids and add to collection
             if line_cells:

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -227,6 +227,89 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
         c2 = rdggs.cell_from_point(1, p2, plane=False)
         self.assertEqual(c1, c2)
 
+    def test_cells_from_line(self):
+        rdggs = WGS84_003
+
+        # Both endpoints in the same cell.
+        cells = rdggs.cells_from_line(1, (10, 10), (11, 11), plane=False)
+        self.assertEqual([str(c) for c in cells], ["Q3"])
+
+        # An endpoint outside the (planar) grid: no trace.
+        R = rdggs.ellipsoid.R_A
+        outside = (0.9 * pi * R, 0.6 * pi * R)
+        inside = (0.1 * R, 0.1 * R)
+        self.assertEqual(rdggs.cells_from_line(1, inside, outside, plane=True), [])
+
+        # A planar segment crossing a void of the cross-shaped image:
+        # cells on both sides of the gap, in order, and nothing invented
+        # in between. From the N square rightward across the void into
+        # the R face's top row.
+        n_square_point = (-0.6 * pi * R, 1.5 * R)  # in N (the polar square)
+        r_face_point = (0.75 * pi * R, 0.7 * R)  # in R (equatorial band)
+        cells = rdggs.cells_from_line(0, n_square_point, r_face_point, plane=True)
+        self.assertEqual([str(c) for c in cells], ["N", "R"])
+
+        # Antimeridian: longitude-latitude segments are straight in
+        # coordinate space and by default don't wrap, so a segment from
+        # longitude 179 to -179 runs the long way around through
+        # longitude 0.
+        cells = rdggs.cells_from_line(0, (179, 10), (-179, 10), plane=False)
+        self.assertEqual([str(c) for c in cells], ["R", "Q", "P", "O"])
+        # With wrap_antimeridian=True it takes the short way, across the
+        # antimeridian -- and traces exactly the same cells as splitting
+        # the segment at the antimeridian (RFC 7946 style) and
+        # concatenating the halves' traces.
+        wrapped = rdggs.cells_from_line(
+            0, (179, 10), (-179, 10), plane=False, wrap_antimeridian=True
+        )
+        self.assertEqual([str(c) for c in wrapped], ["R", "O"])
+        halves = rdggs.cells_from_line(
+            0, (179, 10), (180, 10), plane=False
+        ) + rdggs.cells_from_line(0, (-180, 10), (-179, 10), plane=False)
+        deduped = [c for i, c in enumerate(halves) if i == 0 or c != halves[i - 1]]
+        self.assertEqual(wrapped, deduped)
+
+        # Consecutive traced cells always touch (edge- or
+        # corner-adjacent), across face and region boundaries; endpoints
+        # match cell_from_point. Fixed deterministic segments spanning
+        # equatorial, polar, and region-crossing geometry.
+        segments = [
+            (2, (-11.399091685979357, 64.59420811683768),
+                (-57.31373531501049, 87.0761010527302)),
+            (3, (-11.399091685979357, 64.59420811683768),
+                (-57.31373531501049, 87.0761010527302)),
+            (3, (165.50972831262268, 26.027432190353828),
+                (-12.994806100831056, 60.11220272134576)),
+            (2, (-170, -80), (170, -60)),
+            (2, (-45, 88), (135, 88)),
+        ]
+        for res, a, b in segments:
+            cells = rdggs.cells_from_line(res, a, b, plane=False)
+            self.assertEqual(cells[0], rdggs.cell_from_point(res, a, plane=False))
+            self.assertEqual(cells[-1], rdggs.cell_from_point(res, b, plane=False))
+            for c0, c1 in zip(cells, cells[1:]):
+                self.assertTrue(c0.touches(c1), msg=f"{c0} !~ {c1} on {a}->{b}")
+                self.assertNotEqual(c0, c1)
+
+        # Exactness regressions: these segments pass through a cell over
+        # only a tiny fraction of a cell width (about 1/50 and 1/500 of a
+        # cell, confirmed by ultra-dense point location), which
+        # sampling-based tracing misses.
+        cells = rdggs.cells_from_line(
+            3,
+            (-11.399091685979357, 64.59420811683768),
+            (-57.31373531501049, 87.0761010527302),
+            plane=False,
+        )
+        self.assertIn("N455", [str(c) for c in cells])
+        cells = rdggs.cells_from_line(
+            3,
+            (165.50972831262268, 26.027432190353828),
+            (-12.994806100831056, 60.11220272134576),
+            plane=False,
+        )
+        self.assertIn("N241", [str(c) for c in cells])
+
     def test_cell_from_region(self):
         for rdggs in [WGS84_003, WGS84_003_RADIANS]:
             # For any planar cell X with nucleus c and width w,

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -723,13 +723,17 @@ class RhpWrappersTestCase(unittest.TestCase):
         result = rhpw.linetrace(s_ls, 8, plane=False)
         self.assertEqual(result, ['S00145063'])
 
-        # Lines crossing cube face boundaries (not involving cap cells)
+        # Lines crossing cube face boundaries (not involving cap cells).
+        # The segment runs through the middle of Q6 for a substantial
+        # stretch (confirmed by point location along the segment; also,
+        # jumping S8 -> P8 directly would skip a cell the line plainly
+        # crosses).
         s = gs.WGS84_003.cell(("S", 7))
         e = gs.WGS84_003.cell(("P", 5))
         result = rhpw.linetrace(
             sh.LineString([s.centroid(False), e.centroid(False)]), 1, plane=False
         )
-        self.assertEqual(result, ["S7", "S8", "P8", "P5"])
+        self.assertEqual(result, ["S7", "S8", "Q6", "P8", "P5"])
 
         # Resolution mismatch (coarse resolution, short line segments)
         result = rhpw.linetrace(p_ls, 2, plane=False)
@@ -744,8 +748,15 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertIsNone(rhpw.linetrace(sh.LineString(), 0))
         self.assertIsNone(rhpw.linetrace(sh.LineString([(1, 1), (1, 1)]), 0))
 
-    @unittest.expectedFailure
-    def test_linetrace_known_failure(self):
+    def test_linetrace_polar_cap(self):
+        # A linestring wandering around the north pole, crossing the
+        # resolution 3 cap cell N444. A shapely linestring's segments are
+        # straight in longitude-latitude coordinates, so at these
+        # latitudes each leg sweeps *around* the pole through the cells
+        # at the intermediate longitudes (it does not hop across the
+        # cap the way a geodesic would). Every leg's expected cell
+        # sequence below was independently confirmed by dense point
+        # location along the leg with cell_from_point.
         n_ls = sh.LineString(
             [
                 (-134.998756, 86.549596),
@@ -755,13 +766,10 @@ class RhpWrappersTestCase(unittest.TestCase):
                 (-134, 86),
             ]
         )
-
-        # Cap faces - line string
-        # TODO: this is still wrong - should be "N444", "N445" and not "N444", "N447", "N448", "N445"
         result = rhpw.linetrace(n_ls, 3, plane=False)
         self.assertEqual(
             result,
-            ["N447", "N444", "N445", "N448", "N447"],
+            ["N447", "N444", "N447", "N448", "N445", "N448", "N447"],
         )
 
 


### PR DESCRIPTION
Closes #60.

## The bug being fixed

`RHEALPixDGGS.cells_from_line` (the engine behind `rhp_wrappers.linetrace`)
walked cell-to-cell by testing which neighbor's boundary a shapely segment
intersected, modelling every cell as a straight-edged quadrilateral between
its 4 projected vertices. That model is wrong for polar cells (a cap
cell's boundary is a **circle** in lon-lat coordinates; dart and skew-quad
edges are curves), the walk was forbidden from revisiting a cell (correct
polar paths do revisit), and its fail-safe silently jumped to the end cell
when nothing matched. Confirmed failures ranged from skipping a cell a
segment crossed straight through the middle of — equatorial, no polar
cells involved (`S8 → P8` where the segment spends ~15% of its length
inside `Q6`) — to polar traces missing 20 cells at once.

## The replacement: an exact sweep

- **Piece boundaries** of the projected segment (equatorial/polar region
  changes, polar-triangle edges, face columns, longitude/latitude wraps)
  are computed in closed form — longitude and latitude are linear in the
  segment parameter.
- Within each smooth piece, each planar coordinate has the form
  `c + linear(t)·σ(t)` with σ monotone, so it has at most one interior
  extremum; monotone runs are split there and **every crossing of the
  global cell-edge lattice is bracketed and bisected to machine
  precision** (all planar cell edges of a resolution lie on one lattice).
- Each inter-crossing interval's midpoint is located with
  `cell_from_point` — exact for every cell shape, caps included. Cells
  met in a single point only (segment exactly through a corner) are
  excluded, and documented as such.

## Validation

Against an independent dense point-location oracle over ~450 randomized
segments (equatorial, north/south polar, region-crossing, planar; several
resolutions): **zero disagreements in the oracle's favor** — and the sweep
catches genuine sliver crossings as short as **1/500 of a cell** that the
oracle's own pitch misses (confirmed real by 2-million-point probing;
pinned as regression tests). Consecutive traced cells are always edge- or
corner-adjacent (`touches()`), endpoints match `cell_from_point`, and a
res-6 trace the length of New Zealand runs in ~0.1 s.

## Semantics, decided and documented (previously TODOs)

- Segments are straight in the input coordinate space (planar rHEALPix
  coordinates, or plate carrée for lon-lat) — matching the shapely input
  type and RFC 7946's planar reading. Geodesics: densify first (e.g.
  `pyproj.Geod`), noted in the docstrings.
- **Antimeridian**: no wrapping by default (a 179° → −179° segment runs
  the long way around — the literal planar reading). Splitting inputs at
  the antimeridian per RFC 7946 avoids the ambiguity entirely; the new
  `wrap_antimeridian` keyword (on `cells_from_line` and `linetrace`,
  default False) traces such segments the short way instead — with a test
  proving it equivalent to splitting. `polyfill`'s antimeridian TODO is
  resolved the same way (documented split-first requirement).

## Test changes

- The `@expectedFailure` cap-crossing test becomes a regular passing test
  with the **correct** expected sequence, each leg independently confirmed
  by dense point location. Notably the old TODO's aspiration ("should be
  N444, N445") was itself wrong — it assumed geodesic rather than
  coordinate-space semantics; under the documented semantics each leg
  curves around the pole.
- One existing expectation gains `Q6` (the cell the old walker skipped).
- New tests: wrap-flag/splitting equivalence, planar image-gap crossing,
  adjacency + endpoint invariants over fixed polar/region-crossing
  segments, and the two sliver regressions.
- Suite: 122 tests, all passing — no expected-failures remain.

## Removals

`LINETRACE_WARNING` (nothing left to warn about; `verbose` still gates
malformed-geometry warnings) and `antimeridian_check_and_flip` (existed
solely to patch cell edges for the old algorithm), plus dggs.py's
now-unused shapely import — both noted in CHANGES.rst as breaking.

## Docs

New figure on the `rhp_wrappers` page: the cap-crossing linetrace viewed
from above the pole — traced cells filled, the resolution-4 sub-grid as a
faint outline, Arctic coastlines for context — exactly the case the old
algorithm couldn't handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
