### PR TITLE
Add cell_boundaries: batch boundaries with shared-edge deduplication

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,18 @@
 0.7.0
 ^^^^^
+Added ``RHEALPixDGGS.cell_boundaries(cells, n=2, plane=True)``: boundary
+points for a whole set of cells at once, projecting every shared boundary
+point once instead of once per adjacent cell (issue #87, proposed in
+issue #7). For contiguous blocks of cells this roughly halves the
+projection work of rendering cell outlines, and it makes adjacent cells'
+copies of their shared points identical floats rather than two
+independently computed values. Each cell's entry agrees with its own
+``boundary(n, plane)`` in count, order, and coordinates. ``Cell`` is now
+hashable (consistent with its equality: cells with equal addresses from
+the same DGGS hash alike), so cells can be dictionary keys and set
+members.
+
+
 **Breaking change:** rewrote ``RHEALPixDGGS.cells_from_line`` (the engine
 behind ``rhp_wrappers.linetrace``) to be exact for every cell shape,
 replacing an edge-walking algorithm that modelled each cell as a

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -202,6 +202,12 @@ class Cell(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def __hash__(self):
+        # Consistent with __eq__ (equal cells have equal suids), and
+        # makes cells usable as dictionary keys and set members. A
+        # cell's suid never changes after construction.
+        return hash(self.suid)
+
     def __le__(self, other):
         """
         The (strictly) less-than relation on cells.

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -1383,6 +1383,84 @@ class RHEALPixDGGS(object):
             line_cells.append(end)
         return line_cells
 
+    def cell_boundaries(
+        self, cells, n: int = 2, plane: bool = True
+    ) -> dict[Cell, list]:
+        """
+        Return a dictionary mapping each cell in `cells` to its boundary
+        points -- each value agreeing with that cell's own
+        ``boundary(n=n, plane=plane)`` in point count, order, and
+        coordinates (up to floating point) -- while computing the
+        projection of every shared boundary point only once.
+
+        Adjacent cells share their common edge's points (and cells
+        meeting at a corner share that corner point), so computing each
+        cell's boundary independently projects every interior edge of a
+        map of cells twice. This method projects each distinct planar
+        boundary point once and reuses it, roughly halving the projection
+        work for contiguous sets of cells; as a corollary, two adjacent
+        cells' copies of their shared points are identical floats rather
+        than two independently computed (and potentially last-digit
+        different) values, which helps downstream consumers that dissolve
+        or snap cell geometries.
+
+        Points are shared only between cells of the same region
+        ('equatorial', 'north_polar', 'south_polar'): the inverse
+        projection takes a per-cell region hint that legitimately
+        disambiguates points lying exactly on a region boundary, so
+        edges along those parallels are computed per region, exactly as
+        ``boundary()`` computes them.
+
+        `cells` may mix resolutions; sharing happens per resolution.
+        For `plane` = True there is no projection work to share and this
+        is simply a convenience over calling ``boundary()`` per cell.
+
+        EXAMPLES::
+
+            >>> rdggs = WGS84_003
+            >>> cells = list(rdggs.cell(('P', 0)).subcells())
+            >>> boundaries = rdggs.cell_boundaries(cells, n=3, plane=False)
+            >>> all(len(b) == 4 * 3 - 4 for b in boundaries.values())
+            True
+
+        """
+        if plane:
+            return {cell: cell.boundary(n=n, plane=True) for cell in cells}
+        if n < 2:
+            n = 2
+        R = self.ellipsoid.R_A
+        x_anchor = -pi * R
+        y_anchor = -3 * pi * R / 4
+        cache = {}
+        result = {}
+        for cell in cells:
+            # The same planar points, in the same order, as
+            # cell.boundary(n=n, plane=False) computes: the planar
+            # boundary, reordered to start at the northwest vertex.
+            planar = cell.boundary(n=n, plane=True)
+            v = cell.vertices(plane=True)
+            nw = cell.nw_vertex(plane=True)
+            i = (n - 1) * v.index(nw)
+            planar = planar[i:] + planar[:i]
+            region = cell.region()
+            # All of this cell's boundary points lie on the fine lattice
+            # of pitch w/(n - 1) anchored at the planar image's corner,
+            # shared with every same-resolution neighbor's points, so an
+            # integer lattice key identifies coincident points robustly.
+            pitch = cell.width(plane=True) / (n - 1)
+            points = []
+            for p in planar:
+                key = (
+                    cell.resolution,
+                    region,
+                    round((p[0] - x_anchor) / pitch),
+                    round((p[1] - y_anchor) / pitch),
+                )
+                if key not in cache:
+                    cache[key] = self.rhealpix(*p, inverse=True, region=region)
+                points.append(cache[key])
+            result[cell] = points
+        return result
 
     def cells_from_region(
         self,

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -310,6 +310,74 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
         )
         self.assertIn("N241", [str(c) for c in cells])
 
+    def test_cell_boundaries(self):
+        from numpy import allclose
+
+        rdggs = WGS84_003
+
+        # Agreement with each cell's own boundary() -- same count, order,
+        # and coordinates -- across cell shapes, across a region
+        # boundary, and across mixed resolutions.
+        cell_sets = [
+            list(rdggs.cell((P, 0)).subcells()),  # quads
+            list(rdggs.cell((N, 4)).subcells()),  # cap + darts + skew quads
+            [rdggs.cell((Q, i)) for i in (0, 1, 2)]
+            + [rdggs.cell((N, i)) for i in (6, 7, 8)],  # region-crossing
+            [rdggs.cell((P, 0))] + list(rdggs.cell((P, 0)).subcells()),
+        ]
+        for cells in cell_sets:
+            for n in (2, 3, 7):
+                boundaries = rdggs.cell_boundaries(cells, n=n, plane=False)
+                for c in cells:
+                    expected = c.boundary(n=n, plane=False)
+                    self.assertEqual(len(boundaries[c]), len(expected))
+                    for got, want in zip(boundaries[c], expected):
+                        self.assertTrue(
+                            allclose(got, want, rtol=0, atol=1e-9),
+                            msg=f"{c} n={n}: {got} != {want}",
+                        )
+
+        # The new guarantee: adjacent same-region cells' copies of their
+        # shared edge points are identical values, not merely close.
+        cells = list(rdggs.cell((P, 0)).subcells())
+        n = 5
+        boundaries = rdggs.cell_boundaries(cells, n=n, plane=False)
+        a = set(map(tuple, boundaries[rdggs.cell((P, 0, 1))]))
+        b = set(map(tuple, boundaries[rdggs.cell((P, 0, 2))]))
+        self.assertGreaterEqual(len(a & b), n)
+
+        # And the point of it all: strictly fewer projection calls than
+        # computing each cell's boundary independently (interior edges
+        # projected once, not twice).
+        class CountingProjection:
+            def __init__(self, inner):
+                self.inner = inner
+                self.count = 0
+
+            def __call__(self, *args, **kwargs):
+                self.count += 1
+                return self.inner(*args, **kwargs)
+
+        block = [rdggs.cell((P, i, j)) for i in range(9) for j in range(9)]
+        counter = CountingProjection(rdggs.rhealpix)
+        rdggs.rhealpix = counter
+        try:
+            for c in block:
+                c.boundary(n=4, plane=False)
+            per_cell_calls = counter.count
+            counter.count = 0
+            rdggs.cell_boundaries(block, n=4, plane=False)
+            batched_calls = counter.count
+        finally:
+            del rdggs.__dict__["rhealpix"]
+        self.assertLess(batched_calls, 0.6 * per_cell_calls)
+
+        # Planar mode is a plain convenience passthrough.
+        cells = list(rdggs.cell((P, 0)).subcells())
+        boundaries = rdggs.cell_boundaries(cells, n=3, plane=True)
+        for c in cells:
+            self.assertEqual(boundaries[c], c.boundary(n=3, plane=True))
+
     def test_cell_from_region(self):
         for rdggs in [WGS84_003, WGS84_003_RADIANS]:
             # For any planar cell X with nucleus c and width w,


### PR DESCRIPTION
Closes #87 (proposed by @rggibb in #7; the vectorisation counterpart is #88).

## What it does

`RHEALPixDGGS.cell_boundaries(cells, n=2, plane=True)` returns boundary
points for a whole set of cells, projecting every **distinct** planar
boundary point once — instead of once per adjacent cell, which is what
per-cell `boundary()` calls amount to on a map (every interior edge
twice, every interior corner four times).

The dedup key falls out of the linetrace work: all boundary points of a
resolution at a given `n` lie on one global fine lattice (pitch
`w/(n−1)`), so an integer lattice index identifies coincident points
robustly across neighbors.

## Guarantees (all tested)

- **Per-cell agreement**: each entry matches that cell's own
  `boundary(n, plane)` in count, order, and coordinates — verified across
  quad/cap/dart/skew-quad cells, across the equatorial/polar region
  boundary, and across mixed resolutions.
- **Region correctness**: points are shared only within a region, because
  `boundary()`'s inverse projection takes a per-cell region hint that
  legitimately disambiguates points on the region-boundary parallels —
  those edges are computed per region, exactly as `boundary()` does.
- **Consistency bonus**: adjacent cells' copies of shared points are
  *identical floats*, not two independently computed values — useful for
  anything downstream that dissolves or snaps cell geometries.
- **Measured saving**: 1.9× fewer projection calls on a 9×9 block
  (2916 → 1540 at n=10; interior edges deduped, the block perimeter can't
  be). Asserted in tests via a counting wrapper at a conservative 0.6×
  threshold.

Also: `Cell` is now hashable (hash of the suid, consistent with
`__eq__`) — required by the new API's dict return type, and generally
overdue.

Suite: 123 tests, all passing; doctests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
