### PR TITLE
Fix Projection.__call__ catching the wrong exception type (except NameError)

### DIFF
--- a/rhealpixdggs/projection_wrapper.py
+++ b/rhealpixdggs/projection_wrapper.py
@@ -100,7 +100,16 @@ class Projection(object):
                 # Import projection module for proj.
                 module = importlib.import_module("rhealpixdggs.pj_" + proj)
                 f = getattr(module, proj)(a=a, e=e, **kwargs)
-            except NameError:
+            except (AttributeError, ModuleNotFoundError):
+                # importlib.import_module() raises ModuleNotFoundError when no
+                # rhealpixdggs.pj_<proj> module exists; getattr() raises
+                # AttributeError when the module exists but doesn't define a
+                # same-named callable. Neither is NameError -- that was a
+                # leftover from a pre-importlib implementation (e.g. one that
+                # used eval(proj), which would raise NameError) -- so this
+                # branch was previously dead and isea/csea/qsc (declared in
+                # HOMEMADE_PROJECTIONS but never implemented) crashed with an
+                # uncaught ModuleNotFoundError instead of degrading gracefully.
                 print("Oops! Projection %s is not implemented." % proj)
                 return
         else:

--- a/tests/test_projection_wrapper.py
+++ b/tests/test_projection_wrapper.py
@@ -1,0 +1,81 @@
+"""
+This Python 3.11 code tests the ``projection_wrapper`` module.
+Beware, these tests cover only some functions and only some scenarios.
+Keep adding tests!
+"""
+
+# *****************************************************************************
+#       Copyright (C) 2026
+#
+#  Distributed under the terms of the GNU Lesser General Public License (LGPL)
+#                  http://www.gnu.org/licenses/
+# *****************************************************************************
+
+# Import standard modules.
+import importlib
+import unittest
+from unittest.mock import patch
+
+# Import my modules.
+from rhealpixdggs.ellipsoids import WGS84_ELLIPSOID
+from rhealpixdggs.projection_wrapper import HOMEMADE_PROJECTIONS, Projection
+
+
+class ProjectionWrapperTestCase(unittest.TestCase):
+    def test_implemented_homemade_projection_still_works(self):
+        # rhealpix has a real rhealpixdggs.pj_rhealpix module backing it, so
+        # this must still project normally and not hit the fallback branch.
+        f = Projection(
+            ellipsoid=WGS84_ELLIPSOID, proj="rhealpix", north_square=1, south_square=0
+        )
+        result = f(0, 30)
+        self.assertAlmostEqual(float(result[0]), 0.0, places=6)
+        self.assertAlmostEqual(float(result[1]), 3740232.8933662786, places=6)
+
+    def test_unimplemented_homemade_projections_degrade_gracefully(self):
+        """#50: isea/csea/qsc are declared in HOMEMADE_PROJECTIONS but have no
+        backing rhealpixdggs/pj_*.py module. Projection.__call__ used to catch
+        only NameError while importlib.import_module() actually raises
+        ModuleNotFoundError -- so these crashed uncaught instead of printing
+        the intended "not implemented" message and returning None.
+        """
+        unimplemented = HOMEMADE_PROJECTIONS - {"healpix", "rhealpix"}
+        # Confirm the fixture assumption still holds: these really have no
+        # backing module, i.e. this test is actually exercising the fallback.
+        self.assertTrue(
+            unimplemented, "expected at least one unimplemented homemade projection"
+        )
+
+        for proj in sorted(unimplemented):
+            with self.subTest(proj=proj):
+                f = Projection(ellipsoid=WGS84_ELLIPSOID, proj=proj)
+                # Must not raise ModuleNotFoundError or any other uncaught
+                # exception -- must degrade to None per the documented
+                # fallback behaviour.
+                result = f(0, 0)
+                self.assertIsNone(result)
+
+    def test_module_present_but_missing_attribute_also_degrades_gracefully(self):
+        """The AttributeError half of the fix: a homemade-projection module
+        that exists but doesn't define the expected same-named callable must
+        also degrade gracefully rather than raising.
+        """
+        real_module = importlib.import_module("rhealpixdggs.pj_rhealpix")
+        with patch(
+            "rhealpixdggs.projection_wrapper.importlib.import_module",
+            return_value=real_module,
+        ):
+            # pj_rhealpix has no attribute named "rhealpix_missing_fn", so
+            # getattr(module, proj) raises AttributeError.
+            f = Projection(ellipsoid=WGS84_ELLIPSOID, proj="rhealpix_missing_fn")
+            HOMEMADE_PROJECTIONS.add("rhealpix_missing_fn")
+            try:
+                result = f(0, 0)
+            finally:
+                HOMEMADE_PROJECTIONS.discard("rhealpix_missing_fn")
+            self.assertIsNone(result)
+
+
+# ------------------------------------------------------------------------------
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #50.

`HOMEMADE_PROJECTIONS = {"healpix", "rhealpix", "isea", "csea", "qsc"}`, but `isea`/`csea`/`qsc` have no backing `rhealpixdggs/pj_*.py` module. `Projection.__call__` tries to degrade gracefully when a homemade projection can't be loaded, but was catching `NameError`:

```python
try:
    module = importlib.import_module("rhealpixdggs.pj_" + proj)
    f = getattr(module, proj)(a=a, e=e, **kwargs)
except NameError:
    print("Oops! Projection %s is not implemented." % proj)
    return
```

`importlib.import_module()` actually raises `ModuleNotFoundError` when no such module exists (a present-module-but-missing-function case would raise `AttributeError` from `getattr`). Neither is `NameError` -- this reads like a leftover from a pre-`importlib` implementation (e.g. one that used `eval(proj)`, which would raise `NameError`). The intended "Oops! Projection %s is not implemented" message was dead code for its stated purpose:

```pycon
>>> Projection(ellipsoid=WGS84_ELLIPSOID, proj="isea")(0, 0)
ModuleNotFoundError: No module named 'rhealpixdggs.pj_isea'
```

Fixed exactly as suggested in the issue: `except (AttributeError, ModuleNotFoundError):`.

I left `HOMEMADE_PROJECTIONS` and the `isea`/`csea`/`qsc` entries as-is -- the issue flagged implementing them vs. dropping them from the set as a separate, optional follow-up decision, not part of this bug's scope.

**Testing**

Added `tests/test_projection_wrapper.py`:
- `test_implemented_homemade_projection_still_works` -- `rhealpix` (which does have a backing module) still projects normally.
- `test_unimplemented_homemade_projections_degrade_gracefully` -- each of `isea`/`csea`/`qsc` now returns `None` with the "not implemented" message instead of raising `ModuleNotFoundError`.
- `test_module_present_but_missing_attribute_also_degrades_gracefully` -- covers the `AttributeError` half of the fix (module present, attribute missing).

All 3 tests / 3 subtests pass. Reverting the fix makes the two projection-calling tests fail with the exact `ModuleNotFoundError` from the issue. Full suite: 79 passed, 1 xfailed (pre-existing, unrelated to this change -- `test_linetrace_known_failure`). `black --check` is clean on both changed files (this project uses black, no ruff/flake8 config).