### PR TITLE
Release flow: require Poetry 2.2, draft-first GitHub release

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,11 @@
 # Releasing
 
 How to publish a new release of rHEALPixDGGS. Requires
-[Poetry](https://python-poetry.org/) **version 2.0 or later** — this
-project's `pyproject.toml` uses the PEP 621 `[project]` table, which older
-Poetry versions cannot read (they fail with a cryptic `'name'` error).
+[Poetry](https://python-poetry.org/) **version 2.2 or later** — this
+project's `pyproject.toml` uses the PEP 621 `[project]` table, which Poetry
+before 2.0 cannot read (it fails with a cryptic `'name'` error), and the
+built wheel must carry the PEP 639 `License-Expression` metadata, which only
+poetry-core 2.2+ writes. Upgrade with `poetry self update`.
 
 `scripts/release.py` drives the whole process. It is stdlib-only, so there is
 nothing to install beyond Poetry itself.
@@ -18,14 +20,15 @@ python scripts/release.py check    0.7.0   # preflight only, changes nothing
 python scripts/release.py prepare  0.7.0   # bump versions, test, build, verify
 python scripts/release.py tag      0.7.0   # commit, tag, push
 python scripts/release.py publish  0.7.0   # upload to PyPI
-python scripts/release.py announce 0.7.0   # GitHub release from the changelog
+python scripts/release.py announce 0.7.0   # draft GitHub release: changelog + generated notes
+python scripts/release.py finalize 0.7.0   # publish the draft GitHub release
 ```
 
 Each stage re-runs the checks it depends on, so stopping to fix something
 and starting again is safe. Nothing irreversible happens without you asking
 for it by name, and every stage visible from outside your machine — `tag`,
-which pushes, `publish`, which uploads, and `announce`, which posts the
-GitHub release — also prompts before acting. Add `--dry-run` to any stage to
+which pushes, `publish`, which uploads, `announce`, which drafts the GitHub
+release, and `finalize`, which makes it public — also prompts before acting. Add `--dry-run` to any stage to
 see what it would do, or `--yes` to skip the prompts; either flag works
 before or after the stage name.
 
@@ -94,8 +97,13 @@ stage asks twice over: once for the tag, once at the prompt.
 
 ### `announce`
 
-Creates the GitHub release for `v<VERSION>` via `gh`, with the version's
-`CHANGES.rst` section as the body. The notes are converted from
+Creates a **draft** GitHub release for `v<VERSION>` via `gh` — titled
+`v<VERSION>`, matching the tag and every earlier release. Nothing is
+publicly visible until you run `finalize`.
+
+The body is the version's `CHANGES.rst` section, followed by GitHub's
+auto-generated notes (the "What's Changed" PR list, new contributors, and
+the full-changelog link). The changelog part is converted from
 reStructuredText to Markdown on the way — ``literals`` become backticks and
 `--` becomes an em dash; **bold**, bullet lists and `#123` issue references
 already mean the same thing in both, and GitHub links the issue references
@@ -107,9 +115,16 @@ stage refuses to clobber a release that already exists. A version like
 `0.7.0rc1` is marked as a prerelease automatically.
 
 ```sh
-python scripts/release.py announce 0.7.0 --draft    # review in the browser first
 python scripts/release.py announce 0.7.0 --attach   # also upload the wheel and sdist
 ```
+
+### `finalize`
+
+Publishes the draft release that `announce` created, after showing you it
+exists and prompting. Between the two stages, review the draft in the
+browser — the auto-generated notes in particular — and edit it there if
+anything needs touching up; `finalize` publishes whatever the draft says by
+the time you run it.
 
 ## After publishing
 
@@ -140,6 +155,8 @@ poetry build
 # 4. publish
 poetry publish
 
-# 5. GitHub release, with the CHANGES.rst entry as the body
-gh release create v<VERSION> --title <VERSION> --notes-file <notes.md>
+# 5. draft GitHub release, with the CHANGES.rst entry as the body plus
+#    GitHub's generated notes; then publish the draft once reviewed
+gh release create v<VERSION> --title v<VERSION> --notes-file <notes.md> --generate-notes --draft
+gh release edit v<VERSION> --draft=false
 ```

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2,25 +2,27 @@
 """
 Drive the rHEALPixDGGS release process described in RELEASING.md.
 
-The release is split into five stages, each its own invocation. Nothing
+The release is split into six stages, each its own invocation. Nothing
 irreversible happens without you asking for it by name, and every stage that
 can be seen from outside the machine -- ``tag``, which pushes, ``publish``,
-which uploads, and ``announce``, which posts the GitHub release -- also asks
-for confirmation::
+which uploads, ``announce``, which drafts the GitHub release, and
+``finalize``, which makes that draft public -- also asks for confirmation::
 
     python scripts/release.py check    0.7.0   # preflight only, changes nothing
     python scripts/release.py prepare  0.7.0   # bump versions, test, build, verify
     python scripts/release.py tag      0.7.0   # commit, tag, push
     python scripts/release.py publish  0.7.0   # upload to PyPI (--test-pypi first)
-    python scripts/release.py announce 0.7.0   # GitHub release from the changelog
+    python scripts/release.py announce 0.7.0   # draft GitHub release: changelog + generated notes
+    python scripts/release.py finalize 0.7.0   # publish the draft GitHub release
 
 Run them in that order. Each stage re-runs the checks it depends on, so
 stopping to fix something and starting again is safe.
 
 Stdlib only, so it runs without installing anything. Requires Python 3.11+
-(tomllib) and, for the later stages, Poetry 2.0+ -- this project's
-pyproject.toml uses the PEP 621 [project] table, which older Poetry cannot
-read.
+(tomllib) and, for the later stages, Poetry 2.2+ -- this project's
+pyproject.toml uses the PEP 621 [project] table (unreadable before Poetry
+2.0), and the artifact verification demands the PEP 639 License-Expression
+metadata that only poetry-core 2.2+ writes.
 
 Add --yes to skip the confirmation prompts, --dry-run to print the commands
 a stage would run without running them.
@@ -202,7 +204,7 @@ def check_tools(*, need_poetry: bool) -> None:
     if not need_poetry:
         return
     if shutil.which("poetry") is None:
-        raise Failure("poetry is not on PATH; this project needs Poetry 2.0 or later")
+        raise Failure("poetry is not on PATH; this project needs Poetry 2.2 or later")
     reported = run(["poetry", "--version"], check=False)
     match = re.search(r"(\d+)\.(\d+)", reported)
     if not match:
@@ -210,11 +212,13 @@ def check_tools(*, need_poetry: bool) -> None:
             "could not determine the Poetry version -- `poetry --version` said:\n"
             f"{reported or '(no output)'}"
         )
-    if int(match.group(1)) < 2:
+    if (int(match.group(1)), int(match.group(2))) < (2, 2):
         raise Failure(
-            f"Poetry 2.0 or later is required, found {match.group(0)}. Older versions "
-            "cannot read this project's PEP 621 [project] table and fail with a "
-            "cryptic \"'name'\" error."
+            f"Poetry 2.2 or later is required, found {match.group(0)}. Poetry "
+            "before 2.0 cannot read this project's PEP 621 [project] table, and "
+            "before 2.2 poetry-core writes legacy license metadata instead of the "
+            "PEP 639 License-Expression field that the artifact verification "
+            "requires. Upgrade with `poetry self update`."
         )
     ok(f"poetry {match.group(0)}")
 
@@ -651,13 +655,38 @@ def stage_publish(version: str, *, test_pypi: bool) -> None:
         say(
             f"\nPublished {version}. Now:\n"
             f"    python scripts/release.py announce {version}\n"
+            f"    python scripts/release.py finalize {version}\n"
             "conda-forge/rhealpixdggs-feedstock's bot normally opens a "
             "version-bump PR by itself once PyPI updates."
         )
 
 
-def stage_announce(version: str, *, draft: bool, attach: bool) -> None:
-    say(f"Creating the GitHub release for {version}\n")
+def generated_release_notes(tag: str) -> str:
+    """GitHub's auto-generated notes for ``tag`` (the "What's Changed" PR
+    list, new contributors, and full-changelog link). The generate-notes
+    endpoint is a preview: it creates nothing."""
+    raw = run(
+        [
+            "gh",
+            "api",
+            "repos/{owner}/{repo}/releases/generate-notes",
+            "-f",
+            f"tag_name={tag}",
+        ],
+        check=False,
+    )
+    try:
+        return json.loads(raw)["body"]
+    except (json.JSONDecodeError, KeyError):
+        raise Failure(
+            "could not auto-generate the release notes -- "
+            "`gh api .../releases/generate-notes` said:\n"
+            f"{raw or '(no output)'}"
+        )
+
+
+def stage_announce(version: str, *, attach: bool) -> None:
+    say(f"Drafting the GitHub release for {version}\n")
     check_version_argument(version)
     if shutil.which("gh") is None:
         raise Failure(
@@ -672,10 +701,18 @@ def stage_announce(version: str, *, draft: bool, attach: bool) -> None:
         )
     ok(f"tag {tag} is on origin")
 
-    existing = run(["gh", "release", "view", tag, "--json", "url"], check=False)
+    existing = run(["gh", "release", "view", tag, "--json", "url,isDraft"], check=False)
     if existing.startswith("{"):
+        release = json.loads(existing)
+        if release.get("isDraft"):
+            raise Failure(
+                f"a draft release for {tag} already exists: {release['url']}\n"
+                f"Publish it with `python scripts/release.py finalize {version}`, "
+                f"or delete it with `gh release delete {tag}` and run this "
+                "stage again."
+            )
         raise Failure(
-            f"a GitHub release for {tag} already exists: {json.loads(existing)['url']}\n"
+            f"a GitHub release for {tag} already exists: {release['url']}\n"
             "Edit it in the browser, or delete it with "
             f"`gh release delete {tag}` and run this stage again."
         )
@@ -684,6 +721,11 @@ def stage_announce(version: str, *, draft: bool, attach: bool) -> None:
     if not notes.strip():
         raise Failure(f"the {version} section of {CHANGELOG.name} is empty")
     ok(f"release notes: {len(notes.splitlines())} lines from {CHANGELOG.name}")
+
+    generated = generated_release_notes(tag).strip()
+    if generated:
+        notes = f"{notes.rstrip()}\n\n{generated}\n"
+        ok("appended GitHub's auto-generated notes")
 
     prerelease = bool(re.search(r"(a|b|rc)\d+$", version))
     if prerelease:
@@ -699,10 +741,9 @@ def stage_announce(version: str, *, draft: bool, attach: bool) -> None:
     say(notes)
     say("--- end ---\n")
 
-    if draft:
-        note("creating this as a draft; publish it from the browser when ready")
+    note("the release is created as a draft; nothing goes public yet")
     confirm(
-        f"Create the {'draft ' if draft else ''}GitHub release {tag}"
+        f"Create the draft GitHub release {tag}"
         + (" and upload the artifacts?" if assets else "?")
     )
 
@@ -716,21 +757,49 @@ def stage_announce(version: str, *, draft: bool, attach: bool) -> None:
             "create",
             tag,
             "--title",
-            version,
+            tag,
             "--notes-file",
             str(notes_file),
+            "--draft",
         ]
-        if draft:
-            command.append("--draft")
         if prerelease:
             command.append("--prerelease")
         command += assets
         run(command, capture=False)
 
     say(
-        f"\nGitHub release {tag} created"
-        + (" as a draft; publish it when you are happy with it." if draft else ".")
+        f"\nDraft GitHub release {tag} created. Review it, then make it "
+        f"public:\n    python scripts/release.py finalize {version}"
     )
+
+
+def stage_finalize(version: str) -> None:
+    say(f"Publishing the draft GitHub release for {version}\n")
+    check_version_argument(version)
+    if shutil.which("gh") is None:
+        raise Failure(
+            "gh is not on PATH; publish the draft from the browser instead"
+        )
+
+    tag = f"v{version}"
+    existing = run(["gh", "release", "view", tag, "--json", "url,isDraft"], check=False)
+    if not existing.startswith("{"):
+        raise Failure(
+            f"no GitHub release for {tag}; run the announce stage first"
+        )
+    release = json.loads(existing)
+    if not release.get("isDraft"):
+        raise Failure(
+            f"the GitHub release for {tag} is already public: {release['url']}"
+        )
+    ok(f"found the draft release for {tag}")
+
+    confirm(f"Publish the GitHub release {tag}? This makes it publicly visible.")
+    run(["gh", "release", "edit", tag, "--draft=false"], capture=False)
+
+    published = run(["gh", "release", "view", tag, "--json", "url"], check=False)
+    url = json.loads(published)["url"] if published.startswith("{") else ""
+    say(f"\nGitHub release {tag} is public" + (f": {url}" if url else "."))
 
 
 # --------------------------------------------------------------------------
@@ -770,7 +839,8 @@ def main(argv: list[str]) -> int:
         ("prepare", "bump the version files, run the tests, build, verify"),
         ("tag", "commit the bump, tag, and push"),
         ("publish", "upload the built artifacts"),
-        ("announce", "create the GitHub release from the tag and the changelog"),
+        ("announce", "draft the GitHub release: changelog + auto-generated notes"),
+        ("finalize", "publish the draft GitHub release"),
     ):
         sub = subparsers.add_parser(name, help=help_text, parents=[shared])
         sub.add_argument("version", help="the version being released, e.g. 0.7.0")
@@ -781,11 +851,6 @@ def main(argv: list[str]) -> int:
                 help="rehearse against TestPyPI instead of PyPI",
             )
         if name == "announce":
-            sub.add_argument(
-                "--draft",
-                action="store_true",
-                help="create it as a draft, to review before it goes live",
-            )
             sub.add_argument(
                 "--attach",
                 action="store_true",
@@ -811,7 +876,9 @@ def main(argv: list[str]) -> int:
         elif args.stage == "publish":
             stage_publish(args.version, test_pypi=args.test_pypi)
         elif args.stage == "announce":
-            stage_announce(args.version, draft=args.draft, attach=args.attach)
+            stage_announce(args.version, attach=args.attach)
+        elif args.stage == "finalize":
+            stage_finalize(args.version)
     except Failure as failure:
         print(f"\nstopped: {failure}", file=sys.stderr)
         return 1


### PR DESCRIPTION
Hardening from the 0.7.0 release run:

- `check_tools` now requires Poetry ≥ 2.2 — older poetry-core omits the PEP 639 `License-Expression` metadata that `verify_artifacts` demands, which previously wasn't caught until after the build.
- `announce` now always creates a **draft** release, titled `v<VERSION>` to match the tag, with GitHub's auto-generated notes appended to the `CHANGES.rst` body.
- New `finalize` stage publishes the reviewed draft.

`RELEASING.md` updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)