### PR TITLE
Adopt ruff linting with its full default rule set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
-    name: Formatting
+    name: Formatting and lint
     steps:
       - uses: actions/checkout@v4
 
@@ -43,13 +43,19 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Same bound as the dev dependency in pyproject.toml: black's stable
-      # style only changes between major versions, so any 25.x agrees with
-      # the version the code was formatted with.
+      # Same bounds as the dev dependencies in pyproject.toml: black's
+      # stable style only changes between major versions, so any 25.x
+      # agrees with the version the code was formatted with, and ruff's
+      # default rule set is stable within a minor series.
       - name: black --check
         run: |
           python -m pip install "black>=25,<26"
           black --check --diff .
+
+      - name: ruff check
+        run: |
+          python -m pip install "ruff>=0.16,<0.17"
+          ruff check .
 
   docs:
     runs-on: ubuntu-latest

--- a/docs/make_figures.py
+++ b/docs/make_figures.py
@@ -56,7 +56,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent))
 
 import svg_shrink
 
-from rhealpixdggs.dggs import WGS84_003, CELLS0
+from rhealpixdggs.dggs import CELLS0, WGS84_003
 
 OUT = pathlib.Path(__file__).parent / "source" / "images"
 
@@ -1174,7 +1174,7 @@ print("polar squares figure written")
 # (Recentring in latitude via lat_0 is a planar translation, not an
 # ellipsoid isometry, and produces geographically incoherent polar
 # cells, so it makes a poor showcase.)
-from rhealpixdggs.ellipsoids import Ellipsoid, WGS84_A, WGS84_F
+from rhealpixdggs.ellipsoids import WGS84_A, WGS84_F, Ellipsoid
 
 AKL = (174.0, -37.0)
 E_AKL = Ellipsoid(a=WGS84_A, f=WGS84_F, radians=False, lon_0=AKL[0])

--- a/docs/make_figures.py
+++ b/docs/make_figures.py
@@ -28,6 +28,7 @@ commit for reproducibility) and cached under .cache/ at the repository
 root (outside docs/, which is shipped in the sdist).
 """
 
+import itertools
 import json
 import os
 import pathlib
@@ -53,6 +54,7 @@ from matplotlib.patches import Rectangle
 # up svg_shrink from alongside this file however the script was invoked.
 sys.path.insert(0, str(pathlib.Path(__file__).parents[1]))
 sys.path.insert(0, str(pathlib.Path(__file__).parent))
+
 
 import svg_shrink
 
@@ -106,7 +108,7 @@ def coastline_segments():
         )
         for line in lines:
             current = [line[0]]
-            for prev, cur in zip(line, line[1:]):
+            for prev, cur in itertools.pairwise(line):
                 if abs(cur[0] - prev[0]) > 180:
                     segments.append(current)
                     current = []
@@ -171,7 +173,7 @@ for face in CELLS0:
 for seg in COASTLINES:
     xy = [rdggs.rhealpix(lon, lat) for lon, lat in seg]
     run = [xy[0]]
-    for prev, cur in zip(xy, xy[1:]):
+    for prev, cur in itertools.pairwise(xy):
         if abs(cur[0] - prev[0]) > 0.15 * R or abs(cur[1] - prev[1]) > 0.15 * R:
             if len(run) > 1:
                 ax.plot(
@@ -228,7 +230,7 @@ def split_chart_discontinuities(points):
     off the equator, whose cells can overflow past a pole -- wherever
     the latitude wraps from one pole to the other."""
     segs = [[points[0]]]
-    for prev, cur in zip(points, points[1:]):
+    for prev, cur in itertools.pairwise(points):
         if abs(cur[0] - prev[0]) > 180 or abs(cur[1] - prev[1]) > 90:
             segs.append([])
         segs[-1].append(cur)
@@ -241,7 +243,7 @@ def fill_lonlat_polygon(ax, points, **kwargs):
     longitudes into one continuous ring, then draw it at every 360-degree
     offset that intersects the axis window and let clipping do the rest."""
     lons = [points[0][0]]
-    for prev, cur in zip(points, points[1:]):
+    for prev, cur in itertools.pairwise(points):
         d = cur[0] - prev[0]
         if d > 180:
             d -= 360
@@ -394,6 +396,7 @@ print("globe views written")
 # The H3-style wrappers in action over New Zealand: polyfill (cells whose
 # centroids fall inside a polygon) and linetrace (cells touched by a
 # linestring).
+
 from shapely.geometry import LineString, Polygon
 
 from rhealpixdggs import rhp_wrappers
@@ -409,7 +412,7 @@ def draw_cells_lonlat(ax, addresses, fill_alpha=0.35):
         pts = cell.boundary(n=10, plane=False)
         pts = pts + [pts[0]]
         color = FACE_COLORS[address[0]]
-        if all(abs(cur[0] - prev[0]) <= 180 for prev, cur in zip(pts, pts[1:])):
+        if all(abs(cur[0] - prev[0]) <= 180 for prev, cur in itertools.pairwise(pts)):
             ax.fill(
                 [p[0] for p in pts],
                 [p[1] for p in pts],
@@ -465,6 +468,7 @@ print("wrapper examples written")
 # ---------------------------------------------------------------- figure 5
 # linetrace across the north polar cap: the case where cells are not
 # rectangles in longitude-latitude space, seen from above the pole.
+
 from rhealpixdggs import rhp_wrappers
 
 CAP_LINE = [
@@ -557,14 +561,14 @@ for cell in rdggs.cell(["N", 4, 4]).subcells():
         va="center",
         fontsize=9,
         color="#333333",
-        bbox=dict(facecolor="white", alpha=0.6, linewidth=0, pad=1),
+        bbox={"facecolor": "white", "alpha": 0.6, "linewidth": 0, "pad": 1},
         zorder=5,
     )
 
 # The linestring, densified per leg in longitude-latitude space (its
 # segments are straight in that space, so on the globe each leg curves
 # around the pole).
-for a, b in zip(CAP_LINE, CAP_LINE[1:]):
+for a, b in itertools.pairwise(CAP_LINE):
     ts = np.linspace(0, 1, 400)
     lons = a[0] + ts * (b[0] - a[0])
     lats = a[1] + ts * (b[1] - a[1])
@@ -586,8 +590,8 @@ ax.set_ylim(-lim, lim)
 ax.set_aspect("equal")
 ax.axis("off")
 ax.set_title(
-    "linetrace across the north polar cap (resolution %d, view from above the pole)\n"
-    "traced: %s" % (CAP_RES, " → ".join(traced)),
+    f"linetrace across the north polar cap (resolution {CAP_RES}, view from above the pole)\n"
+    f"traced: {' → '.join(traced)}",
     fontsize=10,
 )
 fig.tight_layout()
@@ -656,7 +660,7 @@ for suid, color, lw in zip(level_cells, level_colors, (1.2, 1.6, 2.0, 2.4)):
         color=color,
         ha="right",
         va="bottom",
-        arrowprops=dict(arrowstyle="-", color=color, linewidth=0.8),
+        arrowprops={"arrowstyle": "-", "color": color, "linewidth": 0.8},
     )
 ax.set_xlim(-0.2, 1.02)
 ax.set_ylim(-0.02, 1.15)
@@ -987,7 +991,7 @@ ax.annotate(
     fontsize=10,
     ha="center",
     color="#222222",
-    arrowprops=dict(arrowstyle="->", color="#222222"),
+    arrowprops={"arrowstyle": "->", "color": "#222222"},
 )
 lim = 0.9
 ax.set_xlim(-lim, lim)
@@ -1081,7 +1085,7 @@ ax.annotate(
     ha="center",
     va="top",
     color="#222222",
-    arrowprops=dict(arrowstyle="->", color="#222222", shrinkB=6),
+    arrowprops={"arrowstyle": "->", "color": "#222222", "shrinkB": 6},
 )
 ax.set_xlim(-1.0, 1.0)
 ax.set_ylim(-1.45, 1.3)
@@ -1096,6 +1100,7 @@ print("cube corner (cube view) figure written")
 
 # --------------------------------------------------------------- figure 10
 # The north_square/south_square parameters: where the polar squares sit.
+
 from rhealpixdggs.dggs import RHEALPixDGGS
 from rhealpixdggs.ellipsoids import WGS84_ELLIPSOID
 
@@ -1134,7 +1139,7 @@ for ax, (ns, ss) in zip(axes, [(0, 0), (1, 2)]):
     for seg in COASTLINES:
         xy = [rd.rhealpix(lon, lat) for lon, lat in seg]
         run = [xy[0]]
-        for prev, cur in zip(xy, xy[1:]):
+        for prev, cur in itertools.pairwise(xy):
             if abs(cur[0] - prev[0]) > 0.15 * Rl or abs(cur[1] - prev[1]) > 0.15 * Rl:
                 if len(run) > 1:
                     ax.plot(
@@ -1202,7 +1207,7 @@ ax.annotate(
     xytext=(AKL[0] - 120, AKL[1] - 30),
     fontsize=9,
     color="#222222",
-    arrowprops=dict(arrowstyle="->", color="#222222"),
+    arrowprops={"arrowstyle": "->", "color": "#222222"},
 )
 ax.set_xlim(-180, 180)
 ax.set_ylim(-90, 90)
@@ -1226,7 +1231,7 @@ RING_COLORS = ["#e5735c", "#e8c34f", "#79bf6f", "#5cc3c9"]
 
 
 def draw_ring_panel(ax, center_name, max_k, window_faces):
-    center = rdggs.cell([c if c in CELLS0 else int(c) for c in center_name])
+    rdggs.cell([c if c in CELLS0 else int(c) for c in center_name])
     rings = {0: [center_name]}
     for k in range(1, max_k + 1):
         rings[k] = rhp_wrappers.cell_ring(center_name, k)
@@ -1370,8 +1375,7 @@ for ax, wrap in zip(axes, (False, True)):
     ax.set_yticks(range(-60, 61, 30))
     ax.grid(True, linewidth=0.3, alpha=0.5)
     ax.set_title(
-        "wrap_antimeridian=%s: (179, 10) to (-179, 10) traced %s"
-        % (
+        "wrap_antimeridian={}: (179, 10) to (-179, 10) traced {}".format(
             wrap,
             (
                 "the short way, across the antimeridian"
@@ -1397,11 +1401,11 @@ filled = rhp_wrappers.polyfill(Polygon(NZ_POLYGON), FILL_RES, plane=False, dggs=
 compacted = compact_cells(filled, N_side=rdggs.N_side)
 fig, axes = plt.subplots(1, 2, figsize=(11, 5.2), sharey=True)
 for ax, cells, title in (
-    (axes[0], filled, "polyfill(polygon, res=%d): %d cells" % (FILL_RES, len(filled))),
+    (axes[0], filled, f"polyfill(polygon, res={FILL_RES}): {len(filled)} cells"),
     (
         axes[1],
         compacted,
-        "compact_cells(...): %d cells, mixed resolutions" % len(compacted),
+        f"compact_cells(...): {len(compacted)} cells, mixed resolutions",
     ),
 ):
     draw_coastlines_lonlat(ax, linewidth=0.7)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,7 +72,7 @@ import datetime
 project = "rHEALPixDGGS"
 # First publication year through the year of the build; the end year is
 # computed so it can't go stale.
-copyright = f"2013–{datetime.date.today().year}, Robert Gibb, Alexander Raichev and contributors"
+copyright = f"2013–{datetime.date.today().year}, Robert Gibb, Alexander Raichev and contributors"  # noqa: DTZ011
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # rHEALPixDGGS documentation build configuration file, created by
 # sphinx-quickstart on Wed Jan 16 11:03:44 2013.
@@ -11,8 +10,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/svg_shrink.py
+++ b/docs/svg_shrink.py
@@ -32,8 +32,8 @@ import sys
 
 # <defs>, <g ...>, </g> and <path .../>. Attribute values in matplotlib's
 # output never contain '>', so matching up to the first '>' is safe here.
-_TAG = re.compile(r"<(/?)(defs|g|path)\b([^>]*)>", re.S)
-_D_ATTR = re.compile(r'(\sd=")([^"]*)(")', re.S)
+_TAG = re.compile(r"<(/?)(defs|g|path)\b([^>]*)>", re.DOTALL)
+_D_ATTR = re.compile(r'(\sd=")([^"]*)(")', re.DOTALL)
 _NUMBER = re.compile(r"-?\d+\.\d+")
 
 DEFAULT_DECIMALS = 2

--- a/poetry.lock
+++ b/poetry.lock
@@ -1253,6 +1253,34 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "ruff"
+version = "0.16.5"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b"},
+    {file = "ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3"},
+    {file = "ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb"},
+    {file = "ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025"},
+    {file = "ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9"},
+    {file = "ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7"},
+    {file = "ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde"},
+    {file = "ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea"},
+    {file = "ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105"},
+    {file = "ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29"},
+    {file = "ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf"},
+    {file = "ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91"},
+    {file = "ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a"},
+    {file = "ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef"},
+    {file = "ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26"},
+    {file = "ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f"},
+    {file = "ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e"},
+    {file = "ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b"},
+]
+
+[[package]]
 name = "scipy"
 version = "1.16.1"
 description = "Fundamental algorithms for scientific computing in Python"
@@ -1605,4 +1633,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "3fc806ee41fa6d7a90710d7b199b690cf14b142fa157b465667bb1e2bd6a8b5f"
+content-hash = "18dc7cd1098ec8bf029634b960f83ccd93c3c61ec71c09c954fde77ab6df323a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ source = "https://github.com/manaakiwhenua/rhealpixdggs-py"
  
 [tool.poetry.group.dev.dependencies]
 black = "^25"
+ruff = "^0.16"
 pytest = "^7.4.0"
 sphinx = "^7.2"
 furo = ">=2024.8"

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -1,12 +1,14 @@
 # from rhealpixdggs.dggs import WGS84_003
 
-from numpy import array, base_repr, pi  # pi is just for the doctests
-from numpy import vectorize as numpy_vectorize
-from scipy import integrate
+from colorsys import hsv_to_rgb
+from functools import cached_property, total_ordering
 from itertools import product
 from random import uniform
-from colorsys import hsv_to_rgb
-from functools import total_ordering, cached_property
+
+# pi is doctest-only: the doctests use it from the module globals.
+from numpy import array, base_repr, pi  # noqa: F401
+from numpy import vectorize as numpy_vectorize
+from scipy import integrate
 
 from rhealpixdggs.utils import wrap_longitude
 
@@ -15,7 +17,7 @@ CELLS0 = ["N", "O", "P", "Q", "R", "S"]
 
 
 @total_ordering
-class Cell(object):
+class Cell:
     """
     Represents a cell of the planar or ellipsoidal rHEALPix grid hierarchies.
     Cell identifiers are of the form (p_0, p_1,...,p_l), where p_0 is one of
@@ -831,8 +833,7 @@ class Cell(object):
             (157.49999999999997, 58.41366190347208)
 
         """
-        if n < 2:
-            n = 2
+        n = max(n, 2)
         # Quad and cap cells have straight or rotationally-symmetric edges on
         # the ellipsoid, so at n=2 extra boundary points would add no accuracy.
         # Fall back to vertices() and avoid the per-point projection cost
@@ -978,7 +979,7 @@ class Cell(object):
             return lon_max <= lam or lam <= lon_min
         else:
             # Typical case.
-            return lon_min <= lam and lam <= lon_max
+            return lon_min <= lam <= lon_max
 
     def intersects_parallel(self, phi):
         """

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -4,6 +4,7 @@ from colorsys import hsv_to_rgb
 from functools import cached_property, total_ordering
 from itertools import product
 from random import uniform
+from typing import ClassVar
 
 # pi is doctest-only: the doctests use it from the module globals.
 from numpy import array, base_repr, pi  # noqa: F401
@@ -157,20 +158,17 @@ class Cell:
         if suid is not None:
             # A little error checking.
             if not isinstance(suid, (list, tuple)):
-                raise TypeError("Cell suid must be a list or tuple. Got %s." % suid)
+                raise TypeError(f"Cell suid must be a list or tuple. Got {suid}.")
             if not (0 < len(suid) <= rdggs.max_resolution + 1):
                 raise ValueError(
-                    "Need 0 < len(suid) <= %s. Got %s."
-                    % (rdggs.max_resolution + 1, suid)
+                    f"Need 0 < len(suid) <= {rdggs.max_resolution + 1}. Got {suid}."
                 )
             if suid[0] not in CELLS0:
-                raise ValueError("suid[0] must lie in %s. Got %s." % (CELLS0, suid[0]))
+                raise ValueError(f"suid[0] must lie in {CELLS0}. Got {suid[0]}.")
             digits = set(range(self.N_side**2))
             for x in suid[1:]:
                 if x not in digits:
-                    raise ValueError(
-                        "Digits of suid must lie in %s. Got %s." % (digits, x)
-                    )
+                    raise ValueError(f"Digits of suid must lie in {digits}. Got {x}.")
 
             self.suid = [suid[0]] + [int(n) for n in suid[1:]]
             self.suid = tuple(self.suid)
@@ -229,10 +227,7 @@ class Cell:
         t = other.suid
         t_starts_with_s = t[: len(s)] == s
         s_starts_with_t = s[: len(t)] == t
-        if (s <= t and not t_starts_with_s) or s_starts_with_t:
-            return True
-        else:
-            return False
+        return (s <= t and not t_starts_with_s) or s_starts_with_t
 
     def index(self, order="resolution"):
         """
@@ -1090,7 +1085,7 @@ class Cell:
             return "cap"
         # Dart check 1.
         dart = True
-        S = set([i * (N + 1) for i in range(N)])
+        S = {i * (N + 1) for i in range(N)}
         for n in suid[1:]:
             if n not in S:
                 dart = False
@@ -1099,7 +1094,7 @@ class Cell:
             return "dart"
         # Dark check 2.
         dart = True
-        S = set([(i + 1) * (N - 1) for i in range(N)])
+        S = {(i + 1) * (N - 1) for i in range(N)}
         for n in suid[1:]:
             if n not in S:
                 dart = False
@@ -1227,7 +1222,7 @@ class Cell:
         A = self.rdggs.child_order
         # Function (written as a dictionary) describing action of rotating A
         # one quarter turn anticlockwise.
-        f = dict()
+        f = {}
         for i in range(N):
             for j in range(N):
                 n = A[(i, j)]
@@ -1327,9 +1322,9 @@ class Cell:
             neighbor_suid = []
             N = self.N_side
             up_border = set(range(N))
-            down_border = set([(N - 1) * N + i for i in range(N)])
-            left_border = set([i * N for i in range(N)])
-            right_border = set([(i + 1) * N - 1 for i in range(N)])
+            down_border = {(N - 1) * N + i for i in range(N)}
+            left_border = {i * N for i in range(N)}
+            right_border = {(i + 1) * N - 1 for i in range(N)}
             border = {
                 "left": left_border,
                 "right": right_border,
@@ -1405,13 +1400,13 @@ class Cell:
             up Q2
 
         """
-        plane_neighbors = dict()
+        plane_neighbors = {}
         for d in ["left", "right", "down", "up"]:
             plane_neighbors[d] = self.neighbor(d, "plane")
         if plane:
             return plane_neighbors
         # Ellipsoid case.
-        result = dict()
+        result = {}
         shape = self.ellipsoidal_shape
         if shape == "quad":
             result["north"] = plane_neighbors["up"]
@@ -1495,7 +1490,7 @@ class Cell:
 
     # Diagonal (corner-touching only) directions, each a (row, column)
     # direction pair, keyed to match neighbor()'s own plane direction names.
-    _DIAGONAL_DIRECTIONS = {
+    _DIAGONAL_DIRECTIONS: ClassVar[dict[str, tuple[str, str]]] = {
         "up_left": ("up", "left"),
         "up_right": ("up", "right"),
         "down_left": ("down", "left"),
@@ -1625,11 +1620,11 @@ class Cell:
         """
         if self.rdggs != other.rdggs:
             raise ValueError(
-                "Cannot test %s between cells of different RHEALPixDGGS "
-                "instances." % verb
+                f"Cannot test {verb} between cells of different RHEALPixDGGS "
+                "instances."
             )
         if not self.suid or not other.suid:
-            raise ValueError("Cannot test %s for an empty cell." % verb)
+            raise ValueError(f"Cannot test {verb} for an empty cell.")
 
     def equals(self, other):
         """
@@ -1853,7 +1848,7 @@ class Cell:
         """
         suid = self.suid
         N = self.rdggs.N_side
-        hue_resolution0 = dict([(v, k / 6.0) for (k, v) in enumerate(CELLS0)])
+        hue_resolution0 = {v: k / 6.0 for (k, v) in enumerate(CELLS0)}
         hue = hue_resolution0[suid[0]]
         n = len(suid)
         if n > 1:

--- a/rhealpixdggs/conversion.py
+++ b/rhealpixdggs/conversion.py
@@ -1,8 +1,10 @@
-from shapely.geometry import Polygon, Point
-from rhealpixdggs.dggs import RHEALPixDGGS, WGS84_003
-from rhealpixdggs.cell import Cell
-from itertools import compress
 from collections.abc import Iterable
+from itertools import compress
+
+from shapely.geometry import Point, Polygon
+
+from rhealpixdggs.cell import Cell
+from rhealpixdggs.dggs import WGS84_003, RHEALPixDGGS
 
 
 def get_finest_containing_cell(
@@ -119,7 +121,7 @@ class CellZoneFromPoly:
         Writes cell / polygon details to either or both of a list or a file.
         """
         if self.file is not None:
-            self.file.write(f"{str(cell)} {desc}\n ")
+            self.file.write(f"{cell!s} {desc}\n ")
             # self.file.write(f"{poly.wkt}\n")
         if self.return_cells:
             # cell = self.add_int_suid(cell)

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -151,28 +151,32 @@ orient the DGGS so that the planar origin (0, 0) is on Auckland, New Zealand ::
 #                  http: //www.gnu.org/licenses/
 # *****************************************************************************
 # Import third-party modules.
-from numpy import array, base_repr, ceil, log, pi
-from math import asin, copysign, floor
-
 # Import standard modules.
 from itertools import product
+from math import asin, copysign, floor
 from random import randint
+
+from numpy import array, base_repr, ceil, log, pi
+
+# assert_allclose is doctest-only: the doctests use it from the module globals.
+from numpy.testing import assert_allclose  # noqa: F401
 
 # Import my modules.
 import rhealpixdggs.pj_rhealpix as pjr
 import rhealpixdggs.projection_wrapper as pw
-from rhealpixdggs.cell import Cell, CELLS0
+from rhealpixdggs.cell import CELLS0, Cell
 from rhealpixdggs.ellipsoids import (
-    WGS84_ELLIPSOID,
-    WGS84_ELLIPSOID_RADIANS,
     UNIT_SPHERE,
     UNIT_SPHERE_RADIANS,
+    WGS84_ELLIPSOID,
+    WGS84_ELLIPSOID_RADIANS,
 )
-from rhealpixdggs.utils import auth_lat, my_round
-from numpy.testing import assert_allclose
+
+# my_round is doctest-only: the doctests use it from the module globals.
+from rhealpixdggs.utils import auth_lat, my_round  # noqa: F401
 
 
-class RHEALPixDGGS(object):
+class RHEALPixDGGS:
     """
     Represents an rHEALPix DGGS on a given ellipsoid.
 
@@ -1426,8 +1430,7 @@ class RHEALPixDGGS(object):
         """
         if plane:
             return {cell: cell.boundary(n=n, plane=True) for cell in cells}
-        if n < 2:
-            n = 2
+        n = max(n, 2)
         R = self.ellipsoid.R_A
         x_anchor = -pi * R
         y_anchor = -3 * pi * R / 4

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -152,7 +152,7 @@ orient the DGGS so that the planar origin (0, 0) is on Auckland, New Zealand ::
 # *****************************************************************************
 # Import third-party modules.
 # Import standard modules.
-from itertools import product
+from itertools import pairwise, product
 from math import asin, copysign, floor
 from random import randint
 
@@ -356,11 +356,11 @@ class RHEALPixDGGS:
 
     def __str__(self):
         result = ["rHEALPix DGGS:"]
-        result.append("    N_side = %s" % self.N_side)
-        result.append("    north_square = %s" % self.north_square)
-        result.append("    south_square = %s" % self.south_square)
-        result.append("    max_areal_resolution = %s" % self.max_areal_resolution)
-        result.append("    max_resolution = %s" % self.max_resolution)
+        result.append(f"    N_side = {self.N_side}")
+        result.append(f"    north_square = {self.north_square}")
+        result.append(f"    south_square = {self.south_square}")
+        result.append(f"    max_areal_resolution = {self.max_areal_resolution}")
+        result.append(f"    max_resolution = {self.max_resolution}")
         result.append("    ellipsoid:")
         for k, v in sorted(self.ellipsoid.__dict__.items()):
             if k == "phi_0":
@@ -639,7 +639,9 @@ class RHEALPixDGGS:
             yield cs
             cs = cs.successor(resolution)
 
-    def num_cells(self, res_1: int, res_2: int = None, subcells: bool = False) -> int:
+    def num_cells(
+        self, res_1: int, res_2: int | None = None, subcells: bool = False
+    ) -> int:
         """
         Return the number of cells of resolutions `res_1` to `res_2`
         (inclusive).
@@ -1286,7 +1288,7 @@ class RHEALPixDGGS:
             )
             lo = min(lstart[0], lend[0]) - ell.lon_0
             hi = max(lstart[0], lend[0]) - ell.lon_0
-            k0, k1 = int(floor(lo / quarter)), int(ceil(hi / quarter))
+            k0, k1 = floor(lo / quarter), int(ceil(hi / quarter))
             add_linear_crossings(
                 lstart[0],
                 lend[0],
@@ -1301,8 +1303,8 @@ class RHEALPixDGGS:
 
         def lattice_lines_between(a, b, anchor):
             lo, hi = (a, b) if a <= b else (b, a)
-            i0 = int(floor((lo - anchor) / w)) + 1
-            i1 = int(floor((hi - anchor) / w))
+            i0 = floor((lo - anchor) / w) + 1
+            i1 = floor((hi - anchor) / w)
             return [anchor + i * w for i in range(i0, i1 + 1)]
 
         def root(f, ta, tb, fa):
@@ -1352,7 +1354,7 @@ class RHEALPixDGGS:
                     cuts.append(0.5 * (lo + hi))
                     direction = d
             cuts.append(tb)
-            return list(zip(cuts, cuts[1:]))
+            return list(pairwise(cuts))
 
         crossings = set()
         for pa, pb in zip(sorted(breakpoints), sorted(breakpoints)[1:]):
@@ -1379,7 +1381,7 @@ class RHEALPixDGGS:
 
         ts = [0.0] + sorted(crossings) + [1.0]
         line_cells = [start]
-        for a, b in zip(ts, ts[1:]):
+        for a, b in pairwise(ts):
             cell = self.cell_from_point(resolution, point_at(0.5 * (a + b)), plane)
             if cell is not None and cell != line_cells[-1]:
                 line_cells.append(cell)
@@ -1635,7 +1637,7 @@ class RHEALPixDGGS:
         # Pick a random point in that cell.
         return c.random_point(plane=plane)
 
-    def random_cell(self, resolution: int = None) -> Cell:
+    def random_cell(self, resolution: int | None = None) -> Cell:
         """
         Return a cell of the given resolution chosen uniformly at random
         from all cells at that resolution.
@@ -1685,7 +1687,7 @@ class RHEALPixDGGS:
             ['N0214', 'P7334']
 
         """
-        cover = dict()  # Use a dictionary to ignore repeated cells.
+        cover = {}  # Use a dictionary to ignore repeated cells.
         for p in points:
             c = self.cell_from_point(resolution, p, plane=plane)
             # nuc = c.nucleus(plane=plane)

--- a/rhealpixdggs/ellipsoids.py
+++ b/rhealpixdggs/ellipsoids.py
@@ -20,14 +20,14 @@ Points lying on an ellipsoid are given in geodetic (longitude, latitude) coordin
 # *****************************************************************************
 
 # Import third-party modules.
-import pyproj
-from numpy import pi, sqrt, sin, cos, arcsin, arctanh, deg2rad, rad2deg
-
 # Import standard modules.
 from random import uniform
 
+import pyproj
+from numpy import arcsin, arctanh, cos, deg2rad, pi, rad2deg, sin, sqrt
+
 # Import my modules.
-from rhealpixdggs.utils import my_round, auth_lat, auth_rad
+from rhealpixdggs.utils import auth_lat, auth_rad, my_round
 
 # Parameters of some common ellipsoids.
 WGS84_A = pyproj.get_ellps_map()["WGS84"]["a"]  # 6378137.0
@@ -38,7 +38,7 @@ WGS84_R_A = sqrt(WGS84_A**2 / 2 + WGS84_B**2 / 2 * (arctanh(WGS84_E) / WGS84_E))
 R_EM = pyproj.get_ellps_map()["sphere"]["a"]  # 6371000 (Earth's mean radius)
 
 
-class Ellipsoid(object):
+class Ellipsoid:
     """
     Represents an ellipsoid of revolution (possibly a sphere) with a
     geodetic longitude-latitude coordinate frame.

--- a/rhealpixdggs/ellipsoids.py
+++ b/rhealpixdggs/ellipsoids.py
@@ -124,10 +124,7 @@ class Ellipsoid:
         return "\n".join(result)
 
     def __eq__(self, other):
-        if self.a == other.a and self.b == other.b:
-            return True
-        else:
-            return False
+        return self.a == other.a and self.b == other.b
 
     def __ne__(self, other):
         """
@@ -312,14 +309,15 @@ class Ellipsoid:
         whitespace and angles given in degrees.
         """
         result = []
-        for line in open(filename, "rb"):
-            if line[0] not in ["-", "1", "2", "3", "4", "5", "6", "7", "8", "9"]:
-                # Ignore line.
-                continue
-            else:
-                # Split coordinate pair on whitespace.
-                p = [float(x) for x in line.split()]
-                result.append(p)
+        with open(filename, "rb") as file:
+            for line in file:
+                if line[0] not in ["-", "1", "2", "3", "4", "5", "6", "7", "8", "9"]:
+                    # Ignore line.
+                    continue
+                else:
+                    # Split coordinate pair on whitespace.
+                    p = [float(x) for x in line.split()]
+                    result.append(p)
         if self.radians:
             # Convert to radians.
             result = [deg2rad(p) for p in result]

--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -20,13 +20,15 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 # *****************************************************************************
 
 # Import third-party modules.
-from numpy import pi, floor, sqrt, sin, arcsin, sign, array, deg2rad, rad2deg
+from collections.abc import Callable
+
 import shapely
+from numpy import arcsin, array, deg2rad, floor, pi, rad2deg, sign, sin, sqrt
 from shapely.geometry import Polygon
-from typing import Callable
 
 # Import my modules.
-from rhealpixdggs.utils import my_round, auth_lat, auth_rad
+# my_round is doctest-only: the doctests use it from the module globals.
+from rhealpixdggs.utils import auth_lat, auth_rad, my_round  # noqa: F401
 
 # Cache for in_healpix_image(); see the comment inside that function.
 _healpix_image_poly = None

--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -85,8 +85,8 @@ def healpix_sphere_inverse(x: float, y: float) -> tuple[float, float]:
     """
     if not in_healpix_image(x, y):
         raise ValueError(
-            "(%.20f,%.20f) is not a point in the image of the HEALPix "
-            "projection of the unit sphere" % (x, y)
+            f"({x:.20f},{y:.20f}) is not a point in the image of the HEALPix "
+            "projection of the unit sphere"
         )
     y0 = pi / 4
     # Equatorial region.

--- a/rhealpixdggs/pj_rhealpix.py
+++ b/rhealpixdggs/pj_rhealpix.py
@@ -332,9 +332,9 @@ def rhealpix_sphere_inverse(
         x, y, south_square=south_square, north_square=north_square
     ):
         raise ValueError(
-            "(%.20f,%.20f) is not a point in the image of the "
-            "(%d, %d)-rHEALPix projection of the unit sphere"
-            % (x, y, north_square, south_square)
+            f"({x:.20f},{y:.20f}) is not a point in the image of the "
+            f"({north_square}, {south_square})-rHEALPix projection of the "
+            "unit sphere"
         )
     if region != "equatorial":
         x, y = combine_triangles(
@@ -410,9 +410,9 @@ def rhealpix_ellipsoid_inverse(
         x, y, south_square=south_square, north_square=north_square
     ):
         raise ValueError(
-            "(%.20f,%.20f) is not a point in the image of the "
-            "(%d, %d)-rHEALPix projection of the unit sphere"
-            % (x, y, north_square, south_square)
+            f"({x:.20f},{y:.20f}) is not a point in the image of the "
+            f"({north_square}, {south_square})-rHEALPix projection of the "
+            "unit sphere"
         )
 
     if region != "equatorial":

--- a/rhealpixdggs/pj_rhealpix.py
+++ b/rhealpixdggs/pj_rhealpix.py
@@ -18,19 +18,22 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 # *****************************************************************************
 
 # Import third-party modules.
-from numpy import pi, sign, array, identity, dot, deg2rad, rad2deg
+from collections.abc import Callable
+
 import shapely
+from numpy import array, deg2rad, dot, identity, pi, rad2deg, sign
 from shapely.geometry import Polygon
-from typing import Callable
 
 # Import my modules.
 from rhealpixdggs.pj_healpix import (
-    healpix_sphere,
-    healpix_sphere_inverse,
     healpix_ellipsoid,
     healpix_ellipsoid_inverse,
+    healpix_sphere,
+    healpix_sphere_inverse,
 )
-from rhealpixdggs.utils import my_round, auth_rad
+
+# my_round is doctest-only: the doctests use it from the module globals.
+from rhealpixdggs.utils import auth_rad, my_round  # noqa: F401
 
 # Matrix for anticlockwise rotation by pi/2:
 ROTATE1 = array([[0, -1], [1, 0]])

--- a/rhealpixdggs/projection_wrapper.py
+++ b/rhealpixdggs/projection_wrapper.py
@@ -18,15 +18,16 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 # *****************************************************************************
 
 # Import third-party modules.
-import pyproj
-
 # Import standard modules.
 import importlib
 
-# Import my modules.
-from rhealpixdggs.utils import my_round, wrap_longitude, wrap_latitude
+import pyproj
+
 from rhealpixdggs.ellipsoids import WGS84_ELLIPSOID
 
+# Import my modules.
+# my_round is doctest-only: the doctests use it from the module globals.
+from rhealpixdggs.utils import my_round, wrap_latitude, wrap_longitude  # noqa: F401
 
 # Homemade map projections, as opposed to those in the PROJ.4 library.
 # Remove 'healpix' and 'rhealpix' to use the PROJ.4 versions instead,
@@ -35,7 +36,7 @@ HOMEMADE_PROJECTIONS = {"healpix", "rhealpix", "isea", "csea", "qsc"}
 # HOMEMADE_PROJECTIONS = {"isea", "csea", "qsc"}
 
 
-class Projection(object):
+class Projection:
     """
     Represents a map projection of a given ellipsoid.
 

--- a/rhealpixdggs/projection_wrapper.py
+++ b/rhealpixdggs/projection_wrapper.py
@@ -85,8 +85,8 @@ class Projection:
 
     def __str__(self):
         result = ["map projection:"]
-        result.append("    proj = %s" % self.proj)
-        result.append("    kwargs = %s" % self.kwargs)
+        result.append(f"    proj = {self.proj}")
+        result.append(f"    kwargs = {self.kwargs}")
         result.append("    ellipsoid:")
         for k, v in sorted(self.ellipsoid.__dict__.items()):
             result.append(" " * 8 + k + " = " + str(v))
@@ -110,7 +110,7 @@ class Projection:
                     module = importlib.import_module("rhealpixdggs.pj_" + self.proj)
                     self._f = getattr(module, self.proj)(a=a, e=e, **self.kwargs)
                 except (AttributeError, ModuleNotFoundError):
-                    print("Oops! Projection %s is not implemented." % self.proj)
+                    print(f"Oops! Projection {self.proj} is not implemented.")
                     return None
             else:
                 # Use a projection from the PROJ library.

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -105,7 +105,10 @@ def rhp_to_geo(
 
 
 def rhp_to_parent(
-    rhpindex: str, res: int = None, verbose: bool = True, dggs: RHEALPixDGGS = WGS84_003
+    rhpindex: str,
+    res: int | None = None,
+    verbose: bool = True,
+    dggs: RHEALPixDGGS = WGS84_003,
 ) -> str | None:
     """
     Returns parent of rhpindex at resolution res (immediate parent if res == None).
@@ -145,7 +148,10 @@ def rhp_to_parent(
 
 
 def rhp_to_center_child(
-    rhpindex: str, res: int = None, verbose: bool = True, dggs: RHEALPixDGGS = WGS84_003
+    rhpindex: str,
+    res: int | None = None,
+    verbose: bool = True,
+    dggs: RHEALPixDGGS = WGS84_003,
 ) -> str | None:
     """
     Returns central child of rhpindex at resolution res (immediate central
@@ -716,10 +722,7 @@ def _malformed_geometry(geometry: Polygon | MultiPolygon) -> bool:
         return True
 
     # Geometry has to have an area, i.e. not be collapsed to a line
-    if geometry.area == 0:
-        return True
-
-    return False
+    return geometry.area == 0
 
 
 def _malformed_lines(lines: LineString | MultiLineString) -> bool:
@@ -735,10 +738,7 @@ def _malformed_lines(lines: LineString | MultiLineString) -> bool:
         return True
 
     # Lines need to have a length, i.e. not be collapsed into points
-    if lines.length == 0:
-        return True
-
-    return False
+    return lines.length == 0
 
 
 def _remove_sequential_duplicates(cells: list[str]) -> list[str]:

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -1,24 +1,20 @@
-from typing import Literal, Union
+from typing import Literal
 from warnings import warn
-from shapely import is_valid_reason
-from shapely.geometry import Point, Polygon, MultiPolygon, LineString, MultiLineString
 
-from rhealpixdggs.dggs import RHEALPixDGGS
-from rhealpixdggs.cell import Cell
+from shapely import is_valid_reason
+from shapely.geometry import LineString, MultiLineString, MultiPolygon, Point, Polygon
+
+# List of resolution 0 cell addresses (i.e. cube faces)
+from rhealpixdggs.cell import CELLS0, Cell
 from rhealpixdggs.conversion import compact_cells
 
 # ======== Messages and constants ======== #
-
-
 # Pre-defined DGGS with WGS84 ellipsoid, coordinates in degrees, n == 3 to subdivide
 # cell sides, and both N and S polar cube face attached to O equatorial cube face:
 # N
 # O P Q R
 # S
-from rhealpixdggs.dggs import WGS84_003
-
-# List of resolution 0 cell addresses (i.e. cube faces)
-from rhealpixdggs.cell import CELLS0
+from rhealpixdggs.dggs import WGS84_003, RHEALPixDGGS
 
 # Warnings
 PARENT_RESOLUTION_WARNING = "WARNING: You requested a parent resolution that is higher than the cell resolution. Returning the cell address itself."
@@ -198,7 +194,7 @@ def rhp_to_center_child(
         c_index = int((dggs.N_side**2 - 1) / 2)
 
         # Append the required number of child digits to cell index
-        child_index = rhpindex + "".join(str(c_index) for _ in range(0, added_levels))
+        child_index = rhpindex + "".join(str(c_index) for _ in range(added_levels))
 
         return child_index
 
@@ -432,7 +428,7 @@ def k_ring(
 
 
 def polyfill(
-    geometry: Union[Polygon, MultiPolygon],
+    geometry: Polygon | MultiPolygon,
     res: int,
     plane: bool = True,
     compress: bool = False,
@@ -547,7 +543,7 @@ def polyfill(
 
 
 def linetrace(
-    geometry: Union[LineString, MultiLineString],
+    geometry: LineString | MultiLineString,
     res: int,
     plane: bool = True,
     verbose: bool = False,
@@ -706,7 +702,7 @@ def _rings_up_to(center: Cell, k: int) -> list[list[Cell]]:
     return rings
 
 
-def _malformed_geometry(geometry: Union[Polygon, MultiPolygon]) -> bool:
+def _malformed_geometry(geometry: Polygon | MultiPolygon) -> bool:
     # Geometry has to have things in it
     if geometry is None or geometry.is_empty:
         return True
@@ -726,7 +722,7 @@ def _malformed_geometry(geometry: Union[Polygon, MultiPolygon]) -> bool:
     return False
 
 
-def _malformed_lines(lines: Union[LineString, MultiLineString]) -> bool:
+def _malformed_lines(lines: LineString | MultiLineString) -> bool:
     # There have to be lines
     if lines is None or lines.is_empty:
         return True

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -208,8 +208,6 @@ def write_if_changed(path: pathlib.Path, old: str, new: str) -> bool:
 
 
 def check_tools(*, need_poetry: bool) -> None:
-    if sys.version_info < (3, 11):
-        raise Failure("this script needs Python 3.11 or newer (tomllib)")
     if not need_poetry:
         return
     if shutil.which("poetry") is None:
@@ -379,7 +377,9 @@ def rst_to_markdown(text: str) -> str:
 
 
 def check_copyright_year() -> None:
-    this_year = datetime.date.today().year
+    # The releaser's local date is the right one here: it matches what a
+    # human writes in the license files.
+    this_year = datetime.date.today().year  # noqa: DTZ011
     for name in COPYRIGHT_FILES:
         path = ROOT / name
         match = re.search(r"Copyright \(c\) (\d{4})-(\d{4})", path.read_text())
@@ -578,7 +578,8 @@ def stage_prepare(version: str) -> None:
         note(f"already at {version}; leaving the version files alone")
     else:
         check_version_bump(version, expect_bumped=False)
-        today = datetime.date.today()
+        # The releaser's local date is the right release date to record.
+        today = datetime.date.today()  # noqa: DTZ011
         say("\nSetting the version")
         if set_pyproject_version(version):
             ok(f"pyproject.toml -> {version}")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -158,7 +158,7 @@ def pyproject_version() -> str:
 
 
 def citation_version() -> str:
-    match = re.search(r"^version:\s*(\S+)\s*$", CITATION.read_text(), re.M)
+    match = re.search(r"^version:\s*(\S+)\s*$", CITATION.read_text(), re.MULTILINE)
     if not match:
         raise Failure(f"no 'version:' line in {CITATION.name}")
     return match.group(1).strip("\"'")
@@ -373,7 +373,7 @@ def rst_to_markdown(text: str) -> str:
         spans.append(match.group(1))
         return f"\x00{len(spans) - 1}\x00"
 
-    text = re.sub(r"``(.+?)``", stash, text, flags=re.S)
+    text = re.sub(r"``(.+?)``", stash, text, flags=re.DOTALL)
     text = re.sub(r"(?<=\s)--(?=\s)", "—", text)
     return re.sub(r"\x00(\d+)\x00", lambda m: f"`{spans[int(m.group(1))]}`", text)
 

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -101,7 +101,9 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             expect = (P, 1)
 
             def num(k):
-                return rdggs.num_cells(res_1=k, subcells=True)
+                # rdggs is stable across this loop iteration, and num() is
+                # only called within it.
+                return rdggs.num_cells(res_1=k, subcells=True)  # noqa: B023
 
             i = 2 * num(0) + 1 * num(1) + num(1) - 1
             get = Cell(rdggs, post_order_index=i).suid
@@ -167,7 +169,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             c = Cell(rdggs, (O, 1, 2))
             self.assertTrue(a < b)
             self.assertTrue(a < c)
-            self.assertFalse(a < a)
+            self.assertFalse(a < a)  # noqa: PLR0124 -- tests < irreflexivity
             self.assertFalse(b < a)
             self.assertFalse(c < a)
 
@@ -207,7 +209,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             c = Cell(rdggs, (O, 1, 2))
             self.assertFalse(a > b)
             self.assertFalse(a > c)
-            self.assertFalse(a > a)
+            self.assertFalse(a > a)  # noqa: PLR0124 -- tests > irreflexivity
             self.assertTrue(b > a)
             self.assertTrue(c > a)
 
@@ -239,8 +241,9 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             self.assertEqual(c.index(order="level"), b.index(order="level") + 1)
 
             # It should invert suid_from_index().
-            M = rdggs.num_cells(0, rdggs.max_resolution)
-            k = 3616048  # randint(0, M - 1)
+            # A fixed index; originally drawn as
+            # randint(0, rdggs.num_cells(0, rdggs.max_resolution) - 1).
+            k = 3616048
             get = Cell(rdggs, Cell.suid_from_index(rdggs, k, order="level")).index(
                 order="level"
             )
@@ -269,7 +272,6 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             # Assume that nucleus() and vertices() work.
             for suid in [[N, 3, 1], [P, 5, 7, 5, 1, 3], [S, 0]]:
                 c = Cell(rdggs, suid)
-                w = c.width()
                 for plane in [True, False]:
                     nucleus = c.nucleus(plane=plane)
                     vertices = c.vertices(plane=plane)
@@ -459,7 +461,6 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             (x, y) = a.ul_vertex()
             error = 1e-10
             for row, col in product(list(range(3)), repeat=2):
-                s = str(row * 3 + col)
                 # Child cell in (row, column) position relative to a:
                 b = Cell(rdggs, list(a.suid) + [3 * row + col])
                 get = b.nucleus()
@@ -548,7 +549,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             # Quad.
             c = Cell(rdggs, (O, 0))
             get = c.neighbors(plane=False)
-            expect = dict()
+            expect = {}
             expect["north"] = Cell(rdggs, (N, 6))
             expect["south"] = Cell(rdggs, (O, 3))
             expect["west"] = Cell(rdggs, (R, 2))
@@ -558,7 +559,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             # Cap.
             c = Cell(rdggs, (S, 4))
             get = c.neighbors(plane=False)
-            expect = dict()
+            expect = {}
             expect["north_0"] = Cell(rdggs, (S, 1))
             expect["north_1"] = Cell(rdggs, (S, 5))
             expect["north_2"] = Cell(rdggs, (S, 7))
@@ -568,7 +569,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             # Dart.
             c = Cell(rdggs, (N, 6))
             get = c.neighbors(plane=False)
-            expect = dict()
+            expect = {}
             expect["west"] = Cell(rdggs, (N, 3))
             expect["east"] = Cell(rdggs, (N, 7))
             expect["south_west"] = Cell(rdggs, (R, 2))
@@ -578,7 +579,7 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             # Skew quad.
             c = Cell(rdggs, (N, 3))
             get = c.neighbors(plane=False)
-            expect = dict()
+            expect = {}
             expect["north"] = Cell(rdggs, (N, 4))
             expect["south"] = Cell(rdggs, (R, 1))
             expect["west"] = Cell(rdggs, (N, 0))
@@ -974,7 +975,9 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             y2 = max(v[1] for v in pv)
 
             def phi(y):
-                return rdggs.rhealpix(x1, y, inverse=True)[1]
+                # rdggs and x1 are stable across this loop iteration, and
+                # phi() is only integrated within it.
+                return rdggs.rhealpix(x1, y, inverse=True)[1]  # noqa: B023
 
             expected_lat = (
                 integrate.quad(phi, y1, y2, epsabs=1e-5, epsrel=1e-10)[0]

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1,20 +1,19 @@
 # Import third-party modules.
-from scipy.spatial.distance import euclidean, norm
-
 # Import standard modules
 import unittest
 from itertools import product
 from math import pi
 
-# Import my modules.
-from rhealpixdggs.cell import Cell, CELLS0
+from scipy.spatial.distance import euclidean, norm
 
-from rhealpixdggs.dggs import RHEALPixDGGS, WGS84_003, WGS84_003_RADIANS
+# Import my modules.
+from rhealpixdggs.cell import CELLS0, Cell
+from rhealpixdggs.dggs import WGS84_003, WGS84_003_RADIANS, RHEALPixDGGS
 from rhealpixdggs.ellipsoids import (
-    Ellipsoid,
     WGS84_ASPHERE_RADIANS,
     WGS84_ELLIPSOID,
     WGS84_ELLIPSOID_RADIANS,
+    Ellipsoid,
 )
 
 # Level 0 cell names

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -8,11 +8,11 @@ Keep adding tests!
 
 # Import standard modules.
 import unittest
+
 from shapely import wkt
 
 # Import my modules.
 from rhealpixdggs.conversion import *
-
 
 test_geom = """
         MULTIPOLYGON (((148.6675 -35.5725, 148.6675 -35.575, 148.67 -35.575, 148.67 -35.5775, 148.6725 -35.5775,

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -16,6 +16,7 @@ Keep adding tests!
 
 # Import third-party modules.
 # Import standard modules
+import itertools
 import unittest
 from random import randint  # , uniform
 
@@ -293,7 +294,7 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
             cells = rdggs.cells_from_line(res, a, b, plane=False)
             self.assertEqual(cells[0], rdggs.cell_from_point(res, a, plane=False))
             self.assertEqual(cells[-1], rdggs.cell_from_point(res, b, plane=False))
-            for c0, c1 in zip(cells, cells[1:]):
+            for c0, c1 in itertools.pairwise(cells):
                 self.assertTrue(c0.touches(c1), msg=f"{c0} !~ {c1} on {a}->{b}")
                 self.assertNotEqual(c0, c1)
 
@@ -519,7 +520,6 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
             phi = PI / 3
             lam_min = -PI
             lam_max = PI
-            end_points = [(lam_min, phi), (lam_max, phi)]
             get = rdggs.cells_from_parallel(1, phi, lam_min, lam_max)
             expect = [
                 rdggs.cell([N, 6]),
@@ -536,7 +536,6 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
             phi = PI / 3
             lam_min = -PI
             lam_max = -PI + 0.1
-            end_points = [(lam_min, phi), (lam_max, phi)]
             get = rdggs.cells_from_parallel(1, phi, lam_min, lam_max)
             expect = [rdggs.cell([N, 6])]
             self.assertEqual(get, expect)
@@ -544,7 +543,6 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
             phi = PI / 3
             lam_min = -PI
             lam_max = 0
-            end_points = [(lam_min, phi), (lam_max, phi)]
             get = rdggs.cells_from_parallel(1, phi, lam_min, lam_max)
             expect = [
                 rdggs.cell([N, 6]),

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -15,22 +15,21 @@ Keep adding tests!
 # *****************************************************************************
 
 # Import third-party modules.
-from numpy import array, pi
-
 # Import standard modules
 import unittest
 from random import randint  # , uniform
 
+from numpy import array, pi
+
 # Import my modules.
 # import rhealpixdggs.dggs as dggs
 from rhealpixdggs.cell import CELLS0
-from rhealpixdggs.dggs import RHEALPixDGGS, WGS84_003, WGS84_003_RADIANS
+from rhealpixdggs.dggs import WGS84_003, WGS84_003_RADIANS, RHEALPixDGGS
 from rhealpixdggs.ellipsoids import (
-    Ellipsoid,
     WGS84_ELLIPSOID,
     WGS84_ELLIPSOID_RADIANS,
+    Ellipsoid,
 )
-
 
 # Level 0 cell names
 N = CELLS0[0]

--- a/tests/test_pj_healpix.py
+++ b/tests/test_pj_healpix.py
@@ -14,11 +14,11 @@ Keep adding tests!
 # *****************************************************************************
 
 # Import third-party modules.
-from scipy.spatial.distance import euclidean, norm
-from numpy import atleast_1d, array, rad2deg, pi, sqrt, sin, arcsin
-
 # Import standard modules.
 import unittest
+
+from numpy import arcsin, array, atleast_1d, pi, rad2deg, sin, sqrt
+from scipy.spatial.distance import euclidean, norm
 
 # Import my modules.
 import rhealpixdggs.pj_healpix as pjh

--- a/tests/test_pj_healpix_c_reference.py
+++ b/tests/test_pj_healpix_c_reference.py
@@ -18,13 +18,13 @@ Keep adding tests!
 # *****************************************************************************
 
 # Import third-party modules.
-from numpy import array, atleast_1d, sin, arcsin, pi, sqrt, rad2deg, deg2rad
-from numpy.linalg import norm
-from pyproj import Proj
-
 # Import standard modules.
 import unittest
 from itertools import product
+
+from numpy import arcsin, array, atleast_1d, deg2rad, pi, rad2deg, sin, sqrt
+from numpy.linalg import norm
+from pyproj import Proj
 
 # Import my modules.
 from rhealpixdggs.utils import auth_lat, auth_rad
@@ -50,7 +50,7 @@ def geo_gap_deg(p, q):
     (180, phi) as the same point, and any two longitudes at a pole as
     the same point.
     """
-    from numpy import cos, sin, deg2rad, clip, arccos
+    from numpy import arccos, clip, cos, deg2rad, sin
 
     lam1, phi1 = deg2rad(array(p, dtype=float))
     lam2, phi2 = deg2rad(array(q, dtype=float))

--- a/tests/test_pj_rhealpix.py
+++ b/tests/test_pj_rhealpix.py
@@ -14,12 +14,12 @@ Keep adding tests!
 # *****************************************************************************
 
 # Import third-party modules.
-from scipy.spatial.distance import euclidean, norm
-from numpy import atleast_1d, array, pi, rad2deg, arcsin
-
 # Import standard modules.
 import unittest
 from itertools import product
+
+from numpy import arcsin, array, atleast_1d, pi, rad2deg
+from scipy.spatial.distance import euclidean, norm
 
 # Import my modules.
 import rhealpixdggs.pj_healpix as pjh

--- a/tests/test_projection_wrapper.py
+++ b/tests/test_projection_wrapper.py
@@ -7,13 +7,14 @@ Keep adding tests!
 # Import standard modules.
 import unittest
 
-# Import my modules.
-from rhealpixdggs.projection_wrapper import Projection
 from rhealpixdggs.ellipsoids import (
-    Ellipsoid,
     WGS84_ELLIPSOID,
     WGS84_ELLIPSOID_RADIANS,
+    Ellipsoid,
 )
+
+# Import my modules.
+from rhealpixdggs.projection_wrapper import Projection
 
 
 class MyTestCase(unittest.TestCase):

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -14,13 +14,14 @@ Keep adding tests!
 # Import standard modules
 import unittest
 
-# Import my modules and classes
-import rhealpixdggs.rhp_wrappers as rhpw
-import rhealpixdggs.dggs as gs
-
 # Import helper modules
 import numpy as np
 import shapely as sh
+
+import rhealpixdggs.dggs as gs
+
+# Import my modules and classes
+import rhealpixdggs.rhp_wrappers as rhpw
 
 
 class RhpWrappersTestCase(unittest.TestCase):
@@ -511,7 +512,7 @@ class RhpWrappersTestCase(unittest.TestCase):
         for center in ["N4", "N0", "Q4", "Q0"]:
             seen = set()
             total = 0
-            for k in range(0, 8):
+            for k in range(8):
                 ring = rhpw.cell_ring(center, k)
                 self.assertEqual(len(ring), len(set(ring)), f"{center} k={k}")
                 self.assertTrue(seen.isdisjoint(ring), f"{center} k={k}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,15 +14,16 @@ Keep adding tests!
 # *****************************************************************************
 
 # Import standard modules.
-from math import asin, pi, sin
 import unittest
+from math import asin, pi, sin
 
 # Import third-party modules.
 from scipy.integrate import quad
 
+import rhealpixdggs.utils as ut
+
 # Import my modules.
 from rhealpixdggs.ellipsoids import WGS84_E
-import rhealpixdggs.utils as ut
 
 
 def auth_lat_by_defining_integral(phi: float, e: float) -> float:


### PR DESCRIPTION
Follow-up to #82's deferred question: adopts ruff (locked 0.16.5, dev dependency `^0.16`) with its complete out-of-the-box rule set, and adds `ruff check` to the CI lint job alongside black.

All 125 findings resolved, in reviewable stages per commit:

1. **Safe autofixes** — import sorting, unused imports, deprecated aliases. Imports that exist only so doctests can use them via module globals (`pi`, `my_round`, `assert_allclose`) are kept with `noqa: F401` and a comment — removing them broke ~30 doctests, which is how they were found.
2. **Unsafe autofixes + hand fixes** — %-formats → f-strings, `dict()`/`set()` → literals, `zip` → `itertools.pairwise`, needless-bool/int-cast removals, a `ClassVar` annotation, a context manager in `Ellipsoid.get_points()`. Deliberate patterns are `noqa`-marked with justification: irreflexivity tests (`a < a`), same-iteration test closures, and local-date usage in the release script and docs config.

No behaviour changes intended: unit tests, doctests, and `black --check` all pass at every commit.

Noticed but deliberately untouched (pre-existing): `Ellipsoid.get_points()` reads the file in binary mode, so `line[0]` is an `int` and the string comparison on it always skips every line — the function appears to return `[]` for any input. Worth its own issue if the function is still wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)