### PR TITLE
Remove the plotting-era dead code

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,17 @@
+0.7.1
+^^^^^
+**Breaking change:** removed the plotting-era point generators, none of
+which has had a caller in any tree in this repository's history (issue
+#110): ``Ellipsoid.get_points`` (which has also returned ``[]`` for any
+input for the whole of the project's Python 3 life, due to a bytes-vs-str
+comparison), ``Ellipsoid.lattice``, ``Ellipsoid.graticule``,
+``Ellipsoid.meridian``, ``Ellipsoid.parallel``,
+``pj_healpix.healpix_vertices`` and ``pj_rhealpix.rhealpix_vertices``.
+They predate the DGGS layer; cell geometry (``Cell.ul_vertex``,
+``Cell.width``, ``Cell.boundary``, ``RHEALPixDGGS.cell_boundaries``) is
+the supported way to draw the grid and the projection image, as
+``docs/make_figures.py`` demonstrates.
+
 0.7.0
 ^^^^^
 Added ``RHEALPixDGGS.cell_boundaries(cells, n=2, plane=True)``: boundary

--- a/docs/source/pj_healpix.rst
+++ b/docs/source/pj_healpix.rst
@@ -10,7 +10,6 @@ The pj_healpix Module
     healpix_ellipsoid_inverse
     healpix_sphere
     healpix_sphere_inverse
-    healpix_vertices
     in_healpix_image
 
 .. automodule:: rhealpixdggs.pj_healpix

--- a/docs/source/pj_rhealpix.rst
+++ b/docs/source/pj_rhealpix.rst
@@ -12,7 +12,6 @@ The pj_rhealpix Module
     rhealpix_ellipsoid_inverse
     rhealpix_sphere
     rhealpix_sphere_inverse
-    rhealpix_vertices
     triangle
 
 .. automodule:: rhealpixdggs.pj_rhealpix

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -150,8 +150,6 @@ orient the DGGS so that the planar origin (0, 0) is on Auckland, New Zealand ::
 #  Distributed under the terms of the GNU Lesser General Public License (LGPL)
 #                  http: //www.gnu.org/licenses/
 # *****************************************************************************
-# Import third-party modules.
-# Import standard modules.
 from itertools import pairwise, product
 from math import asin, copysign, floor
 from random import randint
@@ -161,7 +159,6 @@ from numpy import array, base_repr, ceil, log, pi
 # assert_allclose is doctest-only: the doctests use it from the module globals.
 from numpy.testing import assert_allclose  # noqa: F401
 
-# Import my modules.
 import rhealpixdggs.pj_rhealpix as pjr
 import rhealpixdggs.projection_wrapper as pw
 from rhealpixdggs.cell import CELLS0, Cell

--- a/rhealpixdggs/ellipsoids.py
+++ b/rhealpixdggs/ellipsoids.py
@@ -19,14 +19,11 @@ Points lying on an ellipsoid are given in geodetic (longitude, latitude) coordin
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import third-party modules.
-# Import standard modules.
 from random import uniform
 
 import pyproj
 from numpy import arcsin, arctanh, cos, deg2rad, pi, rad2deg, sin, sqrt
 
-# Import my modules.
 from rhealpixdggs.utils import auth_lat, auth_rad, my_round
 
 # Parameters of some common ellipsoids.
@@ -204,101 +201,6 @@ class Ellipsoid:
             # Convert back to degrees.
             lam, phi = rad2deg([lam, phi])
         return lam, phi
-
-    def lattice(self, n=90):
-        """
-        Return a 2n x n square lattice of longitude-latitude points.
-
-        EXAMPLES::
-
-            >>> E = UNIT_SPHERE
-            >>> for p in E.lattice(n=3):
-            ...     print(p)
-            (-150.0, -60.0)
-            (-150.0, 0.0)
-            (-150.0, 60.0)
-            (-90.0, -60.0)
-            (-90.0, 0.0)
-            (-90.0, 60.0)
-            (-30.0, -60.0)
-            (-30.0, 0.0)
-            (-30.0, 60.0)
-            (30.0, -60.0)
-            (30.0, 0.0)
-            (30.0, 60.0)
-            (90.0, -60.0)
-            (90.0, 0.0)
-            (90.0, 60.0)
-            (150.0, -60.0)
-            (150.0, 0.0)
-            (150.0, 60.0)
-
-        """
-        PI = self.pi()
-        # Longitudinal and latitudinal spacing between points.
-        delta = PI / n
-        return [
-            (-PI + delta * (0.5 + i), -PI / 2 + delta * (0.5 + j))
-            for i in range(2 * n)
-            for j in range(n)
-        ]
-
-    def meridian(self, lam, n=200):
-        """
-        Return a list of `n` equispaced longitude-latitude
-        points lying along the meridian of longitude `lam`.
-        Avoid the poles.
-        """
-        PI = self.pi()
-        delta = PI / n
-        return [(lam, -PI / 2 + delta * (0.5 + i)) for i in range(n)]
-
-    def parallel(self, phi, n=200):
-        """
-        Return a list of `2*n` equispaced longitude-latitude
-        points lying along the parallel of latitude `phi`.
-        """
-        PI = self.pi()
-        delta = PI / n
-        return [(-PI + delta * (0.5 + i), phi) for i in range(2 * n)]
-
-    def graticule(self, n=400, spacing=None):
-        """
-        Return a list of longitude-latitude points sampled from a
-        longitude-latitude graticule on this ellipsoid with the given
-        spacing between meridians and between parallels.
-        The number of points on longitude and latitude per pi radians is `n`.
-        The spacing should be specified in the angle units used for this
-        ellipsoid.
-        If `spacing=None`, then a default spacing of pi/16 radians will be set.
-
-        EXAMPLES::
-
-            >>> E = UNIT_SPHERE
-            >>> print(len(E.graticule(n=400)))
-            25600
-
-        """
-        PI = self.pi()
-        result = []
-        # delta = PI/n
-        # Set default spacing.
-        if spacing is None:
-            spacing = PI / 16
-        # Longitude lines.
-        lam = -PI
-        while lam < PI:
-            # result.extend([(lam, -PI/2 + delta*(0.5 + i)) for i in range(n)])
-            result.extend(self.meridian(lam, n))
-            lam += spacing
-        # Latitude lines. Avoid the poles.
-        eps = PI / 360
-        phi = -PI / 2 + eps
-        while phi < PI / 2:
-            # result.extend([(-PI + delta*(0.5 + i), phi) for i in range(2*n)])
-            result.extend(self.parallel(phi, n))
-            phi += spacing
-        return result
 
     def xyz(self, lam, phi):
         """

--- a/rhealpixdggs/ellipsoids.py
+++ b/rhealpixdggs/ellipsoids.py
@@ -300,29 +300,6 @@ class Ellipsoid:
             phi += spacing
         return result
 
-    def get_points(self, filename):
-        """
-        Return a list of longitude-latitude points contained in
-        the file with filename `filename`.
-        Assume the file is a text file containing at most one
-        longitude-latitude point per line with the coordinates separated by
-        whitespace and angles given in degrees.
-        """
-        result = []
-        with open(filename, "rb") as file:
-            for line in file:
-                if line[0] not in ["-", "1", "2", "3", "4", "5", "6", "7", "8", "9"]:
-                    # Ignore line.
-                    continue
-                else:
-                    # Split coordinate pair on whitespace.
-                    p = [float(x) for x in line.split()]
-                    result.append(p)
-        if self.radians:
-            # Convert to radians.
-            result = [deg2rad(p) for p in result]
-        return result
-
     def xyz(self, lam, phi):
         """
         Given a point on this ellipsoid with longitude-latitude coordinates

--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -19,14 +19,12 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import third-party modules.
 from collections.abc import Callable
 
 import shapely
 from numpy import arcsin, array, deg2rad, floor, pi, rad2deg, sign, sin, sqrt
 from shapely.geometry import Polygon
 
-# Import my modules.
 # my_round is doctest-only: the doctests use it from the module globals.
 from rhealpixdggs.utils import auth_lat, auth_rad, my_round  # noqa: F401
 
@@ -234,33 +232,6 @@ def in_healpix_image(x: float, y: float) -> bool:
     # this (slightly larger) polygon, so they still test True -- verified
     # against every boundary case in this function's own doctest above.
     return bool(shapely.contains_xy(_healpix_image_poly, x, y))
-
-
-def healpix_vertices() -> list[tuple[float, float, float]]:
-    """
-    Return a list of the planar vertices of the HEALPix projection of
-    the unit sphere.
-    """
-    return [
-        (pi, pi / 4),
-        (3 * pi / 4, pi / 2),
-        (pi / 2, pi / 4),
-        (pi / 4, pi / 2),
-        (0, pi / 4),
-        (-pi / 4, pi / 2),
-        (-pi / 2, pi / 4),
-        (-3 * pi / 4, pi / 2),
-        (-pi, pi / 4),
-        (-pi, -pi / 4),
-        (-3 * pi / 4, -pi / 2),
-        (-pi / 2, -pi / 4),
-        (-pi / 4, -pi / 2),
-        (0, -pi / 4),
-        (pi / 4, -pi / 2),
-        (pi / 2, -pi / 4),
-        (3 * pi / 4, -pi / 2),
-        (pi, -pi / 4),
-    ]
 
 
 def healpix(

--- a/rhealpixdggs/pj_rhealpix.py
+++ b/rhealpixdggs/pj_rhealpix.py
@@ -17,14 +17,12 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import third-party modules.
 from collections.abc import Callable
 
 import shapely
 from numpy import array, deg2rad, dot, identity, pi, rad2deg, sign
 from shapely.geometry import Polygon
 
-# Import my modules.
 from rhealpixdggs.pj_healpix import (
     healpix_ellipsoid,
     healpix_ellipsoid_inverse,
@@ -491,44 +489,6 @@ def in_rhealpix_image(
     # this (slightly larger) polygon, so they still test True -- verified
     # against every boundary case in this function's own doctest above.
     return bool(shapely.contains_xy(poly, x, y))
-
-
-def rhealpix_vertices(
-    north_square: int = 0, south_square: int = 0
-) -> list[tuple[float, float]]:
-    """
-    Return a list of the planar vertices of the rHEALPix projection of
-    the unit sphere.
-    """
-    vertices = [
-        (pi, pi / 4),
-        (-pi + (north_square + 1) * pi / 2, pi / 4),
-        (-pi + (north_square + 1) * pi / 2, 3 * pi / 4),
-        (-pi + north_square * pi / 2, 3 * pi / 4),
-        (-pi + north_square * pi / 2, pi / 4),
-        (-pi, pi / 4),
-        (-pi, -pi / 4),
-        (-pi + south_square * pi / 2, -pi / 4),
-        (-pi + south_square * pi / 2, -3 * pi / 4),
-        (-pi + (south_square + 1) * pi / 2, -3 * pi / 4),
-        (-pi + (south_square + 1) * pi / 2, -pi / 4),
-        (pi, -pi / 4),
-    ]
-    # Delete unnecessary non-vertices.
-    if north_square == 3:
-        vertices.remove((pi, pi / 4))
-        vertices.remove((pi, pi / 4))
-    elif north_square == 0:
-        vertices.remove((-pi, pi / 4))
-        vertices.remove((-pi, pi / 4))
-    if south_square == 3:
-        vertices.remove((pi, -pi / 4))
-        vertices.remove((pi, -pi / 4))
-    elif south_square == 0:
-        vertices.remove((-pi, -pi / 4))
-        vertices.remove((-pi, -pi / 4))
-
-    return vertices
 
 
 def rhealpix(

--- a/rhealpixdggs/projection_wrapper.py
+++ b/rhealpixdggs/projection_wrapper.py
@@ -17,15 +17,12 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import third-party modules.
-# Import standard modules.
 import importlib
 
 import pyproj
 
 from rhealpixdggs.ellipsoids import WGS84_ELLIPSOID
 
-# Import my modules.
 # my_round is doctest-only: the doctests use it from the module globals.
 from rhealpixdggs.utils import my_round, wrap_latitude, wrap_longitude  # noqa: F401
 

--- a/rhealpixdggs/utils.py
+++ b/rhealpixdggs/utils.py
@@ -16,7 +16,6 @@ unless indicated otherwise.
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import standard modules.
 from math import asin, copysign, log, pi, sin, sqrt
 from typing import Any
 

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1,12 +1,9 @@
-# Import third-party modules.
-# Import standard modules
 import unittest
 from itertools import product
 from math import pi
 
 from scipy.spatial.distance import euclidean, norm
 
-# Import my modules.
 from rhealpixdggs.cell import CELLS0, Cell
 from rhealpixdggs.dggs import WGS84_003, WGS84_003_RADIANS, RHEALPixDGGS
 from rhealpixdggs.ellipsoids import (

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -6,12 +6,10 @@ Keep adding tests!
 - David Habgood (DH), 2020-10-27: Initial version.
 """
 
-# Import standard modules.
 import unittest
 
 from shapely import wkt
 
-# Import my modules.
 from rhealpixdggs.conversion import *
 
 test_geom = """

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -14,15 +14,12 @@ Keep adding tests!
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import third-party modules.
-# Import standard modules
 import itertools
 import unittest
 from random import randint  # , uniform
 
 from numpy import array, pi
 
-# Import my modules.
 # import rhealpixdggs.dggs as dggs
 from rhealpixdggs.cell import CELLS0
 from rhealpixdggs.dggs import WGS84_003, WGS84_003_RADIANS, RHEALPixDGGS

--- a/tests/test_ellipsoids.py
+++ b/tests/test_ellipsoids.py
@@ -13,10 +13,8 @@ Keep adding tests!
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import standard modules.
 import unittest
 
-# Import my modules.
 import rhealpixdggs.ellipsoids as ell
 
 

--- a/tests/test_pj_healpix.py
+++ b/tests/test_pj_healpix.py
@@ -13,14 +13,11 @@ Keep adding tests!
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import third-party modules.
-# Import standard modules.
 import unittest
 
 from numpy import arcsin, array, atleast_1d, pi, rad2deg, sin, sqrt
 from scipy.spatial.distance import euclidean, norm
 
-# Import my modules.
 import rhealpixdggs.pj_healpix as pjh
 from rhealpixdggs.utils import auth_lat, auth_rad
 

--- a/tests/test_pj_healpix_c_reference.py
+++ b/tests/test_pj_healpix_c_reference.py
@@ -17,8 +17,6 @@ Keep adding tests!
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import third-party modules.
-# Import standard modules.
 import unittest
 from itertools import product
 
@@ -26,7 +24,6 @@ from numpy import arcsin, array, atleast_1d, deg2rad, pi, rad2deg, sin, sqrt
 from numpy.linalg import norm
 from pyproj import Proj
 
-# Import my modules.
 from rhealpixdggs.utils import auth_lat, auth_rad
 
 

--- a/tests/test_pj_rhealpix.py
+++ b/tests/test_pj_rhealpix.py
@@ -13,15 +13,12 @@ Keep adding tests!
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import third-party modules.
-# Import standard modules.
 import unittest
 from itertools import product
 
 from numpy import arcsin, array, atleast_1d, pi, rad2deg
 from scipy.spatial.distance import euclidean, norm
 
-# Import my modules.
 import rhealpixdggs.pj_healpix as pjh
 import rhealpixdggs.pj_rhealpix as pjr
 from rhealpixdggs.utils import auth_lat, auth_rad

--- a/tests/test_projection_wrapper.py
+++ b/tests/test_projection_wrapper.py
@@ -4,7 +4,6 @@ Beware, these tests cover only some functions and only some scenarios.
 Keep adding tests!
 """
 
-# Import standard modules.
 import unittest
 
 from rhealpixdggs.ellipsoids import (
@@ -12,8 +11,6 @@ from rhealpixdggs.ellipsoids import (
     WGS84_ELLIPSOID_RADIANS,
     Ellipsoid,
 )
-
-# Import my modules.
 from rhealpixdggs.projection_wrapper import Projection
 
 

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -11,16 +11,12 @@ Keep adding tests!
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import standard modules
 import unittest
 
-# Import helper modules
 import numpy as np
 import shapely as sh
 
 import rhealpixdggs.dggs as gs
-
-# Import my modules and classes
 import rhealpixdggs.rhp_wrappers as rhpw
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,16 +13,12 @@ Keep adding tests!
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-# Import standard modules.
 import unittest
 from math import asin, pi, sin
 
-# Import third-party modules.
 from scipy.integrate import quad
 
 import rhealpixdggs.utils as ut
-
-# Import my modules.
 from rhealpixdggs.ellipsoids import WGS84_E
 
 


### PR DESCRIPTION
Closes #110. Removes seven functions, none of which has ever had a caller in any tree in this repository's history (verified back through the 0.4 and 0.5 source drops):

- `Ellipsoid.get_points()` — also **broken** for the project's entire Python 3 life: binary-mode read makes `line[0]` an `int`, so the digit filter skips every line and it always returns `[]`.
- `Ellipsoid.lattice()`, `Ellipsoid.graticule()`, `Ellipsoid.meridian()`, `Ellipsoid.parallel()` — point generators for the Sage-era scatter-plotting workflow. `graticule()` returns all gridlines concatenated into one flat point list, unusable for line plotting even in principle.
- `pj_healpix.healpix_vertices()`, `pj_rhealpix.rhealpix_vertices()` — projection-outline corners; the neglect shows (`healpix_vertices` declares 3-tuples but returns 2-tuples; `rhealpix_vertices`' non-vertex cleanup only handles squares 0 and 3).

All predate the DGGS layer. Cell geometry (`Cell.ul_vertex`/`width`/`boundary`, `RHEALPixDGGS.cell_boundaries`) is how everything is drawn now — `docs/make_figures.py` draws all sixteen figures from it and uses none of the removed functions.

Since `graticule`/`meridian`/`parallel`/`lattice` were documented `Ellipsoid` API, CHANGES.rst gains a 0.7.1 section with a breaking-change callout.

Also removes the `# Import my/standard/third-party modules` section comments repo-wide — import sorting had already scrambled them out of sense.

Verified: no stale references in code, tests, or docs sources; unit tests, doctests, ruff, black, and a warnings-as-errors docs build all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)