### PR TITLE
Make rhealpix_sphere honour the region hint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,9 @@ planar grid instead of collecting a spurious ``None`` entry,
 ``cells_from_region`` returns ``[]`` when any corner of a planar region
 falls outside the grid instead of raising ``AttributeError``, and
 ``cell_from_region`` likewise returns ``None`` instead of raising when a
-corner is off-grid.
+corner is off-grid. ``pj_rhealpix.rhealpix_sphere`` now honours the
+``region="equatorial"`` hint like its three siblings instead of silently
+ignoring it.
 **Breaking change:** removed the plotting-era point generators, none of
 which has had a caller in any tree in this repository's history (issue
 #110): ``Ellipsoid.get_points`` (which has also returned ``[]`` for any

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ falls outside the grid instead of raising ``AttributeError``, and
 corner is off-grid. ``pj_rhealpix.rhealpix_sphere`` now honours the
 ``region="equatorial"`` hint like its three siblings instead of silently
 ignoring it.
+
 **Breaking change:** removed the plotting-era point generators, none of
 which has had a caller in any tree in this repository's history (issue
 #110): ``Ellipsoid.get_points`` (which has also returned ``[]`` for any

--- a/rhealpixdggs/pj_rhealpix.py
+++ b/rhealpixdggs/pj_rhealpix.py
@@ -304,7 +304,11 @@ def rhealpix_sphere(
         *---*---*---*---*
     """
     x, y = healpix_sphere(lam, phi)
-    return combine_triangles(x, y, north_square=north_square, south_square=south_square)
+    if region != "equatorial":
+        x, y = combine_triangles(
+            x, y, north_square=north_square, south_square=south_square
+        )
+    return x, y
 
 
 def rhealpix_sphere_inverse(

--- a/tests/test_pj_rhealpix.py
+++ b/tests/test_pj_rhealpix.py
@@ -260,6 +260,23 @@ class MyTestCase(unittest.TestCase):
                 pp = pjr.rhealpix_sphere_inverse(*q, north_square=ns, south_square=ss)
                 self.assertTrue(euclidean(p, pp) < error)
 
+    def test_rhealpix_sphere_region_hint(self):
+        # region='equatorial' promises to skip the polar-triangle
+        # rearrangement, matching rhealpix_ellipsoid()'s handling of the
+        # same hint; rhealpix_sphere() used to accept and ignore it.
+        p = (0, pi / 3)  # a genuinely polar point
+        for ns, ss in product(list(range(4)), repeat=2):
+            hinted = pjr.rhealpix_sphere(
+                *p, north_square=ns, south_square=ss, region="equatorial"
+            )
+            self.assertEqual(hinted, pjh.healpix_sphere(*p))
+            self.assertEqual(
+                hinted,
+                pjr.rhealpix_ellipsoid(
+                    *p, north_square=ns, south_square=ss, region="equatorial"
+                ),
+            )
+
     def test_rhealpix_ellipsoid(self):
         # Test map projection.
         # Should return the same output as healpix_ellipsoid(), followed


### PR DESCRIPTION
`rhealpix_sphere` accepted the `region` parameter (the issue-#6 hint that protects boundary points from floating-point region misclassification) but silently ignored it — the only one of the four `rhealpix_*` functions to do so. It now applies the same `if region != "equatorial"` guard as its siblings, so the hint forces identity in the equatorial band as documented by the family's behaviour.

No production caller is affected (the `Projection` factory routes through the ellipsoid functions), but the exported function now keeps the contract it advertises. The regression test asserts parity with both `healpix_sphere` and `rhealpix_ellipsoid(region="equatorial")` across all square positions, and fails against the old behaviour (verified).

Note: this branch and #114 both add a sentence to the same CHANGES.rst 0.7.1 paragraph — whichever merges second may need a trivial conflict resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)