### PR TITLE
Compute quad cell boundaries directly and exploit equatorial separability in cell_boundaries (issue #91)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+0.8.0
+^^^^^
+``Cell.boundary(plane=False)`` on quad cells now projects only the four
+corners and the interior points of the west and north edges (``2*n``
+inverse projections instead of ``4*n - 4``) and derives the remaining
+points from the equatorial projection's separability: the east edge
+shares the west edge's latitudes and the south edge shares the north
+edge's longitudes. Every coordinate is still one the projection
+computed, and adjacent quad cells still share bit-identical points
+(issue #91).
+
 0.7.1
 ^^^^^
 Adopted mypy (issue #109, first three stages): every function in the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ shares the west edge's latitudes and the south edge shares the north
 edge's longitudes. Every coordinate is still one the projection
 computed, and adjacent quad cells still share bit-identical points
 (issue #91).
+``RHEALPixDGGS.cell_boundaries`` exploits the same separability for
+every equatorial cell, so the projections needed for a block of
+equatorial cells grow with its perimeter rather than its area (a 9 × 9
+block at ``n=4`` takes 55 instead of 460). Every coordinate is still one
+the projection computed, and all points in a lattice column or row share
+one longitude or latitude value across the whole block, not only where
+cells touch.
 
 0.7.1
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,9 @@ the projection computed, and all points in a lattice column or row share
 one longitude or latitude value across the whole block, not only where
 cells touch. ``Cell.boundary(n=2, plane=False, interior=True)`` on quad
 and cap cells now honours ``interior``; since 0.6.0 those two shapes had
-returned the plain vertices for that call.
+returned the plain vertices for that call. Planar boundary points are
+built with float arithmetic instead of a two-element numpy array per
+point, and are returned as Python floats; the values are unchanged.
 
 0.7.1
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ equatorial cells grow with its perimeter rather than its area (a 9 × 9
 block at ``n=4`` takes 55 instead of 460). Every coordinate is still one
 the projection computed, and all points in a lattice column or row share
 one longitude or latitude value across the whole block, not only where
-cells touch.
+cells touch. ``Cell.boundary(n=2, plane=False, interior=True)`` on quad
+and cap cells now honours ``interior``; since 0.6.0 those two shapes had
+returned the plain vertices for that call.
 
 0.7.1
 ^^^^^

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from rhealpixdggs.dggs import RHEALPixDGGS
 
 # pi is doctest-only: the doctests use it from the module globals.
-from numpy import array, base_repr, pi  # noqa: F401
+from numpy import base_repr, pi  # noqa: F401
 from numpy import vectorize as numpy_vectorize
 from scipy import integrate
 
@@ -839,7 +839,7 @@ class Cell:
             >>> c.boundary(n=2, plane=True) == c.vertices(plane=True)
             True
             >>> for p in c.boundary(n=3, plane=True):
-            ...     print(tuple(x.tolist() for x in my_round(p, 14)))
+            ...     print(my_round(p, 14))
             (-3.14159265358979, 1.30899693899575)
             (-2.87979326579064, 1.30899693899575)
             (-2.61799387799149, 1.30899693899575)
@@ -882,13 +882,12 @@ class Cell:
         if not plane and self.ellipsoidal_shape == "quad":
             return self._quad_boundary(n, eps)
         delta = (w - 2 * eps) / (n - 1)
-        point = (ul[0] + eps, ul[1] - eps)
-        result = [point]
-        for direction in [(1, 0), (0, -1), (-1, 0), (0, 1)]:
+        x, y = float(ul[0]) + eps, float(ul[1]) - eps
+        result = [(x, y)]
+        for dx, dy in [(1, 0), (0, -1), (-1, 0), (0, 1)]:
             for j in range(1, n):
-                temp = array(point) + j * delta * array(direction)
-                result.append(tuple(temp))
-            point = result[-1]
+                result.append((x + j * delta * dx, y + j * delta * dy))
+            x, y = result[-1]
         # Remove the last point because it's the first point.
         result.pop()
         if not plane:

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -812,17 +812,23 @@ class Cell:
         interior of the cell, which is convenient for some graphics methods.
 
         When `plane` = False, the cost scales with `n` because each point
-        requires an inverse projection call. For quad and cap cells, `n` = 2
-        is short-circuited straight to ``vertices(plane=False)`` (skipping the
-        projection calls entirely), since that's what the general algorithm
-        below would compute anyway. For `n` > 2 on quad/cap cells the general,
-        per-point-projected algorithm still runs -- unlike dart/skew_quad
-        cells, quad/cap edges are known to be lines of constant longitude or
-        latitude on the ellipsoid, so in principle the extra points could be
-        computed directly without projecting each one, but doing that
-        correctly for cap cells requires careful antimeridian-wrapping
-        arithmetic (a cap cell's boundary is a single constant-latitude ring
-        split into 4 arcs by longitude) that hasn't been implemented yet.
+        requires an inverse projection call, except on quad cells. A quad
+        cell lies entirely in the equatorial region, where the inverse
+        projection is separable: longitude depends only on `x` and latitude
+        only on `y`. Its east and west edges are meridians sharing the same
+        `n - 2` interior latitudes, and its north and south edges are
+        parallels sharing the same `n - 2` interior longitudes. Only the four
+        corners and the interior points of the west and north edges are
+        projected (`2*n` calls instead of `4*n - 4`); the east and south
+        edges reuse those values. Every coordinate returned is one the
+        projection computed, and adjacent quad cells get bit-identical
+        shared points.
+
+        For quad and cap cells with `n` = 2 the result is
+        ``vertices(plane=False)``. Cap cells with `n` > 2 take the general
+        per-point path: a cap's boundary is a single parallel and could be
+        computed directly too, but there are only two cap cells per
+        resolution, so it isn't worth a third code path.
 
         EXAMPLES::
 
@@ -859,8 +865,7 @@ class Cell:
         # Quad and cap cells have straight or rotationally-symmetric edges on
         # the ellipsoid, so at n=2 extra boundary points would add no accuracy.
         # Fall back to vertices() and avoid the per-point projection cost
-        # entirely. For n>2 this cell falls through to the general algorithm
-        # below, same as any other shape (see the n>2 note in the docstring).
+        # entirely.
         if not plane and n == 2 and self.ellipsoidal_shape in ("quad", "cap"):
             return self.vertices(plane=False)
         ul = self.ul_vertex(plane=True)
@@ -869,6 +874,8 @@ class Cell:
             eps = w / 10000  # A smidgen.
         else:
             eps = 0
+        if not plane and self.ellipsoidal_shape == "quad":
+            return self._quad_boundary(n, eps)
         delta = (w - 2 * eps) / (n - 1)
         point = (ul[0] + eps, ul[1] - eps)
         result = [point]
@@ -894,6 +901,39 @@ class Cell:
                 self.rdggs.rhealpix(*p, inverse=True, region=region) for p in result
             ]
         return result
+
+    def _quad_boundary(self, n: int, eps: float) -> list[tuple[float, float]]:
+        """
+        Return ``boundary(n, plane=False)`` for this quad cell, its planar
+        square shrunk inward by `eps`, projecting only the four corners and
+        the interior points of the west and north edges. See ``boundary()``.
+        """
+        ul = self.ul_vertex(plane=True)
+        w = self.width(plane=True)
+        x_west, y_north = ul[0] + eps, ul[1] - eps
+        x_east, y_south = ul[0] + w - eps, ul[1] - w + eps
+        delta = (w - 2 * eps) / (n - 1)
+        region = self.region()
+
+        def project(x: float, y: float) -> tuple[float, float]:
+            return self.rdggs.rhealpix(x, y, inverse=True, region=region)
+
+        nw = project(x_west, y_north)
+        ne = project(x_east, y_north)
+        se = project(x_east, y_south)
+        sw = project(x_west, y_south)
+        lats = [project(x_west, y_north - j * delta)[1] for j in range(1, n - 1)]
+        lons = [project(x_west + j * delta, y_north)[0] for j in range(1, n - 1)]
+        return (
+            [nw]
+            + [(lon, nw[1]) for lon in lons]
+            + [ne]
+            + [(ne[0], lat) for lat in lats]
+            + [se]
+            + [(lon, se[1]) for lon in reversed(lons)]
+            + [sw]
+            + [(sw[0], lat) for lat in reversed(lats)]
+        )
 
     def interior(
         self, n: int = 2, plane: bool = True, flatten: bool = False

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -824,8 +824,8 @@ class Cell:
         projection computed, and adjacent quad cells get bit-identical
         shared points.
 
-        For quad and cap cells with `n` = 2 the result is
-        ``vertices(plane=False)``. Cap cells with `n` > 2 take the general
+        For quad and cap cells with `n` = 2 and `interior` = False the result
+        is ``vertices(plane=False)``. Cap cells with `n` > 2 take the general
         per-point path: a cap's boundary is a single parallel and could be
         computed directly too, but there are only two cap cells per
         resolution, so it isn't worth a third code path.
@@ -866,7 +866,12 @@ class Cell:
         # the ellipsoid, so at n=2 extra boundary points would add no accuracy.
         # Fall back to vertices() and avoid the per-point projection cost
         # entirely.
-        if not plane and n == 2 and self.ellipsoidal_shape in ("quad", "cap"):
+        if (
+            not plane
+            and n == 2
+            and not interior
+            and self.ellipsoidal_shape in ("quad", "cap")
+        ):
             return self.vertices(plane=False)
         ul = self.ul_vertex(plane=True)
         w = self.width(plane=True)

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -1457,6 +1457,16 @@ class RHEALPixDGGS:
         edges along those parallels are computed per region, exactly as
         ``boundary()`` computes them.
 
+        In the equatorial region the inverse projection is separable
+        (longitude depends only on `x`, latitude only on `y`), so there
+        each projected point also yields the longitude of every other
+        point in its column and the latitude of every other point in its
+        row. The number of projections for a block of equatorial cells
+        thus grows with the block's perimeter rather than its area, every
+        coordinate is still one the projection computed rather than an
+        interpolation, and all points in one lattice column (or row)
+        share one longitude (or latitude) value across the whole block.
+
         `cells` may mix resolutions; sharing happens per resolution.
         For `plane` = True there is no projection work to share and this
         is simply a convenience over calling ``boundary()`` per cell.
@@ -1476,7 +1486,9 @@ class RHEALPixDGGS:
         R = self.ellipsoid.R_A
         x_anchor = -pi * R
         y_anchor = -3 * pi * R / 4
-        cache = {}
+        cache: dict[tuple[int | None, str, int, int], tuple[float, float]] = {}
+        lons: dict[tuple[int | None, int], float] = {}
+        lats: dict[tuple[int | None, int], float] = {}
         result = {}
         for cell in cells:
             # The same planar points, in the same order, as
@@ -1495,12 +1507,20 @@ class RHEALPixDGGS:
             pitch = cell.width(plane=True) / (n - 1)
             points = []
             for p in planar:
-                key = (
-                    cell.resolution,
-                    region,
-                    round((p[0] - x_anchor) / pitch),
-                    round((p[1] - y_anchor) / pitch),
-                )
+                col = round((p[0] - x_anchor) / pitch)
+                row = round((p[1] - y_anchor) / pitch)
+                if region == "equatorial":
+                    lon_key = (cell.resolution, col)
+                    lat_key = (cell.resolution, row)
+                    if lon_key not in lons or lat_key not in lats:
+                        lon, lat = self.rhealpix(
+                            p[0], p[1], inverse=True, region=region
+                        )
+                        lons.setdefault(lon_key, lon)
+                        lats.setdefault(lat_key, lat)
+                    points.append((lons[lon_key], lats[lat_key]))
+                    continue
+                key = (cell.resolution, region, col, row)
                 if key not in cache:
                     cache[key] = self.rhealpix(p[0], p[1], inverse=True, region=region)
                 points.append(cache[key])

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1,5 +1,5 @@
 import unittest
-from itertools import product
+from itertools import pairwise, product
 from math import pi
 
 from scipy.spatial.distance import euclidean, norm
@@ -449,13 +449,111 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             # n=2 (the short-circuited case) must still agree with vertices().
             self.assertEqual(c.boundary(n=2, plane=False), c.vertices(plane=False))
 
+    def test_boundary_quad_direct(self):
+        # Quad cells compute boundary(plane=False, n > 2) from the corners
+        # and the west and north edges alone (issue #91). Reference: project
+        # every planar boundary point, as the general algorithm does.
+        from numpy import allclose
+
+        shifted = RHEALPixDGGS(
+            ellipsoid=Ellipsoid(
+                a=6378137.0,
+                b=6356752.314140356,
+                e=0.0578063088401,
+                f=0.003352810681182,
+                lon_0=-131.25,
+            )
+        )
+        for rdggs in (WGS84_003, WGS84_003_RADIANS, WGS84_123, shifted):
+            for suid in [(P, 1), (O, 0, 8), (R, 5), (Q,), (P, 4, 4, 4)]:
+                c = rdggs.cell(suid)
+                self.assertEqual(c.ellipsoidal_shape, "quad")
+                for n in (3, 4, 10):
+                    for interior in (False, True):
+                        got = c.boundary(n=n, plane=False, interior=interior)
+                        planar = c.boundary(n=n, plane=True, interior=interior)
+                        v = c.vertices(plane=True)
+                        i = (n - 1) * v.index(c.nw_vertex(plane=True))
+                        planar = planar[i:] + planar[:i]
+                        expect = [
+                            rdggs.rhealpix(*p, inverse=True, region=c.region())
+                            for p in planar
+                        ]
+                        self.assertEqual(len(got), 4 * n - 4)
+                        for g, e in zip(got, expect):
+                            self.assertTrue(
+                                allclose(g, e, rtol=0, atol=1e-12),
+                                msg=f"{c} n={n} interior={interior}: {g} != {e}",
+                            )
+
+        # With a shifted lon_0 a quad edge can straddle the antimeridian.
+        c = shifted.cell((P, 1))
+        corner_lons = [p[0] for p in c.vertices(plane=False)]
+        self.assertGreater(max(corner_lons) - min(corner_lons), 180)
+        n = 6
+        north_edge = c.boundary(n=n, plane=False)[:n]
+        steps = [(b[0] - a[0]) % 360 for a, b in pairwise(north_edge)]
+        self.assertTrue(all(0 < step < 90 for step in steps), steps)
+        self.assertTrue(all(-180 <= p[0] < 180 for p in north_edge))
+
+        # Only the corners and the west and north edges are projected, and
+        # every returned coordinate is one of the projection's outputs.
+        outputs = []
+        rdggs = WGS84_003
+        inner = rdggs.rhealpix
+
+        def recording(*a, **k):
+            outputs.append(inner(*a, **k))
+            return outputs[-1]
+
+        rdggs.rhealpix = recording
+        try:
+            b = rdggs.cell((P, 4)).boundary(n=10, plane=False)
+        finally:
+            del rdggs.__dict__["rhealpix"]
+        self.assertEqual(len(outputs), 2 * 10)
+        lons = {p[0] for p in outputs}
+        lats = {p[1] for p in outputs}
+        self.assertTrue(all(p[0] in lons and p[1] in lats for p in b))
+
+    def test_boundary_quad_neighbors_share_points(self):
+        # Adjacent quad cells' copies of their shared edge points are
+        # identical floats, across a face boundary and vertically too. A
+        # quad and its differently-shaped polar neighbour agree to
+        # floating point.
+        rdggs = WGS84_003
+        n = 6
+        for a, b in [
+            ((P, 4), (P, 5)),
+            ((P, 5), (Q, 3)),
+            ((R, 2), (O, 0)),
+            ((P, 1), (P, 4)),
+            ((P, 3, 8), (P, 4, 6)),
+        ]:
+            ca, cb = rdggs.cell(a), rdggs.cell(b)
+            self.assertIn(cb, ca.neighbors(plane=True).values())
+            shared = set(map(tuple, ca.boundary(n=n, plane=False))) & set(
+                map(tuple, cb.boundary(n=n, plane=False))
+            )
+            self.assertEqual(len(shared), n, (a, b))
+        quad, skew = rdggs.cell((P, 1)), rdggs.cell((N, 5))
+        self.assertEqual(skew.ellipsoidal_shape, "skew_quad")
+        bq = quad.boundary(n=n, plane=False)
+        bs = skew.boundary(n=n, plane=False)
+        close = [
+            p
+            for p in bq
+            if any(abs(p[0] - q[0]) < 1e-9 and abs(p[1] - q[1]) < 1e-9 for q in bs)
+        ]
+        self.assertEqual(len(close), n)
+
     def test_nucleus(self):
         for rdggs in [WGS84_123, WGS84_123_RADIANS]:
             # Nuclei of children should be in correct position
             # relative to parent cell in rHEALPix projection.
             a = Cell(rdggs, (S, 7, 4, 1, 2, 1))  # Arbitrary cell.
             w = a.width()
-            (x, y) = a.ul_vertex()
+            x, y = a.ul_vertex()
             error = 1e-10
             for row, col in product(list(range(3)), repeat=2):
                 # Child cell in (row, column) position relative to a:

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -439,6 +439,8 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         # Regression test for the boundary(plane=False) short-circuit that
         # silently returned only 4 points for quad/cap cells regardless of
         # n, instead of the documented 4*n - 4. See issue #49.
+        from numpy import allclose
+
         rdggs = RHEALPixDGGS()
         quad = Cell(rdggs, [P, 2])
         cap = Cell(rdggs, [N])
@@ -448,6 +450,17 @@ class SCENZGridCELLTestCase(unittest.TestCase):
                 self.assertEqual(len(b), max(4 * n - 4, 4))
             # n=2 (the short-circuited case) must still agree with vertices().
             self.assertEqual(c.boundary(n=2, plane=False), c.vertices(plane=False))
+            # ... unless the points are pushed into the interior.
+            pushed = c.boundary(n=2, plane=False, interior=True)
+            self.assertEqual(len(pushed), 4)
+            planar = c.boundary(n=2, plane=True, interior=True)
+            v = c.vertices(plane=True)
+            i = v.index(c.nw_vertex(plane=True))
+            planar = planar[i:] + planar[:i]
+            for got, p in zip(pushed, planar):
+                want = rdggs.rhealpix(*p, inverse=True, region=c.region())
+                self.assertTrue(allclose(got, want, rtol=0, atol=1e-12), (got, want))
+            self.assertNotEqual(pushed, c.vertices(plane=False))
 
     def test_boundary_quad_direct(self):
         # Quad cells compute boundary(plane=False, n > 2) from the corners

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -362,19 +362,39 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
                 self.count += 1
                 return self.inner(*args, **kwargs)
 
-        block = [rdggs.cell((P, i, j)) for i in range(9) for j in range(9)]
-        counter = CountingProjection(rdggs.rhealpix)
-        rdggs.rhealpix = counter
-        try:
-            for c in block:
-                c.boundary(n=4, plane=False)
-            per_cell_calls = counter.count
-            counter.count = 0
-            rdggs.cell_boundaries(block, n=4, plane=False)
-            batched_calls = counter.count
-        finally:
-            del rdggs.__dict__["rhealpix"]
-        self.assertLess(batched_calls, 0.6 * per_cell_calls)
+        for face, ratio in ((N, 0.6), (P, 0.15)):
+            block = [rdggs.cell((face, i, j)) for i in range(9) for j in range(9)]
+            counter = CountingProjection(rdggs.rhealpix)
+            rdggs.rhealpix = counter
+            try:
+                for c in block:
+                    c.boundary(n=4, plane=False)
+                per_cell_calls = counter.count
+                counter.count = 0
+                boundaries = rdggs.cell_boundaries(block, n=4, plane=False)
+                batched_calls = counter.count
+            finally:
+                del rdggs.__dict__["rhealpix"]
+            self.assertLess(batched_calls, ratio * per_cell_calls, face)
+
+        # In the equatorial region the batch exploits the projection's
+        # separability: every point in one lattice column gets one
+        # identical longitude and every point in one row one identical
+        # latitude, for the whole block, not just where cells touch.
+        R = rdggs.ellipsoid.R_A
+        pitch = block[0].width(plane=True) / 3
+        by_col = {}
+        by_row = {}
+        for c in block:
+            for got, p in zip(boundaries[c], c.boundary(n=4, plane=True)):
+                col = round((p[0] + pi * R) / pitch)
+                row = round((p[1] + 3 * pi * R / 4) / pitch)
+                by_col.setdefault(col, set()).add(got[0])
+                by_row.setdefault(row, set()).add(got[1])
+        self.assertEqual(len(by_col), 28)
+        self.assertEqual(len(by_row), 28)
+        self.assertTrue(all(len(v) == 1 for v in by_col.values()))
+        self.assertTrue(all(len(v) == 1 for v in by_row.values()))
 
         # Planar mode is a plain convenience passthrough.
         cells = list(rdggs.cell((P, 0)).subcells())


### PR DESCRIPTION
Closes #91 (quad half; cap cells deliberately stay on the general path, see below).

A quad cell lies entirely in the equatorial region, where the inverse rHEALPix projection is separable: longitude depends only on `x`, latitude only on `y`. Four commits use that:

1. **`Cell.boundary(plane=False)` on quad cells** projects the four corners and the interior points of the west and north edges (`2n` calls instead of `4n - 4`); the east edge reuses the west edge's latitudes and the south edge the north edge's longitudes. Every coordinate returned is one the projection computed (a test records the projection's outputs during a call and checks each returned value is among them), and adjacent quad cells share bit-identical points across face boundaries and vertically.
2. **`RHEALPixDGGS.cell_boundaries`** caches longitude per lattice column and latitude per lattice row for equatorial cells, so the projections for a block of quads grow with its perimeter rather than its area (81 cells at `n=4`: 55 calls instead of 460). Without this, commit 1 had made the batch API *slower* than per-cell `boundary()` for quads — its own call-count test caught that. Polar cells keep the per-point cache.
3. **`boundary(n=2, plane=False, interior=True)`** on quad and cap cells now honours `interior`; since 0.6.0 the `n=2` short-circuit ran before `interior` was consulted.
4. **Planar boundary points** are built with float arithmetic instead of a two-element numpy array per point. Bit-identical values (checked over 52,224 points), returned as Python `float` instead of `np.float64` — the one type-visible change, noted in the changelog.

Cap cells could take the same treatment (their boundary is one parallel), but there are two per resolution, so the docstring documents the decision rather than adding a third code path.

### Benchmark (WGS84_003, `n=10`, `plane=False`, best of 3, same script on both trees)

| Workload | master | branch |
|---|---|---|
| quad `boundary` | 1264 µs | 547 µs |
| dart `boundary` | 2085 µs | 1659 µs |
| res 2, 486 cells, per-cell `boundary` | 707 ms | 409 ms |
| res 2, 486 cells, `cell_boundaries` | 462 ms | 162 ms |
| res 3, 4374 cells, `cell_boundaries` | 3.63 s | 1.33 s |

Remaining cost is polar cells, and within them the two in-image checks per projection (#116).

### Precision

Against projecting every planar point with the general algorithm, north and east edges are bit-identical; south-edge longitudes and west-edge latitudes differ by at most 5.7e-14° (≈2 ulp). That residual is planar rounding — the general algorithm walks its lattice clockwise and reaches those edges from the opposite corner — not interpolation. Quad–polar shared points agree to 1e-9 as before (they already differed by an ulp on master because of the region hint).

Note: the first commit alone fails `test_cell_boundaries` (the call-count assertion described in commit 2); the second commit fixes it. Happy to reorder the two if a green bisect matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
