### PR TITLE
Test image membership with arithmetic instead of shapely (issue #116)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,12 @@ and cap cells now honours ``interior``; since 0.6.0 those two shapes had
 returned the plain vertices for that call. Planar boundary points are
 built with float arithmetic instead of a two-element numpy array per
 point, and are returned as Python floats; the values are unchanged.
+``pj_healpix.in_healpix_image`` and ``pj_rhealpix.in_rhealpix_image``
+test their rectangles and triangles with arithmetic instead of a shapely
+point-in-polygon query, cutting the two checks that every inverse
+projection performs from about 40% of its cost to almost nothing (issue
+#116). The accepted region is unchanged for rHEALPix and differs for
+HEALPix only within the 1e-10 fuzz margin outside the image.
 
 0.7.1
 ^^^^^

--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -21,15 +21,10 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 
 from collections.abc import Callable
 
-import shapely
 from numpy import arcsin, array, deg2rad, floor, pi, rad2deg, sign, sin, sqrt
-from shapely.geometry import Polygon
 
 # my_round is doctest-only: the doctests use it from the module globals.
 from rhealpixdggs.utils import auth_lat, auth_rad, my_round  # noqa: F401
-
-# Cache for in_healpix_image(); see the comment inside that function.
-_healpix_image_poly = None
 
 
 def healpix_sphere(lam: float, phi: float) -> tuple[float, float]:
@@ -161,7 +156,9 @@ def healpix_ellipsoid_inverse(x: float, y: float, e: float = 0) -> tuple[float, 
 def in_healpix_image(x: float, y: float) -> bool:
     """
     Return True if and only if `(x, y)` lies in the image of the HEALPix
-    projection of the unit sphere.
+    projection of the unit sphere, allowing a margin of about 1e-10 outside
+    it so that points computed to lie on the boundary are not rejected for
+    rounding error.
 
     EXAMPLES::
 
@@ -196,42 +193,19 @@ def in_healpix_image(x: float, y: float) -> bool:
         False
 
     """
-    global _healpix_image_poly
-    if _healpix_image_poly is None:
-        # Fuzz to slightly expand HEALPix image boundary so that
-        # points on the boundary count as lying in the image.
-        eps = 1e-10
-        vertices = [
-            (-pi - eps, pi / 4 + eps),
-            (-3 * pi / 4, pi / 2 + eps),
-            (-pi / 2, pi / 4 + eps),
-            (-pi / 4, pi / 2 + eps),
-            (0, pi / 4 + eps),
-            (pi / 4, pi / 2 + eps),
-            (pi / 2, pi / 4 + eps),
-            (3 * pi / 4, pi / 2 + eps),
-            (pi + eps, pi / 4 + eps),
-            (pi + eps, -pi / 4 - eps),
-            (3 * pi / 4, -pi / 2 - eps),
-            (pi / 2, -pi / 4 - eps),
-            (pi / 4, -pi / 2 - eps),
-            (0, -pi / 4 - eps),
-            (-pi / 4, -pi / 2 - eps),
-            (-pi / 2, -pi / 4 - eps),
-            (-3 * pi / 4, -pi / 2 - eps),
-            (-pi - eps, -pi / 4 - eps),
-        ]
-        # This polygon never varies (the function takes no parameters), so
-        # build it once and reuse it -- constructing it is not free, and
-        # this function may be called once per point projected.
-        _healpix_image_poly = Polygon(vertices)
-    # contains_xy (vectorized, coordinate-based) avoids constructing a Point
-    # object per call, unlike the equivalent poly.contains(Point(x, y)).
-    # It's a strict interior test (excludes the boundary), but the eps fuzz
-    # above already pushes genuine boundary points into the interior of
-    # this (slightly larger) polygon, so they still test True -- verified
-    # against every boundary case in this function's own doctest above.
-    return bool(shapely.contains_xy(_healpix_image_poly, x, y))
+    # Fuzz to slightly expand the image so that points on its boundary
+    # count as lying in it.
+    eps = 1e-10
+    abs_y = abs(y)
+    if not (abs(x) < pi + eps and abs_y < pi / 2 + eps):
+        return False
+    if abs_y < pi / 4 + eps:
+        return True
+    # Polar triangle with apex (x_c, +-pi/2) and base corners (x_c +- pi/4,
+    # +-pi/4): |x - x_c| + |y| <= pi/2.
+    cap_number = min(max(int(2 * x / pi + 2), 0), 3)
+    x_c = -3 * pi / 4 + (pi / 2) * cap_number
+    return abs(x - x_c) + abs_y < pi / 2 + eps
 
 
 def healpix(

--- a/rhealpixdggs/pj_rhealpix.py
+++ b/rhealpixdggs/pj_rhealpix.py
@@ -19,9 +19,7 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 
 from collections.abc import Callable
 
-import shapely
 from numpy import array, deg2rad, dot, identity, pi, rad2deg, sign
-from shapely.geometry import Polygon
 
 from rhealpixdggs.pj_healpix import (
     healpix_ellipsoid,
@@ -49,9 +47,6 @@ ROTATE = {
     -2: ROTATE2,
     -3: ROTATE1,
 }
-
-# Cache for in_rhealpix_image(); see the comment inside that function.
-_rhealpix_image_polys: dict[tuple[int, int], Polygon] = {}
 
 
 def combine_triangles(
@@ -431,7 +426,9 @@ def in_rhealpix_image(
 ) -> bool:
     """
     Return True if and only if the point `(x, y)` lies in the image of
-    the rHEALPix projection of the unit sphere.
+    the rHEALPix projection of the unit sphere, allowing a margin of 1e-15
+    outside it so that points computed to lie on the boundary are not
+    rejected for rounding error.
 
     EXAMPLES::
 
@@ -461,39 +458,15 @@ def in_rhealpix_image(
         False
 
     """
-    # This polygon only depends on (north_square, south_square), which are
-    # fixed per DGGS instance, so build it once per distinct pair and reuse
-    # it -- constructing it is not free, and this function may be called
-    # once per point projected.
-    key = (north_square, south_square)
-    poly = _rhealpix_image_polys.get(key)
-    if poly is None:
-        # Fuzz to slightly expand rHEALPix image so that
-        # points on the boundary count as lying in the image.
-        eps = 1e-15
-        vertices = [
-            (-pi - eps, pi / 4 + eps),
-            (-pi + north_square * pi / 2 - eps, pi / 4 + eps),
-            (-pi + north_square * pi / 2 - eps, 3 * pi / 4 + eps),
-            (-pi + (north_square + 1) * pi / 2 + eps, 3 * pi / 4 + eps),
-            (-pi + (north_square + 1) * pi / 2 + eps, pi / 4 + eps),
-            (pi + eps, pi / 4 + eps),
-            (pi + eps, -pi / 4 - eps),
-            (-pi + (south_square + 1) * pi / 2 + eps, -pi / 4 - eps),
-            (-pi + (south_square + 1) * pi / 2 + eps, -3 * pi / 4 - eps),
-            (-pi + south_square * pi / 2 - eps, -3 * pi / 4 - eps),
-            (-pi + south_square * pi / 2 - eps, -pi / 4 - eps),
-            (-pi - eps, -pi / 4 - eps),
-        ]
-        poly = Polygon(vertices)
-        _rhealpix_image_polys[key] = poly
-    # contains_xy (vectorized, coordinate-based) avoids constructing a Point
-    # object per call, unlike the equivalent poly.contains(Point(x, y)).
-    # It's a strict interior test (excludes the boundary), but the eps fuzz
-    # above already pushes genuine boundary points into the interior of
-    # this (slightly larger) polygon, so they still test True -- verified
-    # against every boundary case in this function's own doctest above.
-    return bool(shapely.contains_xy(poly, x, y))
+    # Fuzz to slightly expand the image so that points on its boundary
+    # count as lying in it.
+    eps = 1e-15
+    if abs(y) < pi / 4 + eps:
+        return -pi - eps < x < pi + eps
+    if not abs(y) < 3 * pi / 4 + eps:
+        return False
+    square = north_square if y > 0 else south_square
+    return -pi + square * pi / 2 - eps < x < -pi + (square + 1) * pi / 2 + eps
 
 
 def rhealpix(

--- a/tests/test_pj_healpix.py
+++ b/tests/test_pj_healpix.py
@@ -50,6 +50,84 @@ inputs = [
 ]
 
 
+_ORACLE_POLYGONS = {}
+
+
+def shapely_in_healpix_image(x, y):
+    # The polygon-based implementation this function replaced (issue #116),
+    # kept as the oracle for the arithmetic one.
+    from shapely import contains_xy
+    from shapely.geometry import Polygon
+
+    if () in _ORACLE_POLYGONS:
+        return bool(contains_xy(_ORACLE_POLYGONS[()], x, y))
+    eps = 1e-10
+    poly = Polygon(
+        [
+            (-pi - eps, pi / 4 + eps),
+            (-3 * pi / 4, pi / 2 + eps),
+            (-pi / 2, pi / 4 + eps),
+            (-pi / 4, pi / 2 + eps),
+            (0, pi / 4 + eps),
+            (pi / 4, pi / 2 + eps),
+            (pi / 2, pi / 4 + eps),
+            (3 * pi / 4, pi / 2 + eps),
+            (pi + eps, pi / 4 + eps),
+            (pi + eps, -pi / 4 - eps),
+            (3 * pi / 4, -pi / 2 - eps),
+            (pi / 2, -pi / 4 - eps),
+            (pi / 4, -pi / 2 - eps),
+            (0, -pi / 4 - eps),
+            (-pi / 4, -pi / 2 - eps),
+            (-pi / 2, -pi / 4 - eps),
+            (-3 * pi / 4, -pi / 2 - eps),
+            (-pi - eps, -pi / 4 - eps),
+        ]
+    )
+    _ORACLE_POLYGONS[()] = poly
+    return bool(contains_xy(poly, x, y))
+
+
+def outside_healpix_image(x, y):
+    # How far (x, y) lies outside the unfuzzed image, 0 if inside or on it.
+    abs_y = abs(y)
+    if abs(x) <= pi and abs_y <= pi / 4:
+        return 0.0
+    cap = min(max(int(2 * x / pi + 2), 0), 3)
+    x_c = -3 * pi / 4 + (pi / 2) * cap
+    return max(abs(x) - pi, abs(x - x_c) + abs_y - pi / 2, 0.0)
+
+
+# Offsets from an edge, straddling both fuzz scales (1e-10 and 1e-15).
+EDGE_OFFSETS = [
+    0.0,
+    1e-16,
+    -1e-16,
+    5e-16,
+    -5e-16,
+    1e-15,
+    -1e-15,
+    2e-15,
+    -2e-15,
+    1e-12,
+    -1e-12,
+    5e-11,
+    -5e-11,
+    1e-10,
+    -1e-10,
+    2e-10,
+    -2e-10,
+    1e-9,
+    -1e-9,
+    1e-6,
+    -1e-6,
+    0.01,
+    -0.01,
+]
+# Offsets along an edge, paired with every EDGE_OFFSETS value across it.
+ALONG_OFFSETS = [0.0, 1e-15, -1e-15, 1e-10, -1e-10, 1e-3, -1e-3]
+
+
 class MyTestCase(unittest.TestCase):
     def test_healpix_sphere(self):
         # Expected outputs of healpix_sphere() applied to inputs.
@@ -158,17 +236,45 @@ class MyTestCase(unittest.TestCase):
                 self.assertAlmostEqual(get[i], expect[i])
             # ------------------------------------------------------------------------------
 
-    def test_in_healpix_image_poly_is_cached(self):
-        # Regression test: in_healpix_image() used to rebuild its polygon
-        # (originally a matplotlib Path, now a shapely Polygon) on every
-        # call even though it takes no parameters (the polygon is always
-        # identical). See issue #64.
-        pjh._healpix_image_poly = None
-        self.assertTrue(pjh.in_healpix_image(0, 0))
-        cached = pjh._healpix_image_poly
-        self.assertIsNotNone(cached)
-        self.assertTrue(pjh.in_healpix_image(0.1, 0.1))
-        self.assertIs(pjh._healpix_image_poly, cached)
+    def test_in_healpix_image_matches_polygon_oracle(self):
+        # in_healpix_image() is arithmetic (issue #116). It must accept the
+        # whole image including its boundary, reject anything more than
+        # about 2e-10 outside, and agree with the polygon it replaced
+        # everywhere except within that fuzz margin, where the polygon's
+        # slightly rotated triangle edges differ from the exact ones.
+        from itertools import product
+        from math import inf, nan
+
+        from numpy import linspace
+
+        points = [
+            (x, y)
+            for x in linspace(-pi - 1e-3, pi + 1e-3, 101)
+            for y in linspace(-pi / 2 - 1e-3, pi / 2 + 1e-3, 101)
+        ]
+        for cap in range(4):
+            x_c = -3 * pi / 4 + (pi / 2) * cap
+            for t in linspace(0, pi / 4, 12):
+                for s, dx, dy in product((1, -1), ALONG_OFFSETS, EDGE_OFFSETS):
+                    points.append((x_c + t + dx, s * (pi / 2 - t) + dy))
+                    points.append((x_c - t + dx, s * (pi / 2 - t) + dy))
+        for y in linspace(-pi / 4, pi / 4, 10):
+            for dx, dy in product(EDGE_OFFSETS, ALONG_OFFSETS):
+                points.append((-pi + dx, y + dy))
+                points.append((pi + dx, y + dy))
+        for x, y in points:
+            got = pjh.in_healpix_image(x, y)
+            outside = outside_healpix_image(x, y)
+            if outside == 0.0:
+                self.assertTrue(got, (x, y))
+            elif outside > 2e-10:
+                self.assertFalse(got, (x, y))
+            else:
+                continue
+            self.assertEqual(got, shapely_in_healpix_image(x, y), (x, y))
+        for x, y in [(nan, 0.0), (0.0, nan), (nan, nan), (inf, 0.0), (0.0, -inf)]:
+            self.assertFalse(pjh.in_healpix_image(x, y), (x, y))
+            self.assertFalse(shapely_in_healpix_image(x, y), (x, y))
 
     def test_out_of_bounds_raises_value_error(self):
         # Regression test for issue #52: out-of-bounds coordinates used to

--- a/tests/test_pj_rhealpix.py
+++ b/tests/test_pj_rhealpix.py
@@ -52,6 +52,68 @@ inputs = [
 ]
 
 
+_ORACLE_POLYGONS = {}
+
+
+def shapely_in_rhealpix_image(x, y, north_square=0, south_square=0):
+    # The polygon-based implementation this function replaced (issue #116),
+    # kept as the oracle for the arithmetic one.
+    from shapely import contains_xy
+    from shapely.geometry import Polygon
+
+    if (north_square, south_square) in _ORACLE_POLYGONS:
+        return bool(contains_xy(_ORACLE_POLYGONS[(north_square, south_square)], x, y))
+    eps = 1e-15
+    poly = Polygon(
+        [
+            (-pi - eps, pi / 4 + eps),
+            (-pi + north_square * pi / 2 - eps, pi / 4 + eps),
+            (-pi + north_square * pi / 2 - eps, 3 * pi / 4 + eps),
+            (-pi + (north_square + 1) * pi / 2 + eps, 3 * pi / 4 + eps),
+            (-pi + (north_square + 1) * pi / 2 + eps, pi / 4 + eps),
+            (pi + eps, pi / 4 + eps),
+            (pi + eps, -pi / 4 - eps),
+            (-pi + (south_square + 1) * pi / 2 + eps, -pi / 4 - eps),
+            (-pi + (south_square + 1) * pi / 2 + eps, -3 * pi / 4 - eps),
+            (-pi + south_square * pi / 2 - eps, -3 * pi / 4 - eps),
+            (-pi + south_square * pi / 2 - eps, -pi / 4 - eps),
+            (-pi - eps, -pi / 4 - eps),
+        ]
+    )
+    _ORACLE_POLYGONS[(north_square, south_square)] = poly
+    return bool(contains_xy(poly, x, y))
+
+
+# Offsets from an edge, straddling both fuzz scales (1e-10 and 1e-15).
+EDGE_OFFSETS = [
+    0.0,
+    1e-16,
+    -1e-16,
+    5e-16,
+    -5e-16,
+    1e-15,
+    -1e-15,
+    2e-15,
+    -2e-15,
+    1e-12,
+    -1e-12,
+    5e-11,
+    -5e-11,
+    1e-10,
+    -1e-10,
+    2e-10,
+    -2e-10,
+    1e-9,
+    -1e-9,
+    1e-6,
+    -1e-6,
+    0.01,
+    -0.01,
+]
+# Offsets along an edge, paired with every EDGE_OFFSETS value across it.
+ALONG_OFFSETS = [0.0, 1e-15, -1e-15, 1e-10, -1e-10, 1e-3, -1e-3]
+
+
 class MyTestCase(unittest.TestCase):
     def test_triangle(self):
         # Create test points in the equatorial, north_square polar, and
@@ -331,22 +393,53 @@ class MyTestCase(unittest.TestCase):
             for i in range(len(expect)):
                 self.assertAlmostEqual(get[i], expect[i])
 
-    def test_in_rhealpix_image_poly_is_cached(self):
-        # Regression test: in_rhealpix_image() used to rebuild its polygon
-        # (originally a matplotlib Path, now a shapely Polygon) on every
-        # call even though it only depends on (north_square, south_square),
-        # which are fixed per DGGS instance. See issue #64.
-        pjr._rhealpix_image_polys.clear()
-        self.assertTrue(pjr.in_rhealpix_image(0, 0, north_square=1, south_square=2))
-        key = (1, 2)
-        self.assertIn(key, pjr._rhealpix_image_polys)
-        cached = pjr._rhealpix_image_polys[key]
-        self.assertTrue(pjr.in_rhealpix_image(0.1, 0.1, north_square=1, south_square=2))
-        self.assertIs(pjr._rhealpix_image_polys[key], cached)
-        # A different (north_square, south_square) pair gets its own entry.
-        self.assertTrue(pjr.in_rhealpix_image(0, 0, north_square=0, south_square=0))
-        self.assertIn((0, 0), pjr._rhealpix_image_polys)
-        self.assertIsNot(pjr._rhealpix_image_polys[(0, 0)], cached)
+    def test_in_rhealpix_image_matches_polygon_oracle(self):
+        # in_rhealpix_image() is arithmetic (issue #116). The image is a
+        # union of axis-aligned rectangles, so it must agree with the
+        # polygon it replaced at every point, including on the fuzz
+        # margin, for every (north_square, south_square) pair.
+        from math import inf, nan
+
+        from numpy import linspace
+
+        for north_square, south_square in product(range(4), repeat=2):
+            points = [
+                (x, y)
+                for x in linspace(-pi - 1e-3, pi + 1e-3, 51)
+                for y in linspace(-3 * pi / 4 - 1e-3, 3 * pi / 4 + 1e-3, 51)
+            ]
+            x_edges = [-pi, pi] + [
+                -pi + k * pi / 2
+                for k in (
+                    north_square,
+                    north_square + 1,
+                    south_square,
+                    south_square + 1,
+                )
+            ]
+            for x_e in x_edges:
+                for y in linspace(-3 * pi / 4, 3 * pi / 4, 7):
+                    for dx, dy in product(EDGE_OFFSETS, ALONG_OFFSETS):
+                        points.append((x_e + dx, y + dy))
+            for y_e in (-3 * pi / 4, -pi / 4, pi / 4, 3 * pi / 4):
+                for x in linspace(-pi, pi, 7):
+                    for dx, dy in product(ALONG_OFFSETS, EDGE_OFFSETS):
+                        points.append((x + dx, y_e + dy))
+            for x, y in points:
+                self.assertEqual(
+                    pjr.in_rhealpix_image(
+                        x, y, north_square=north_square, south_square=south_square
+                    ),
+                    shapely_in_rhealpix_image(x, y, north_square, south_square),
+                    (north_square, south_square, x, y),
+                )
+            for x, y in [(nan, 0.0), (-2.5, nan), (nan, nan), (inf, 0.0), (0.0, -inf)]:
+                self.assertFalse(
+                    pjr.in_rhealpix_image(
+                        x, y, north_square=north_square, south_square=south_square
+                    ),
+                    (x, y),
+                )
 
     def test_out_of_bounds_raises_value_error(self):
         # Regression test for issue #52: out-of-bounds coordinates used to


### PR DESCRIPTION
Closes #116.

`in_healpix_image` and `in_rhealpix_image` answered "is this planar point inside the projection's image?" by handing a polygon to shapely and running a GEOS point-in-polygon query. Every inverse projection calls both, and together they were about 40% of its cost. The images are simple shapes — a strip plus two axis-aligned squares for rHEALPix, a strip plus eight triangles for HEALPix — so a handful of float comparisons decide membership. Both modules no longer import shapely (it remains a dependency for `rhp_wrappers` and `conversion`).

**Semantics.** Same fuzz margins as before (1e-15 for rHEALPix, 1e-10 for HEALPix), same strictness on the fuzzed line, and NaN/inf are rejected as before (the first draft let a NaN coordinate through; the guards are written positively so NaN falls through to False, and the tests pin it).

- rHEALPix: identical to the polygon at every sampled point, fuzz line included, for all 16 `(north_square, south_square)` placements — axis-aligned edges reduce to the same double comparisons either way.
- HEALPix: accepts the whole image and its boundary, rejects anything more than 2e-10 outside; within that margin it differs from the polygon, whose fuzzed triangle edges were very slightly rotated (apexes and base corners shifted, not the edges offset). No point inside or on the true image changes classification.

**Tests.** The two polygon-cache regression tests go (there is no cache). The old polygon code lives on in each test module as the oracle; the new tests check agreement over a grid and at points placed just inside and just outside every edge at offsets from 1e-16 to 1e-2, plus NaN/inf. Whole suite: ~10 s (it was ~12 s; the projection got faster).

### Benchmark (this branch vs master, same machine)

| Per call | master | branch |
|---|---|---|
| `in_healpix_image` | 4.61 µs | 0.65 µs |
| `in_rhealpix_image` | 4.48 µs | 0.39 µs |
| inverse projection, equatorial | 23.7 µs | 10.7 µs |
| inverse projection, polar | 42.0 µs | 26.5 µs |

| `n=10, plane=False` | master | branch |
|---|---|---|
| quad `boundary` | 504 µs | 259 µs |
| dart `boundary` | 1592 µs | 958 µs |
| res 2, 486 cells, per-cell | 410 ms | 243 ms |
| res 2, 486 cells, `cell_boundaries` | 159 ms | 116 ms |
| res 3, 4374 cells, per-cell | 3.67 s | 2.20 s |
| res 3, 4374 cells, `cell_boundaries` | 1.36 s | 0.92 s |
| res 4, 39366 cells, per-cell | 36.0 s | 21.3 s |
| res 4, 39366 cells, `cell_boundaries` | 12.1 s | 8.6 s |

Against v0.7.1 (before #117 and this), resolution 4 was 48.8 s per-cell and 32.5 s batch: 2.3× and 3.8× combined.

Both checks per inverse projection are kept (the issue floated skipping the second once the first passes); at well under a microsecond each there is nothing left to save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
