### PR TITLE
Array twins for auth_lat and the wrap helpers (issue #88, part 1)

### DIFF
--- a/rhealpixdggs/utils.py
+++ b/rhealpixdggs/utils.py
@@ -17,7 +17,30 @@ unless indicated otherwise.
 # *****************************************************************************
 
 from math import asin, copysign, log, pi, sin, sqrt
-from typing import Any
+from typing import Any, Protocol, overload
+
+import numpy as np
+from numpy.typing import NDArray
+
+FloatArray = NDArray[np.float64]
+
+
+class ProjectionFunction(Protocol):
+    """
+    The callable a homemade projection factory returns: ``f(u, v,
+    radians=False, inverse=False)`` mapping a pair of floats to a pair of
+    floats, or a pair of equal-shape float arrays to a pair of arrays.
+    """
+
+    @overload
+    def __call__(
+        self, u: float, v: float, radians: bool = ..., inverse: bool = ...
+    ) -> tuple[float, float]: ...
+
+    @overload
+    def __call__(
+        self, u: FloatArray, v: FloatArray, radians: bool = ..., inverse: bool = ...
+    ) -> tuple[FloatArray, FloatArray]: ...
 
 
 def my_round(x: Any, digits: int = 0) -> Any:
@@ -112,6 +135,164 @@ def wrap_latitude(phi: float, radians: bool = False) -> float:
     return result
 
 
+def _wrap_longitude_array(lam: FloatArray, radians: bool = False) -> FloatArray:
+    """
+    ``wrap_longitude`` applied elementwise to an array.
+    """
+    lam = np.asarray(lam, dtype=np.float64)
+    half_range = pi if radians else 180
+    wrapped = lam % (2 * half_range)
+    wrapped = np.where(wrapped >= half_range, wrapped - 2 * half_range, wrapped)
+    out_of_range = (lam < -half_range) | (lam >= half_range)
+    return np.asarray(np.where(out_of_range, wrapped, lam), dtype=np.float64)
+
+
+def _wrap_latitude_array(phi: FloatArray, radians: bool = False) -> FloatArray:
+    """
+    ``wrap_latitude`` applied elementwise to an array.
+    """
+    phi = _wrap_longitude_array(phi, radians=radians)
+    half_range = pi if radians else 180
+    reflected = phi - np.copysign(half_range, phi)
+    return np.asarray(
+        np.where(np.abs(phi) <= half_range / 2, phi, reflected), dtype=np.float64
+    )
+
+
+def _auth_lat_coefficients(
+    n: float, inverse: bool
+) -> tuple[float, float, float, float, float, float]:
+    """
+    The power-series coefficients of sin(2 phi), ..., sin(12 phi) used by
+    ``auth_lat`` for third flattening `n`: equation A19 (forward) or A20
+    (inverse) of https://doi.org/10.48550/arXiv.2212.05818.
+    """
+    if not inverse:
+        return (
+            n
+            * (
+                -4 / 3
+                + n
+                * (
+                    -4 / 45
+                    + n
+                    * (
+                        88 / 315
+                        + n
+                        * (538 / 4725 + n * (20824 / 467775 + n * (-44732 / 2837835)))
+                    )
+                )
+            ),
+            n
+            * (
+                n
+                * (
+                    34 / 45
+                    + n
+                    * (
+                        8 / 105
+                        + n
+                        * (
+                            -2482 / 14175
+                            + n * (-37192 / 467775 + n * (-12467764 / 212837625))
+                        )
+                    )
+                )
+            ),
+            n
+            * (
+                n
+                * (
+                    n
+                    * (
+                        -1532 / 2835
+                        + n
+                        * (
+                            -898 / 14175
+                            + n * (54968 / 467775 + n * 100320856 / 1915538625)
+                        )
+                    )
+                )
+            ),
+            n
+            * (
+                n
+                * (
+                    n
+                    * (
+                        n
+                        * (
+                            6007 / 14175
+                            + n * (24496 / 467775 + n * (-5884124 / 70945875))
+                        )
+                    )
+                )
+            ),
+            n * (n * (n * (n * (n * (-23356 / 66825 + n * (-839792 / 19348875)))))),
+            n * (n * (n * (n * (n * (n * 570284222 / 1915538625))))),
+        )
+    return (
+        n
+        * (
+            4 / 3
+            + n
+            * (
+                4 / 45
+                + n
+                * (
+                    -16 / 35
+                    + n
+                    * (-2582 / 14175 + n * (60136 / 467775 + n * 28112932 / 212837625))
+                )
+            )
+        ),
+        n
+        * (
+            n
+            * (
+                46 / 45
+                + n
+                * (
+                    152 / 945
+                    + n
+                    * (
+                        -11966 / 14175
+                        + n * (-21016 / 51975 + n * 251310128 / 638512875)
+                    )
+                )
+            )
+        ),
+        n
+        * (
+            n
+            * (
+                n
+                * (
+                    3044 / 2835
+                    + n
+                    * (3802 / 14175 + n * (-94388 / 66825 + n * (-8797648 / 10945935)))
+                )
+            )
+        ),
+        n
+        * (
+            n
+            * (
+                n
+                * (
+                    n
+                    * (
+                        6059 / 4725
+                        + n * (41072 / 93555 + n * (-1472637812 / 638512875))
+                    )
+                )
+            )
+        ),
+        n * (n * (n * (n * (n * (768272 / 467775 + n * 455935736 / 638512875))))),
+        n * (n * (n * (n * (n * (n * 4210684958 / 1915538625))))),
+    )
+
+
 def auth_lat(
     phi: float, e: float, inverse: bool = False, radians: bool = False
 ) -> float:
@@ -178,79 +359,14 @@ def auth_lat(
             if not radians:
                 phi = phi * pi / 180
 
+            c2, c4, c6, c8, c10, c12 = _auth_lat_coefficients(n, inverse=False)
             authalic_lat = phi + (
-                n
-                * (
-                    -4 / 3
-                    + n
-                    * (
-                        -4 / 45
-                        + n
-                        * (
-                            88 / 315
-                            + n
-                            * (
-                                538 / 4725
-                                + n * (20824 / 467775 + n * (-44732 / 2837835))
-                            )
-                        )
-                    )
-                )
-                * sin(2 * phi)
-                + n
-                * (
-                    n
-                    * (
-                        34 / 45
-                        + n
-                        * (
-                            8 / 105
-                            + n
-                            * (
-                                -2482 / 14175
-                                + n * (-37192 / 467775 + n * (-12467764 / 212837625))
-                            )
-                        )
-                    )
-                )
-                * sin(4 * phi)
-                + n
-                * (
-                    n
-                    * (
-                        n
-                        * (
-                            -1532 / 2835
-                            + n
-                            * (
-                                -898 / 14175
-                                + n * (54968 / 467775 + n * 100320856 / 1915538625)
-                            )
-                        )
-                    )
-                )
-                * sin(6 * phi)
-                + n
-                * (
-                    n
-                    * (
-                        n
-                        * (
-                            n
-                            * (
-                                6007 / 14175
-                                + n * (24496 / 467775 + n * (-5884124 / 70945875))
-                            )
-                        )
-                    )
-                )
-                * sin(8 * phi)
-                + n
-                * (n * (n * (n * (n * (-23356 / 66825 + n * (-839792 / 19348875))))))
-                * sin(10 * phi)
-                + n
-                * (n * (n * (n * (n * (n * 570284222 / 1915538625)))))
-                * sin(12 * phi)
+                c2 * sin(2 * phi)
+                + c4 * sin(4 * phi)
+                + c6 * sin(6 * phi)
+                + c8 * sin(8 * phi)
+                + c10 * sin(10 * phi)
+                + c12 * sin(12 * phi)
             )
 
             if not radians:
@@ -263,83 +379,59 @@ def auth_lat(
         if not radians:
             phi = phi * pi / 180
 
+        c2, c4, c6, c8, c10, c12 = _auth_lat_coefficients(n, inverse=True)
         common_lat = phi + (
-            n
-            * (
-                4 / 3
-                + n
-                * (
-                    4 / 45
-                    + n
-                    * (
-                        -16 / 35
-                        + n
-                        * (
-                            -2582 / 14175
-                            + n * (60136 / 467775 + n * 28112932 / 212837625)
-                        )
-                    )
-                )
-            )
-            * sin(2 * phi)
-            + n
-            * (
-                n
-                * (
-                    46 / 45
-                    + n
-                    * (
-                        152 / 945
-                        + n
-                        * (
-                            -11966 / 14175
-                            + n * (-21016 / 51975 + n * 251310128 / 638512875)
-                        )
-                    )
-                )
-            )
-            * sin(4 * phi)
-            + n
-            * (
-                n
-                * (
-                    n
-                    * (
-                        3044 / 2835
-                        + n
-                        * (
-                            3802 / 14175
-                            + n * (-94388 / 66825 + n * (-8797648 / 10945935))
-                        )
-                    )
-                )
-            )
-            * sin(6 * phi)
-            + n
-            * (
-                n
-                * (
-                    n
-                    * (
-                        n
-                        * (
-                            6059 / 4725
-                            + n * (41072 / 93555 + n * (-1472637812 / 638512875))
-                        )
-                    )
-                )
-            )
-            * sin(8 * phi)
-            + n
-            * (n * (n * (n * (n * (768272 / 467775 + n * 455935736 / 638512875)))))
-            * sin(10 * phi)
-            + n * (n * (n * (n * (n * (n * 4210684958 / 1915538625))))) * sin(12 * phi)
+            c2 * sin(2 * phi)
+            + c4 * sin(4 * phi)
+            + c6 * sin(6 * phi)
+            + c8 * sin(8 * phi)
+            + c10 * sin(10 * phi)
+            + c12 * sin(12 * phi)
         )
 
         if not radians:
             common_lat = common_lat * 180 / pi
 
         return common_lat
+
+
+def _auth_lat_array(
+    phi: FloatArray, e: float, inverse: bool = False, radians: bool = False
+) -> FloatArray:
+    """
+    ``auth_lat`` applied elementwise to an array. Every expression mirrors
+    the scalar function's form so the two agree to the last bit wherever
+    the platform's array and scalar transcendental kernels do.
+    """
+    phi = np.asarray(phi, dtype=np.float64)
+    if e == 0:
+        return phi.copy()
+    f = 1 - sqrt(1 - e**2)
+    n = (1 - sqrt(1 - e**2)) / (1 + sqrt(1 - e**2))
+    if not radians:
+        phi = phi * pi / 180
+    if not inverse and abs(f) > 1 / 150:
+        s = np.sin(phi)
+        q = ((1 - e**2) * s) / (1 - np.float_power(e * s, 2)) - (1 - e**2) / (
+            2.0 * e
+        ) * np.log((1 - e * s) / (1 + e * s))
+        qp = 1 - (1 - e**2) / (2.0 * e) * log((1.0 - e) / (1.0 + e))
+        ratio = q / qp
+        ratio = np.where(np.abs(ratio) > 1, np.copysign(1, ratio), ratio)
+        result = np.arcsin(ratio)
+    else:
+        c2, c4, c6, c8, c10, c12 = _auth_lat_coefficients(n, inverse)
+        result = phi + (
+            c2 * np.sin(2 * phi)
+            + c4 * np.sin(4 * phi)
+            + c6 * np.sin(6 * phi)
+            + c8 * np.sin(8 * phi)
+            + c10 * np.sin(10 * phi)
+            + c12 * np.sin(12 * phi)
+        )
+    if not radians:
+        result = result * 180 / pi
+    return np.asarray(result, dtype=np.float64)
 
 
 def auth_rad(a: float, e: float, inverse: bool = False) -> float:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,9 +13,12 @@ Keep adding tests!
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
+import os
 import unittest
-from math import asin, pi, sin
+from math import asin, pi, sin, sqrt
 
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
 from scipy.integrate import quad
 
 import rhealpixdggs.utils as ut
@@ -43,6 +46,166 @@ def auth_lat_by_defining_integral(phi: float, e: float) -> float:
     q, _ = quad(integrand, 0, sin(phi), epsabs=1e-13, epsrel=1e-13)
     q_pole, _ = quad(integrand, 0, 1, epsabs=1e-13, epsrel=1e-13)
     return asin(q / q_pole)
+
+
+def auth_lat_series_before_refactor(phi: float, e: float, inverse: bool) -> float:
+    """
+    The power-series expressions exactly as ``auth_lat`` wrote them before
+    the coefficients were extracted into ``_auth_lat_coefficients``; `phi`
+    in radians. Kept verbatim so the refactor can be shown bit-identical.
+    """
+    n = (1 - sqrt(1 - e**2)) / (1 + sqrt(1 - e**2))
+    if not inverse:
+        authalic_lat = phi + (
+            n
+            * (
+                -4 / 3
+                + n
+                * (
+                    -4 / 45
+                    + n
+                    * (
+                        88 / 315
+                        + n
+                        * (538 / 4725 + n * (20824 / 467775 + n * (-44732 / 2837835)))
+                    )
+                )
+            )
+            * sin(2 * phi)
+            + n
+            * (
+                n
+                * (
+                    34 / 45
+                    + n
+                    * (
+                        8 / 105
+                        + n
+                        * (
+                            -2482 / 14175
+                            + n * (-37192 / 467775 + n * (-12467764 / 212837625))
+                        )
+                    )
+                )
+            )
+            * sin(4 * phi)
+            + n
+            * (
+                n
+                * (
+                    n
+                    * (
+                        -1532 / 2835
+                        + n
+                        * (
+                            -898 / 14175
+                            + n * (54968 / 467775 + n * 100320856 / 1915538625)
+                        )
+                    )
+                )
+            )
+            * sin(6 * phi)
+            + n
+            * (
+                n
+                * (
+                    n
+                    * (
+                        n
+                        * (
+                            6007 / 14175
+                            + n * (24496 / 467775 + n * (-5884124 / 70945875))
+                        )
+                    )
+                )
+            )
+            * sin(8 * phi)
+            + n
+            * (n * (n * (n * (n * (-23356 / 66825 + n * (-839792 / 19348875))))))
+            * sin(10 * phi)
+            + n * (n * (n * (n * (n * (n * 570284222 / 1915538625))))) * sin(12 * phi)
+        )
+        return authalic_lat
+    common_lat = phi + (
+        n
+        * (
+            4 / 3
+            + n
+            * (
+                4 / 45
+                + n
+                * (
+                    -16 / 35
+                    + n
+                    * (-2582 / 14175 + n * (60136 / 467775 + n * 28112932 / 212837625))
+                )
+            )
+        )
+        * sin(2 * phi)
+        + n
+        * (
+            n
+            * (
+                46 / 45
+                + n
+                * (
+                    152 / 945
+                    + n
+                    * (
+                        -11966 / 14175
+                        + n * (-21016 / 51975 + n * 251310128 / 638512875)
+                    )
+                )
+            )
+        )
+        * sin(4 * phi)
+        + n
+        * (
+            n
+            * (
+                n
+                * (
+                    3044 / 2835
+                    + n
+                    * (3802 / 14175 + n * (-94388 / 66825 + n * (-8797648 / 10945935)))
+                )
+            )
+        )
+        * sin(6 * phi)
+        + n
+        * (
+            n
+            * (
+                n
+                * (
+                    n
+                    * (
+                        6059 / 4725
+                        + n * (41072 / 93555 + n * (-1472637812 / 638512875))
+                    )
+                )
+            )
+        )
+        * sin(8 * phi)
+        + n
+        * (n * (n * (n * (n * (768272 / 467775 + n * 455935736 / 638512875)))))
+        * sin(10 * phi)
+        + n * (n * (n * (n * (n * (n * 4210684958 / 1915538625))))) * sin(12 * phi)
+    )
+    return common_lat
+
+
+# RHP_STRICT_BITS=1 asserts the array helpers reproduce the scalar ones to
+# the last bit; the default tolerates the ulp-level differences that
+# platforms with SIMD transcendental kernels can show.
+STRICT_BITS = os.environ.get("RHP_STRICT_BITS") == "1"
+
+
+def assert_continuous(got, want, atol):
+    if STRICT_BITS:
+        assert_array_equal(got, want)
+    else:
+        assert_allclose(got, want, rtol=0, atol=atol)
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -218,6 +381,101 @@ class UtilsTestCase(unittest.TestCase):
                 ut.auth_lat(phi, e, radians=True), e, radians=True, inverse=True
             )
             self.assertAlmostEqual(round_trip, phi, places=12)
+
+    def test_auth_lat_coefficient_refactor_is_bit_identical(self):
+        # The series coefficients come from _auth_lat_coefficients (issue
+        # #88); each is the `n * (...)` factor the original expression
+        # evaluated before multiplying by the sine, so results must match
+        # that expression to the bit.
+        phis = [-pi / 2 + k * pi / 4000 for k in range(4001)]
+        for e in (WGS84_E, 1e-3, 0.02, 0.1155, 0.8):
+            for inverse in (False, True):
+                if not inverse and 1 - sqrt(1 - e**2) > 1 / 150:
+                    continue  # the direct formula, not the series
+                for phi in phis:
+                    self.assertEqual(
+                        ut.auth_lat(phi, e, inverse=inverse, radians=True),
+                        auth_lat_series_before_refactor(phi, e, inverse),
+                        (e, inverse, phi),
+                    )
+
+    def test_auth_lat_array_matches_scalar(self):
+        rng = np.random.default_rng(20260811)
+        phis = np.concatenate(
+            [
+                rng.uniform(-pi / 2, pi / 2, 20000),
+                np.linspace(-pi / 2, pi / 2, 2001),
+                [0.0, -0.0, pi / 2, -pi / 2, pi / 2 - 1e-9, -pi / 2 + 1e-9],
+                pi / 2 - np.logspace(-15, -3, 25),
+            ]
+        )
+        near_pole = np.abs(np.abs(phis) - pi / 2) < 1e-6
+        for e in (0.0, WGS84_E, 0.1155, 0.8):
+            for inverse in (False, True):
+                for radians in (True, False):
+                    x = phis if radians else phis * 180 / pi
+                    scale = 1 if radians else 180 / pi
+                    got = ut._auth_lat_array(x, e, inverse=inverse, radians=radians)
+                    want = np.array(
+                        [
+                            ut.auth_lat(float(v), e, inverse=inverse, radians=radians)
+                            for v in x
+                        ]
+                    )
+                    self.assertEqual(got.dtype, np.float64)
+                    assert_continuous(got[~near_pole], want[~near_pole], 1e-12 * scale)
+                    assert_continuous(got[near_pole], want[near_pole], 1e-9 * scale)
+
+    def test_auth_lat_array_matches_defining_integral(self):
+        lat_degs = np.array([-89, -80, -60, -45, -30, -10, 0, 10, 30, 45, 60, 80, 89])
+        phis = lat_degs * pi / 180
+        for e in (0.8, 0.1155, WGS84_E):
+            expected = [auth_lat_by_defining_integral(float(p), e) for p in phis]
+            got_rad = ut._auth_lat_array(phis, e, radians=True)
+            got_deg = ut._auth_lat_array(lat_degs, e, radians=False)
+            for i, want in enumerate(expected):
+                self.assertAlmostEqual(got_rad[i], want, places=12)
+                self.assertAlmostEqual(got_deg[i], want * 180 / pi, places=10)
+
+    def test_auth_lat_array_shapes(self):
+        phi = np.array([[0.1, 0.2], [0.3, 0.4]])
+        original = phi.copy()
+        out = ut._auth_lat_array(phi, WGS84_E, radians=True)
+        self.assertEqual(out.shape, (2, 2))
+        assert_array_equal(phi, original)
+        # A sphere returns a copy, not the input.
+        out = ut._auth_lat_array(phi, 0.0, radians=True)
+        assert_array_equal(out, phi)
+        self.assertIsNot(out, phi)
+        self.assertFalse(np.shares_memory(out, phi))
+        # 0-d and integer inputs come back as float64 arrays.
+        out = ut._auth_lat_array(np.asarray(45), WGS84_E, radians=False)
+        self.assertEqual(out.shape, ())
+        self.assertEqual(out.dtype, np.float64)
+        self.assertAlmostEqual(float(out), ut.auth_lat(45, WGS84_E, radians=False))
+
+    def test_wrap_arrays_are_bit_identical_to_scalars(self):
+        rng = np.random.default_rng(20260811)
+        exact = [0.0, -0.0, 1.0, -1.0, 2.0, -2.0, 3.0, -3.0, 0.5, -0.5, 1.5, -1.5]
+        for radians in (True, False):
+            half = pi if radians else 180
+            values = np.concatenate(
+                [
+                    rng.uniform(-3 * half, 3 * half, 20000),
+                    np.array(exact) * half,
+                    np.array(exact) * half + 1e-12,
+                    np.array(exact) * half - 1e-12,
+                ]
+            )
+            for array_fn, scalar_fn in (
+                (ut._wrap_longitude_array, ut.wrap_longitude),
+                (ut._wrap_latitude_array, ut.wrap_latitude),
+            ):
+                got = array_fn(values, radians=radians)
+                want = np.array([scalar_fn(float(v), radians=radians) for v in values])
+                assert_array_equal(got, want)
+                self.assertEqual(got.dtype, np.float64)
+            self.assertEqual(ut._wrap_longitude_array(np.asarray(190.0)).shape, ())
 
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Part 1 of 7 for #88 (plan: utils → pj_healpix → pj_rhealpix → wrapper/DGGS → cell.py callers → cell_boundaries → remaining callers + benchmark).

Adds private array twins in `utils.py`: `_auth_lat_array`, `_wrap_longitude_array`, `_wrap_latitude_array`, plus the `FloatArray` alias and the `ProjectionFunction` protocol (two `@overload`ed `__call__`s) that the projection factories will be typed with in parts 2–3. No public behaviour changes; the scalar functions are untouched except for the coefficient extraction below.

**Bit-identity by construction.** Every array expression keeps the scalar function's textual form: `phi * pi / 180` rather than `np.deg2rad` (they differ in ~28% of inputs), `np.float_power(x, 2)` rather than `x ** 2` (array `**2` is `x*x`, scalar is C `pow()`; 1 ulp apart in ~0.1% of inputs), same left-to-right association everywhere. On this machine (numpy 2.4.5, AVX2) `_auth_lat_array` equals the scalar `auth_lat` to the bit for e ∈ {0, WGS84, 0.1155, 0.8}, both directions, both angle modes, over 22k latitudes including the poles. Platforms where numpy dispatches SIMD transcendental kernels may differ by an ulp, so the default tests use `atol=1e-12` rad (1e-9 within 1e-6 of a pole) and `RHP_STRICT_BITS=1` upgrades them to exact equality for local runs.

**The one edit to a hot scalar body.** `auth_lat`'s six power-series coefficients move into `_auth_lat_coefficients(n, inverse)` so both paths share them. Python evaluated each `n * (...)` factor before multiplying by `sin(2k·phi)`, so extracting it cannot change a bit; `test_auth_lat_coefficient_refactor_is_bit_identical` asserts exact equality against the pre-refactor expressions (kept verbatim in the test) over 4001 latitudes × 5 eccentricities × both directions. Timing, same machine, best of 7:

| | master | branch |
|---|---|---|
| `auth_lat` forward series | 1.525 µs | 1.541 µs |
| `auth_lat` inverse series | 1.550 µs | 1.580 µs |
| `auth_lat` forward direct (e=0.8) | 1.401 µs | 1.394 µs |

**Tests added** (`tests/test_utils.py`): refactor bit-identity; array vs scalar per the tolerance policy; array vs the existing `scipy.quad` defining-integral oracle (12 places); shapes/dtypes/no-mutation/copy-not-view for e=0; wrap arrays bit-identical to the scalars on 20k random values plus exact boundaries in both angle modes. Suite: 131 tests in ~10.6 s.

CHANGES.rst is deliberately untouched in parts 1–3 (private helpers); the user-visible entry lands with part 4, when `Projection.__call__` and `RHEALPixDGGS.rhealpix` start accepting arrays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
