### PR TITLE
Array twins for the HEALPix projection (issue #88, part 2)

### DIFF
--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -19,12 +19,55 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-from collections.abc import Callable
+from typing import cast
 
+import numpy as np
 from numpy import arcsin, array, deg2rad, floor, pi, rad2deg, sign, sin, sqrt
 
 # my_round is doctest-only: the doctests use it from the module globals.
-from rhealpixdggs.utils import auth_lat, auth_rad, my_round  # noqa: F401
+from rhealpixdggs.utils import (  # noqa: F401
+    FloatArray,
+    ProjectionFunction,
+    _auth_lat_array,
+    auth_lat,
+    auth_rad,
+    my_round,
+)
+
+_PHI0 = arcsin(2.0 / 3)
+_IMAGE_EPS = 1e-10
+
+
+def _as_float_arrays(u: object, v: object) -> tuple[FloatArray, FloatArray]:
+    """
+    Coerce `u` and `v` to float64 arrays broadcast to a common shape.
+    """
+    u_arr, v_arr = np.broadcast_arrays(
+        np.asarray(u, dtype=np.float64), np.asarray(v, dtype=np.float64)
+    )
+    return u_arr, v_arr
+
+
+def _raise_out_of_image(
+    x: FloatArray, y: FloatArray, ok: np.ndarray, projection: str
+) -> None:
+    bad = np.flatnonzero(~ok)
+    i = int(bad[0])
+    raise ValueError(
+        f"{bad.size} of {ok.size} points are not in the image of the "
+        f"{projection} projection of the unit sphere; first offending point "
+        f"at index {i}: ({x.ravel()[i]:.20f},{y.ravel()[i]:.20f})"
+    )
+
+
+def _cap_number(lam: FloatArray) -> FloatArray:
+    """
+    The polar cap (0-3) each longitude or planar x falls in, as
+    ``healpix_sphere`` and ``healpix_sphere_inverse`` compute it: floor,
+    clamped from above only.
+    """
+    cap = np.floor(2 * lam / pi + 2)
+    return np.asarray(np.where(cap >= 4, 3.0, cap), dtype=np.float64)
 
 
 def healpix_sphere(lam: float, phi: float) -> tuple[float, float]:
@@ -58,6 +101,27 @@ def healpix_sphere(lam: float, phi: float) -> tuple[float, float]:
         lamc = -3 * pi / 4 + (pi / 2) * cap_number
         x = lamc + (lam - lamc) * sigma
         y = sign(phi) * pi / 4 * (2 - sigma)
+    return x, y
+
+
+def _healpix_sphere_array(
+    lam: FloatArray, phi: FloatArray
+) -> tuple[FloatArray, FloatArray]:
+    """
+    ``healpix_sphere`` applied elementwise to arrays.
+    """
+    lam, phi = _as_float_arrays(lam, phi)
+    x = np.empty_like(lam)
+    y = np.empty_like(lam)
+    s = np.sin(phi)
+    equatorial = np.abs(phi) <= _PHI0
+    x[equatorial] = lam[equatorial]
+    y[equatorial] = 3 * pi / 8 * s[equatorial]
+    polar = ~equatorial
+    sigma = np.sqrt(3 * (1 - np.abs(s[polar])))
+    lamc = -3 * pi / 4 + (pi / 2) * _cap_number(lam[polar])
+    x[polar] = lamc + (lam[polar] - lamc) * sigma
+    y[polar] = np.sign(phi[polar]) * pi / 4 * (2 - sigma)
     return x, y
 
 
@@ -108,6 +172,34 @@ def healpix_sphere_inverse(x: float, y: float) -> tuple[float, float]:
     return lam, phi
 
 
+def _healpix_sphere_inverse_array(
+    x: FloatArray, y: FloatArray
+) -> tuple[FloatArray, FloatArray]:
+    """
+    ``healpix_sphere_inverse`` applied elementwise to arrays. Raises
+    ``ValueError`` if any point lies outside the image.
+    """
+    x, y = _as_float_arrays(x, y)
+    ok = _in_healpix_image_array(x, y)
+    if not ok.all():
+        _raise_out_of_image(x, y, ok, "HEALPix")
+    lam = np.empty_like(x)
+    phi = np.empty_like(x)
+    abs_y = np.abs(y)
+    equatorial = abs_y <= pi / 4
+    pole = abs_y >= pi / 2
+    polar = ~equatorial & ~pole
+    lam[equatorial] = x[equatorial]
+    phi[equatorial] = np.arcsin(8 * y[equatorial] / (3 * pi))
+    xc = -3 * pi / 4 + (pi / 2) * _cap_number(x[polar])
+    tau = 2 - 4 * abs_y[polar] / pi
+    lam[polar] = np.clip(xc + (x[polar] - xc) / tau, -pi, pi)
+    phi[polar] = np.sign(y[polar]) * np.arcsin(1 - np.float_power(tau, 2) / 3)
+    lam[pole] = -pi
+    phi[pole] = np.sign(y[pole]) * pi / 2
+    return lam, phi
+
+
 def healpix_ellipsoid(lam: float, phi: float, e: float = 0) -> tuple[float, float]:
     """
     Compute the signature functions of the HEALPix projection of an oblate
@@ -150,6 +242,27 @@ def healpix_ellipsoid_inverse(x: float, y: float, e: float = 0) -> tuple[float, 
     # no need to duplicate that check here.
     lam, beta = healpix_sphere_inverse(x, y)
     phi = auth_lat(beta, e, radians=True, inverse=True)
+    return lam, phi
+
+
+def _healpix_ellipsoid_array(
+    lam: FloatArray, phi: FloatArray, e: float = 0
+) -> tuple[FloatArray, FloatArray]:
+    """
+    ``healpix_ellipsoid`` applied elementwise to arrays.
+    """
+    beta = _auth_lat_array(np.asarray(phi, dtype=np.float64), e, radians=True)
+    return _healpix_sphere_array(lam, beta)
+
+
+def _healpix_ellipsoid_inverse_array(
+    x: FloatArray, y: FloatArray, e: float = 0
+) -> tuple[FloatArray, FloatArray]:
+    """
+    ``healpix_ellipsoid_inverse`` applied elementwise to arrays.
+    """
+    lam, beta = _healpix_sphere_inverse_array(x, y)
+    phi = _auth_lat_array(beta, e, radians=True, inverse=True)
     return lam, phi
 
 
@@ -208,9 +321,22 @@ def in_healpix_image(x: float, y: float) -> bool:
     return abs(x - x_c) + abs_y < pi / 2 + eps
 
 
-def healpix(
-    a: float = 1, e: float = 0
-) -> Callable[[float, float, bool, bool], tuple[float, float]]:
+def _in_healpix_image_array(x: FloatArray, y: FloatArray) -> np.ndarray:
+    """
+    ``in_healpix_image`` applied elementwise to arrays.
+    """
+    x, y = _as_float_arrays(x, y)
+    eps = _IMAGE_EPS
+    abs_y = np.abs(y)
+    band = (np.abs(x) < pi + eps) & (abs_y < pi / 2 + eps)
+    equatorial = abs_y < pi / 4 + eps
+    cap_number = np.clip(np.trunc(2 * x / pi + 2), 0, 3)
+    x_c = -3 * pi / 4 + (pi / 2) * cap_number
+    triangle = np.abs(x - x_c) + abs_y < pi / 2 + eps
+    return np.asarray(band & (equatorial | triangle))
+
+
+def healpix(a: float = 1, e: float = 0) -> ProjectionFunction:
     """
     Return a function object that wraps the HEALPix projection and its inverse
     of an ellipsoid with major radius `a` and eccentricity `e`.
@@ -231,12 +357,33 @@ def healpix(
     OUTPUT:
 
     - A function object of the form f(u, v, radians=False, inverse=False).
+      `u` and `v` may be floats or numpy arrays of a common shape; arrays
+      come back as a pair of float64 arrays.
     """
     R_A = auth_rad(a, e)
 
+    def f_array(
+        u: float | FloatArray, v: float | FloatArray, radians: bool, inverse: bool
+    ) -> tuple[FloatArray, FloatArray]:
+        u, v = _as_float_arrays(u, v)
+        if not inverse:
+            if not radians:
+                u, v = deg2rad(u), deg2rad(v)
+            x, y = _healpix_ellipsoid_array(u, v, e=e)
+            return R_A * x, R_A * y
+        lam, phi = _healpix_ellipsoid_inverse_array(u / R_A, v / R_A, e=e)
+        if not radians:
+            lam, phi = rad2deg(lam), rad2deg(phi)
+        return lam, phi
+
     def f(
-        u: float, v: float, radians: bool = False, inverse: bool = False
-    ) -> tuple[float, float]:
+        u: float | FloatArray,
+        v: float | FloatArray,
+        radians: bool = False,
+        inverse: bool = False,
+    ) -> tuple[float, float] | tuple[FloatArray, FloatArray]:
+        if isinstance(u, np.ndarray) or isinstance(v, np.ndarray):
+            return f_array(u, v, radians, inverse)
         if not inverse:
             lam, phi = u, v
             if not radians:
@@ -252,4 +399,4 @@ def healpix(
                 lam, phi = rad2deg([lam, phi])
             return lam, phi
 
-    return f
+    return cast(ProjectionFunction, f)

--- a/tests/test_pj_array.py
+++ b/tests/test_pj_array.py
@@ -1,0 +1,304 @@
+"""
+Tests of the array (vectorised) projection paths against the scalar ones
+(issue #88). Discrete outputs and pure-arithmetic functions must match
+exactly; outputs that pass through transcendental functions match to
+`ATOL` radians by default and exactly under RHP_STRICT_BITS=1.
+"""
+
+import os
+import unittest
+from itertools import product
+from math import pi
+
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
+from pyproj import Proj
+
+import rhealpixdggs.pj_healpix as pjh
+from rhealpixdggs.ellipsoids import WGS84_E
+from rhealpixdggs.utils import auth_lat, auth_rad
+from tests.test_pj_healpix import ALONG_OFFSETS, EDGE_OFFSETS
+from tests.test_pj_healpix_c_reference import geo_gap_deg
+
+STRICT_BITS = os.environ.get("RHP_STRICT_BITS") == "1"
+SEED = 20260811
+ATOL = 1e-12
+POLE_ATOL = 1e-9  # within 1e-6 rad of a pole, sqrt(3(1 - |sin phi|)) amplifies
+E_VALUES = (0.0, WGS84_E, 0.1155, 0.8)
+
+
+def scalar_map(fn, *arrays, **kwargs):
+    """
+    Apply the scalar function `fn` to every point of the broadcast arrays,
+    returning its outputs as arrays of the same shape.
+    """
+    arrays = np.broadcast_arrays(*(np.asarray(a, dtype=float) for a in arrays))
+    shape = arrays[0].shape
+    flat = [a.ravel() for a in arrays]
+    outs = [fn(*(float(v) for v in point), **kwargs) for point in zip(*flat)]
+    if isinstance(outs[0], tuple):
+        return tuple(np.array(col, dtype=float).reshape(shape) for col in zip(*outs))
+    return np.array(outs).reshape(shape)
+
+
+def assert_continuous(got, want, atol=ATOL, near_pole=None):
+    if STRICT_BITS:
+        assert_array_equal(got, want)
+    elif near_pole is None:
+        assert_allclose(got, want, rtol=0, atol=atol)
+    else:
+        assert_allclose(got[~near_pole], want[~near_pole], rtol=0, atol=atol)
+        assert_allclose(got[near_pole], want[near_pole], rtol=0, atol=POLE_ATOL)
+
+
+def lonlat_points():
+    rng = np.random.default_rng(SEED)
+    lam = [rng.uniform(-pi, pi, 10000), rng.uniform(-pi, pi, 1000)]
+    phi = [
+        np.arcsin(rng.uniform(-1, 1, 10000)),
+        rng.choice([-1.0, 1.0], 1000) * rng.uniform(1.4, pi / 2, 1000),
+    ]
+    exact_phi = [0.0, pjh._PHI0, -pjh._PHI0, pi / 2, -pi / 2]
+    seam_phi = [
+        s * (pjh._PHI0 + d)
+        for s in (1, -1)
+        for d in (1e-16, -1e-16, 1e-15, -1e-15, 1e-10, -1e-10)
+    ]
+    exact_lam = [-pi, -pi / 2, 0.0, pi / 2, -pi + 1e-15, pi - 1e-15]
+    grid = list(product(exact_lam, exact_phi + seam_phi))
+    lam.append(np.array([g[0] for g in grid]))
+    phi.append(np.array([g[1] for g in grid]))
+    return np.concatenate(lam), np.concatenate(phi)
+
+
+LONLAT = lonlat_points()
+LONLAT_NEAR_POLE = np.abs(np.abs(LONLAT[1]) - pi / 2) < 1e-6
+
+
+def healpix_planar_points():
+    """
+    Planar points inside the HEALPix image (projected random points plus
+    every seam with the fuzz-scale offsets) and the offset points that fall
+    outside it.
+    """
+    x, y = scalar_map(pjh.healpix_sphere, *LONLAT)
+    seams = []
+    for cap in range(4):
+        x_c = -3 * pi / 4 + (pi / 2) * cap
+        for t in np.linspace(0, pi / 4, 12):
+            for s, dx, dy in product((1, -1), ALONG_OFFSETS, EDGE_OFFSETS):
+                seams.append((x_c + t + dx, s * (pi / 2 - t) + dy))
+                seams.append((x_c - t + dx, s * (pi / 2 - t) + dy))
+    for yy in np.linspace(-pi / 4, pi / 4, 10):
+        for dx, dy in product(EDGE_OFFSETS, ALONG_OFFSETS):
+            seams.append((-pi + dx, yy + dy))
+            seams.append((pi + dx, yy + dy))
+    for k in range(5):
+        for yy in np.linspace(-pi / 2, pi / 2, 9):
+            for dx, dy in product(EDGE_OFFSETS, ALONG_OFFSETS):
+                seams.append((-pi + k * pi / 2 + dx, yy + dy))
+    for s in (1, -1):
+        for xx in np.linspace(-pi, pi, 9):
+            for dx, dy in product(ALONG_OFFSETS, EDGE_OFFSETS):
+                seams.append((xx + dx, s * pi / 2 + dy))
+    sx = np.array([p[0] for p in seams])
+    sy = np.array([p[1] for p in seams])
+    inside = np.array([pjh.in_healpix_image(a, b) for a, b in zip(sx, sy)])
+    planar = (np.concatenate([x, sx[inside]]), np.concatenate([y, sy[inside]]))
+    return planar, (sx[~inside], sy[~inside])
+
+
+HEALPIX_PLANAR, HEALPIX_OUTSIDE = healpix_planar_points()
+PLANAR_NEAR_POLE = np.abs(np.abs(HEALPIX_PLANAR[1]) - pi / 2) < 1e-6
+NOT_FINITE = (
+    np.array([np.nan, 0.0, np.nan, np.inf, 0.0]),
+    np.array([0.0, np.nan, np.nan, 0.0, -np.inf]),
+)
+
+
+class HealpixArrayTestCase(unittest.TestCase):
+    def test_in_healpix_image_array_matches_scalar(self):
+        for x, y in (HEALPIX_PLANAR, HEALPIX_OUTSIDE, NOT_FINITE):
+            got = pjh._in_healpix_image_array(x, y)
+            want = np.array([pjh.in_healpix_image(a, b) for a, b in zip(x, y)])
+            assert_array_equal(got, want)
+        self.assertTrue(pjh._in_healpix_image_array(*HEALPIX_PLANAR).all())
+        self.assertFalse(pjh._in_healpix_image_array(*HEALPIX_OUTSIDE).any())
+
+    def test_cap_number_matches_scalar(self):
+        for values in (LONLAT[0], HEALPIX_PLANAR[0], HEALPIX_OUTSIDE[0]):
+            want = np.floor(2 * values / pi + 2)
+            want = np.where(want >= 4, 3.0, want)
+            assert_array_equal(pjh._cap_number(values), want)
+
+    def test_healpix_sphere_array_matches_scalar(self):
+        got = pjh._healpix_sphere_array(*LONLAT)
+        want = scalar_map(pjh.healpix_sphere, *LONLAT)
+        for g, w in zip(got, want):
+            assert_continuous(g, w, near_pole=LONLAT_NEAR_POLE)
+
+    def test_healpix_sphere_inverse_array_matches_scalar(self):
+        got = pjh._healpix_sphere_inverse_array(*HEALPIX_PLANAR)
+        want = scalar_map(pjh.healpix_sphere_inverse, *HEALPIX_PLANAR)
+        for g, w in zip(got, want):
+            assert_continuous(g, w, near_pole=PLANAR_NEAR_POLE)
+
+    def test_healpix_ellipsoid_arrays_match_scalar(self):
+        for e in E_VALUES:
+            got = pjh._healpix_ellipsoid_array(*LONLAT, e=e)
+            want = scalar_map(pjh.healpix_ellipsoid, *LONLAT, e=e)
+            for g, w in zip(got, want):
+                assert_continuous(g, w, near_pole=LONLAT_NEAR_POLE)
+            got = pjh._healpix_ellipsoid_inverse_array(*HEALPIX_PLANAR, e=e)
+            want = scalar_map(pjh.healpix_ellipsoid_inverse, *HEALPIX_PLANAR, e=e)
+            for g, w in zip(got, want):
+                assert_continuous(g, w, near_pole=PLANAR_NEAR_POLE)
+
+    def test_healpix_factory_arrays_match_scalar(self):
+        for a, e, radians in product((1.0, 6378137.0), (0.0, WGS84_E), (True, False)):
+            f = pjh.healpix(a=a, e=e)
+            R_A = auth_rad(a, e)
+            angle = 1.0 if radians else 180 / pi
+            lam, phi = LONLAT[0] * angle, LONLAT[1] * angle
+            got = f(lam, phi, radians=radians)
+            want = scalar_map(f, lam, phi, radians=radians)
+            for g, w in zip(got, want):
+                self.assertEqual(g.dtype, np.float64)
+                assert_continuous(g, w, atol=ATOL * R_A, near_pole=LONLAT_NEAR_POLE)
+            # Scaling by R_A and back can push fuzz-edge seam points out of
+            # the image; keep the ones both paths accept.
+            x, y = HEALPIX_PLANAR[0] * R_A, HEALPIX_PLANAR[1] * R_A
+            keep = pjh._in_healpix_image_array(x / R_A, y / R_A)
+            x, y, near_pole = x[keep], y[keep], PLANAR_NEAR_POLE[keep]
+            got = f(x, y, radians=radians, inverse=True)
+            want = scalar_map(f, x, y, radians=radians, inverse=True)
+            for g, w in zip(got, want):
+                assert_continuous(g, w, atol=ATOL * angle, near_pole=near_pole)
+            # Scalars still take the scalar path and come back as numpy scalars.
+            out = f(float(lam[0]), float(phi[0]), radians=radians)
+            self.assertIsInstance(out, tuple)
+            self.assertIsInstance(out[0], np.float64)
+
+    def test_exact_inputs_are_bit_identical(self):
+        # Inputs whose transcendental values are exact in any correct kernel
+        # must agree exactly on every platform.
+        lam = np.array([k * pi / 2 for k in range(-2, 3)] * 3)
+        phi = np.repeat([0.0, pi / 2, -pi / 2], 5)
+        got = pjh._healpix_sphere_array(lam, phi)
+        want = scalar_map(pjh.healpix_sphere, lam, phi)
+        for g, w in zip(got, want):
+            assert_array_equal(g, w)
+        band_x = [k * pi / 2 for k in range(-2, 3)]
+        apex_x = [-3 * pi / 4, -pi / 4, pi / 4, 3 * pi / 4]
+        x = np.array(band_x * 3 + apex_x * 2 + [-7 * pi / 8, -5 * pi / 6])
+        y = np.concatenate(
+            [
+                np.repeat([0.0, pi / 4, -pi / 4], 5),
+                np.repeat([pi / 2, -pi / 2], 4),
+                [3 * pi / 8, 5 * pi / 12],
+            ]
+        )
+        got = pjh._healpix_sphere_inverse_array(x, y)
+        want = scalar_map(pjh.healpix_sphere_inverse, x, y)
+        for g, w in zip(got, want):
+            assert_array_equal(g, w)
+        # The two seam points invert to exactly -pi, not pi - epsilon.
+        self.assertEqual(got[0][-1], -pi)
+        self.assertEqual(got[0][-2], -pi)
+
+    def test_round_trips(self):
+        lam, phi = LONLAT
+        off_pole = np.abs(phi) < pi / 2
+        x, y = pjh._healpix_sphere_array(lam, phi)
+        lam2, phi2 = pjh._healpix_sphere_inverse_array(x, y)
+        assert_allclose(lam2[off_pole], lam[off_pole], rtol=0, atol=1e-12)
+        assert_allclose(phi2, phi, rtol=0, atol=1e-12)
+        # The inverse authalic series is truncated at n^6, so the round trip
+        # is exact to rounding only for small flattenings (the e = 0.8 bound
+        # is the one tests/test_utils.py uses).
+        # Approaching a pole the polar branch's arcsin(1 - tau^2/3) grows
+        # ill-conditioned: the ellipsoidal round trip is ~1e-12 off at 1e-4
+        # rad from the pole and ~1e-8 off at the pole itself.
+        near = np.abs(np.abs(phi) - pi / 2) < 1e-3
+        for e, atol in ((WGS84_E, 1e-12), (0.1155, 1e-12), (0.8, 1e-3)):
+            x, y = pjh._healpix_ellipsoid_array(lam, phi, e=e)
+            lam2, phi2 = pjh._healpix_ellipsoid_inverse_array(x, y, e=e)
+            assert_allclose(lam2[off_pole], lam[off_pole], rtol=0, atol=1e-12)
+            assert_allclose(phi2[~near], phi[~near], rtol=0, atol=atol)
+            assert_allclose(phi2[near], phi[near], rtol=0, atol=max(atol, 1e-6))
+
+    def test_healpix_array_matches_proj_c_reference(self):
+        # PROJ's C HEALPix on the unit sphere, and on the authalic sphere for
+        # the ellipsoid, as tests/test_pj_healpix_c_reference.py does.
+        lon, lat = LONLAT[0] * 180 / pi, LONLAT[1] * 180 / pi
+        x_ref, y_ref = Proj(proj="healpix", R=1)(lon, lat)
+        x, y = pjh.healpix(a=1, e=0)(lon, lat)
+        assert_allclose(x, x_ref, rtol=1e-12, atol=1e-12)
+        assert_allclose(y, y_ref, rtol=1e-12, atol=1e-12)
+        a, e = 5.0, WGS84_E
+        R_A = auth_rad(a, e)
+        beta = np.array([auth_lat(v, e) for v in lat])
+        x_ref, y_ref = Proj(proj="healpix", R=R_A)(lon, beta)
+        x, y = pjh.healpix(a=a, e=e)(lon, lat)
+        assert_allclose(x, x_ref, rtol=1e-12, atol=1e-12 * R_A)
+        assert_allclose(y, y_ref, rtol=1e-12, atol=1e-12 * R_A)
+        lon2, lat2 = Proj(proj="healpix", a=a, e=e)(x, y, inverse=True)
+        gaps = [geo_gap_deg(p, q) for p, q in zip(zip(lon, lat), zip(lon2, lat2))]
+        self.assertLess(max(gaps), 1e-5)
+
+    def test_value_error_parity(self):
+        rng = np.random.default_rng(SEED)
+        good = HEALPIX_PLANAR
+        pick = rng.choice(len(HEALPIX_OUTSIDE[0]), 100, replace=False)
+        n_out = len(HEALPIX_OUTSIDE[0])
+        inverses = [
+            pjh._healpix_sphere_inverse_array,
+            pjh._healpix_ellipsoid_inverse_array,
+            lambda x, y: pjh.healpix(a=1, e=0)(x, y, radians=True, inverse=True),
+            lambda x, y: pjh.healpix(a=1, e=0)(x, y, radians=False, inverse=True),
+        ]
+        for fn in inverses:
+            fn(*good)  # a wholly in-image batch does not raise
+            for i in pick:
+                bx, by = HEALPIX_OUTSIDE[0][i], HEALPIX_OUTSIDE[1][i]
+                with self.assertRaises(ValueError):
+                    pjh.healpix_sphere_inverse(float(bx), float(by))
+                x = np.concatenate([good[0][:5], [bx]])
+                y = np.concatenate([good[1][:5], [by]])
+                with self.assertRaises(ValueError) as cm:
+                    fn(x, y)
+                self.assertIn("1 of 6 points", str(cm.exception))
+                self.assertIn("index 5", str(cm.exception))
+            with self.assertRaises(ValueError) as cm:
+                fn(*HEALPIX_OUTSIDE)
+            self.assertIn(f"{n_out} of {n_out} points", str(cm.exception))
+            with self.assertRaises(ValueError):
+                fn(*NOT_FINITE)
+
+    def test_shapes_and_dtypes(self):
+        lam = np.array([[0.1, 0.2, 0.3], [1.5, -1.5, 0.0]])
+        phi = np.array([[0.4, 1.4, -1.4], [0.0, 1.0, -1.0]])
+        lam_copy, phi_copy = lam.copy(), phi.copy()
+        x, _ = pjh._healpix_sphere_array(lam, phi)
+        self.assertEqual(x.shape, (2, 3))
+        self.assertEqual(x.dtype, np.float64)
+        assert_array_equal(lam, lam_copy)
+        assert_array_equal(phi, phi_copy)
+        self.assertFalse(np.shares_memory(x, lam))
+        # Broadcasting, integer and empty inputs.
+        x, _ = pjh._healpix_sphere_array(lam[0], np.asarray(0.5))
+        self.assertEqual(x.shape, (3,))
+        x, _ = pjh._healpix_sphere_array(np.array([1, 0]), np.array([1, 0]))
+        self.assertEqual(x.dtype, np.float64)
+        x, _ = pjh._healpix_sphere_inverse_array(np.array([]), np.array([]))
+        self.assertEqual(x.shape, (0,))
+        # 0-d array inputs take the array path; as with numpy's own ufuncs,
+        # 0-d operands yield numpy scalars.
+        f = pjh.healpix(a=2, e=0.1)
+        x, _ = f(np.asarray(10.0), np.asarray(80.0))
+        self.assertEqual(np.ndim(x), 0)
+        self.assertEqual(float(x), f(10.0, 80.0)[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Part 2 of 7 for #88. **Stacked on #123** (base branch `vectorise-utils`); retarget to `master` once that merges.

Adds the HEALPix array twins in `pj_healpix.py` — `_healpix_sphere_array`, `_healpix_sphere_inverse_array`, `_healpix_ellipsoid_array`, `_healpix_ellipsoid_inverse_array`, `_in_healpix_image_array` — plus `_cap_number` (shared cap selection: `floor`, clamped from above only, exactly as the scalar code), `_as_float_arrays` (coerce + broadcast) and `_raise_out_of_image`. The closure returned by `healpix(a, e)` dispatches on `isinstance(u, ndarray) or isinstance(v, ndarray)` (~0.05 µs) to an array body; the scalar body is unchanged and scalar calls still return numpy scalars, so every doctest passes as before. The factory's return type is now the `ProjectionFunction` protocol from part 1.

**Numerics mirrored deliberately**: branches are evaluated on index subsets (`x[mask]`) rather than whole-array `where`, so no out-of-domain `arcsin`/`sqrt` is ever evaluated and no spurious warnings appear; `tau**2` is `np.float_power(tau, 2)` (array `**2` is `x*x`, scalar is C `pow()`); the equatorial/polar/pole split, the `lam` clamp (`clip`) and the `int()`-truncation cap in the in-image test are transcribed literally. On this machine every array output is bit-identical to the scalar path (50k random points, all seams, all four eccentricities, both angle modes).

**Contract**: inputs coerced to float64 and broadcast; outputs are fresh float64 arrays of the broadcast shape (0-d operands yield numpy scalars, as numpy's own ufuncs do); any out-of-image point makes the whole call raise `ValueError("N of M points are not in the image …; first offending point at index i: (x,y)")`; NaN/inf count as outside.

**Tests** (`tests/test_pj_array.py`, new; part 3 adds the rHEALPix cases): shared `scalar_map`/`assert_continuous` helpers and point sets — 11k area-uniform lon-lat plus exact poles, cap boundaries and the `arcsin(2/3)` seam at ±1e-16/1e-15/1e-10; planar points from projecting those plus every triangle edge, band side, cap boundary and pole with the existing `EDGE_OFFSETS × ALONG_OFFSETS`, split into in-image and out-of-image sets. Checks: in-image mask and cap numbers exact; sphere/ellipsoid forward and inverse vs scalar (`atol=1e-12`, `1e-9` within 1e-6 of a pole; exact under `RHP_STRICT_BITS=1`); factory in both angle modes and radii; exact-input subset bit-identical unconditionally (incl. the `(-7π/8, 3π/8)` seam inverting to exactly −π); round trips; PROJ C reference (unit sphere `rtol=1e-12`, WGS84 via the authalic sphere, inverse gap < 1e-5°); ValueError parity for 100 outside points × 4 entry points; shapes/dtypes/no-mutation/no-aliasing. Module runs in ~4.7 s; whole suite 142 tests in ~15 s.

No public API or changelog change yet (private helpers; the factory closure accepting arrays is documented with part 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
