### PR TITLE
Array twins for the rHEALPix projection (issue #88, part 3)

### DIFF
--- a/rhealpixdggs/pj_rhealpix.py
+++ b/rhealpixdggs/pj_rhealpix.py
@@ -17,11 +17,18 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 #                  http://www.gnu.org/licenses/
 # *****************************************************************************
 
-from collections.abc import Callable
+from typing import cast
 
+import numpy as np
 from numpy import array, deg2rad, dot, identity, pi, rad2deg, sign
 
 from rhealpixdggs.pj_healpix import (
+    _as_float_arrays,
+    _healpix_ellipsoid_array,
+    _healpix_ellipsoid_inverse_array,
+    _healpix_sphere_array,
+    _healpix_sphere_inverse_array,
+    _raise_out_of_image,
     healpix_ellipsoid,
     healpix_ellipsoid_inverse,
     healpix_sphere,
@@ -29,7 +36,15 @@ from rhealpixdggs.pj_healpix import (
 )
 
 # my_round is doctest-only: the doctests use it from the module globals.
-from rhealpixdggs.utils import auth_rad, my_round  # noqa: F401
+from rhealpixdggs.utils import (  # noqa: F401
+    FloatArray,
+    ProjectionFunction,
+    auth_rad,
+    my_round,
+)
+
+_IMAGE_EPS = 1e-15
+_TRIANGLE_EPS = 1e-15
 
 # Matrix for anticlockwise rotation by pi/2:
 ROTATE1 = array([[0, -1], [1, 0]])
@@ -117,6 +132,53 @@ def combine_triangles(
             u = array((-3 * pi / 4 + south_square * pi / 2, -pi / 2))
             x, y = dot(ROTATE[c - south_square], xy - u) + tc
     return x, y
+
+
+def _combine_triangles_array(
+    x: FloatArray,
+    y: FloatArray,
+    north_square: int = 0,
+    south_square: int = 0,
+    inverse: bool = False,
+) -> tuple[FloatArray, FloatArray]:
+    """
+    ``combine_triangles`` applied elementwise to arrays. Rotation by k
+    quarter turns is written out per case, which is exact, in place of the
+    ``ROTATE`` matrices.
+    """
+    x, y = _as_float_arrays(x, y)
+    north_square = north_square % 4
+    south_square = south_square % 4
+    tri, region = _triangle_array(
+        x, y, north_square=north_square, south_square=south_square, inverse=inverse
+    )
+    x_out = x.copy()
+    y_out = y.copy()
+    polar = region != 0
+    if not polar.any():
+        return x_out, y_out
+    north = region[polar] == 1
+    c = tri[polar].astype(np.float64)
+    xp, yp = x[polar], y[polar]
+    tc_x = -3 * pi / 4 + c * pi / 2
+    tc_y = np.sign(yp) * pi / 2
+    square = np.where(north, north_square, south_square)
+    u_x = -3 * pi / 4 + square * pi / 2
+    u_y = np.where(north, pi / 2, -pi / 2)
+    if not inverse:
+        dx, dy = xp - tc_x, yp - tc_y
+        k = np.where(north, c - north_square, -(c - south_square))
+        o_x, o_y = u_x, u_y
+    else:
+        dx, dy = xp - u_x, yp - u_y
+        k = np.where(north, -(c - north_square), c - south_square)
+        o_x, o_y = tc_x, tc_y
+    k = k.astype(np.int64) % 4
+    r_x = np.select([k == 0, k == 1, k == 2], [dx, -dy, -dx], default=dy)
+    r_y = np.select([k == 0, k == 1, k == 2], [dy, dx, -dy], default=-dx)
+    x_out[polar] = r_x + o_x
+    y_out[polar] = r_y + o_y
+    return x_out, y_out
 
 
 def triangle(
@@ -259,6 +321,52 @@ def triangle(
     return triangle_number, region
 
 
+def _triangle_array(
+    x: FloatArray,
+    y: FloatArray,
+    north_square: int = 0,
+    south_square: int = 0,
+    inverse: bool = False,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    ``triangle`` applied elementwise to arrays, with integer codes in place
+    of its labels: triangle number -1 for equatorial points, and region 0
+    for equatorial, 1 for north polar, -1 for south polar.
+    """
+    x, y = _as_float_arrays(x, y)
+    region = np.where(y > pi / 4, 1, np.where(y < -pi / 4, -1, 0)).astype(np.int8)
+    if not inverse:
+        tri = np.select([x < -pi / 2, x < 0, x < pi / 2], [0, 1, 2], default=3)
+    else:
+        eps = _TRIANGLE_EPS
+        ns, ss = north_square, south_square
+        L1 = x - (-3 * pi / 4 + (ns - 1) * pi / 2)
+        L2 = -x + (-3 * pi / 4 + (ns + 1) * pi / 2)
+        tri_north = np.select(
+            [
+                (y < L1 - eps) & (y >= L2 - eps),
+                (y >= L1 - eps) & (y > L2 + eps),
+                (y > L1 + eps) & (y <= L2 + eps),
+            ],
+            [(ns + 1) % 4, (ns + 2) % 4, (ns + 3) % 4],
+            default=ns,
+        )
+        L1 = x - (-3 * pi / 4 + (ss + 1) * pi / 2)
+        L2 = -x + (-3 * pi / 4 + (ss - 1) * pi / 2)
+        tri_south = np.select(
+            [
+                (y <= L1 + eps) & (y > L2 + eps),
+                (y < L1 - eps) & (y <= L2 + eps),
+                (y >= L1 - eps) & (y < L2 - eps),
+            ],
+            [(ss + 1) % 4, (ss + 2) % 4, (ss + 3) % 4],
+            default=ss,
+        )
+        tri = np.where(region == 1, tri_north, tri_south)
+    tri = np.where(region == 0, -1, tri).astype(np.int8)
+    return tri, region
+
+
 def rhealpix_sphere(
     lam: float,
     phi: float,
@@ -306,6 +414,24 @@ def rhealpix_sphere(
     return x, y
 
 
+def _rhealpix_sphere_array(
+    lam: FloatArray,
+    phi: FloatArray,
+    north_square: int = 0,
+    south_square: int = 0,
+    region: str = "none",
+) -> tuple[FloatArray, FloatArray]:
+    """
+    ``rhealpix_sphere`` applied elementwise to arrays.
+    """
+    x, y = _healpix_sphere_array(lam, phi)
+    if region != "equatorial":
+        x, y = _combine_triangles_array(
+            x, y, north_square=north_square, south_square=south_square
+        )
+    return x, y
+
+
 def rhealpix_sphere_inverse(
     x: float,
     y: float,
@@ -339,6 +465,30 @@ def rhealpix_sphere_inverse(
             x, y, north_square=north_square, south_square=south_square, inverse=True
         )
     return healpix_sphere_inverse(x, y)
+
+
+def _rhealpix_sphere_inverse_array(
+    x: FloatArray,
+    y: FloatArray,
+    north_square: int = 0,
+    south_square: int = 0,
+    region: str = "none",
+) -> tuple[FloatArray, FloatArray]:
+    """
+    ``rhealpix_sphere_inverse`` applied elementwise to arrays. Raises
+    ``ValueError`` if any point lies outside the image.
+    """
+    x, y = _as_float_arrays(x, y)
+    ok = _in_rhealpix_image_array(
+        x, y, north_square=north_square, south_square=south_square
+    )
+    if not ok.all():
+        _raise_out_of_image(x, y, ok, f"({north_square}, {south_square})-rHEALPix")
+    if region != "equatorial":
+        x, y = _combine_triangles_array(
+            x, y, north_square=north_square, south_square=south_square, inverse=True
+        )
+    return _healpix_sphere_inverse_array(x, y)
 
 
 def rhealpix_ellipsoid(
@@ -383,6 +533,25 @@ def rhealpix_ellipsoid(
     return x, y
 
 
+def _rhealpix_ellipsoid_array(
+    lam: FloatArray,
+    phi: FloatArray,
+    e: float = 0,
+    north_square: int = 0,
+    south_square: int = 0,
+    region: str = "none",
+) -> tuple[FloatArray, FloatArray]:
+    """
+    ``rhealpix_ellipsoid`` applied elementwise to arrays.
+    """
+    x, y = _healpix_ellipsoid_array(lam, phi, e)
+    if region != "equatorial":
+        x, y = _combine_triangles_array(
+            x, y, north_square=north_square, south_square=south_square
+        )
+    return x, y
+
+
 def rhealpix_ellipsoid_inverse(
     x: float,
     y: float,
@@ -419,6 +588,31 @@ def rhealpix_ellipsoid_inverse(
         )
 
     return healpix_ellipsoid_inverse(x, y, e=e)
+
+
+def _rhealpix_ellipsoid_inverse_array(
+    x: FloatArray,
+    y: FloatArray,
+    e: float = 0,
+    north_square: int = 0,
+    south_square: int = 0,
+    region: str = "none",
+) -> tuple[FloatArray, FloatArray]:
+    """
+    ``rhealpix_ellipsoid_inverse`` applied elementwise to arrays. Raises
+    ``ValueError`` if any point lies outside the image.
+    """
+    x, y = _as_float_arrays(x, y)
+    ok = _in_rhealpix_image_array(
+        x, y, north_square=north_square, south_square=south_square
+    )
+    if not ok.all():
+        _raise_out_of_image(x, y, ok, f"({north_square}, {south_square})-rHEALPix")
+    if region != "equatorial":
+        x, y = _combine_triangles_array(
+            x, y, north_square=north_square, south_square=south_square, inverse=True
+        )
+    return _healpix_ellipsoid_inverse_array(x, y, e=e)
 
 
 def in_rhealpix_image(
@@ -469,13 +663,33 @@ def in_rhealpix_image(
     return -pi + square * pi / 2 - eps < x < -pi + (square + 1) * pi / 2 + eps
 
 
+def _in_rhealpix_image_array(
+    x: FloatArray, y: FloatArray, north_square: int = 0, south_square: int = 0
+) -> np.ndarray:
+    """
+    ``in_rhealpix_image`` applied elementwise to arrays.
+    """
+    x, y = _as_float_arrays(x, y)
+    eps = _IMAGE_EPS
+    abs_y = np.abs(y)
+    band = abs_y < pi / 4 + eps
+    in_band = (-pi - eps < x) & (x < pi + eps)
+    square = np.where(y > 0, north_square, south_square)
+    in_square = (
+        (abs_y < 3 * pi / 4 + eps)
+        & (-pi + square * pi / 2 - eps < x)
+        & (x < -pi + (square + 1) * pi / 2 + eps)
+    )
+    return np.asarray(np.where(band, in_band, in_square))
+
+
 def rhealpix(
     a: float = 1,
     e: float = 0,
     north_square: int = 0,
     south_square: int = 0,
     region: str = "none",
-) -> Callable[[float, float, bool, bool], tuple[float, float]]:
+) -> ProjectionFunction:
     """
     Return a function object that wraps the rHEALPix projection and its inverse
     of an ellipsoid with major radius `a` and eccentricity `e`.
@@ -497,12 +711,47 @@ def rhealpix(
     OUTPUT:
 
     - A function object of the form f(u, v, radians=False, inverse=False).
+      `u` and `v` may be floats or numpy arrays of a common shape; arrays
+      come back as a pair of float64 arrays.
     """
     R_A = auth_rad(a, e)
 
+    def f_array(
+        u: float | FloatArray, v: float | FloatArray, radians: bool, inverse: bool
+    ) -> tuple[FloatArray, FloatArray]:
+        u, v = _as_float_arrays(u, v)
+        if not inverse:
+            if not radians:
+                u, v = deg2rad(u), deg2rad(v)
+            x, y = _rhealpix_ellipsoid_array(
+                u,
+                v,
+                e=e,
+                north_square=north_square,
+                south_square=south_square,
+                region=region,
+            )
+            return R_A * x, R_A * y
+        lam, phi = _rhealpix_ellipsoid_inverse_array(
+            u / R_A,
+            v / R_A,
+            e=e,
+            north_square=north_square,
+            south_square=south_square,
+            region=region,
+        )
+        if not radians:
+            lam, phi = rad2deg(lam), rad2deg(phi)
+        return lam, phi
+
     def f(
-        u: float, v: float, radians: bool = False, inverse: bool = False
-    ) -> tuple[float, float]:
+        u: float | FloatArray,
+        v: float | FloatArray,
+        radians: bool = False,
+        inverse: bool = False,
+    ) -> tuple[float, float] | tuple[FloatArray, FloatArray]:
+        if isinstance(u, np.ndarray) or isinstance(v, np.ndarray):
+            return f_array(u, v, radians, inverse)
         if not inverse:
             lam, phi = u, v
             if not radians:
@@ -540,4 +789,4 @@ def rhealpix(
                 lam, phi = rad2deg([lam, phi])
             return lam, phi
 
-    return f
+    return cast(ProjectionFunction, f)

--- a/tests/test_pj_array.py
+++ b/tests/test_pj_array.py
@@ -15,6 +15,7 @@ from numpy.testing import assert_allclose, assert_array_equal
 from pyproj import Proj
 
 import rhealpixdggs.pj_healpix as pjh
+import rhealpixdggs.pj_rhealpix as pjr
 from rhealpixdggs.ellipsoids import WGS84_E
 from rhealpixdggs.utils import auth_lat, auth_rad
 from tests.test_pj_healpix import ALONG_OFFSETS, EDGE_OFFSETS
@@ -114,6 +115,103 @@ NOT_FINITE = (
     np.array([np.nan, 0.0, np.nan, np.inf, 0.0]),
     np.array([0.0, np.nan, np.nan, 0.0, -np.inf]),
 )
+
+SQUARE_PAIRS = list(product(range(4), repeat=2))
+REGION_CODE = {"equatorial": 0, "north_polar": 1, "south_polar": -1}
+# The last 102 LONLAT points are the exact/seam grid; keep it in the smaller
+# per-square-pair set.
+LONLAT_SMALL = (
+    np.concatenate([LONLAT[0][:2000], LONLAT[0][-102:]]),
+    np.concatenate([LONLAT[1][:2000], LONLAT[1][-102:]]),
+)
+
+
+def rhealpix_planar_points(north_square, south_square):
+    """
+    Planar points inside the (north_square, south_square)-rHEALPix image:
+    projected random points, the polar squares' diagonals and boundaries
+    with fuzz-scale offsets, and the band and square edges; plus the offset
+    points that fall outside.
+    """
+    x, y = scalar_map(
+        pjr.rhealpix_sphere,
+        *LONLAT_SMALL,
+        north_square=north_square,
+        south_square=south_square,
+    )
+    seams = []
+    small = (0.0, 1e-16, -1e-16, 1e-15, -1e-15, 2e-15, -2e-15, 1e-10, -1e-10)
+    for square, sign in ((north_square, 1), (south_square, -1)):
+        u_x, u_y = -3 * pi / 4 + square * pi / 2, sign * pi / 2
+        for t in np.linspace(-pi / 4, pi / 4, 25):
+            for d in small:
+                seams.append((u_x + t, u_y + t + d))
+                seams.append((u_x + t, u_y - t + d))
+        for cx, cy in product((-pi / 4, 0.0, pi / 4), repeat=2):
+            for dx, dy in product(small, repeat=2):
+                seams.append((u_x + cx + dx, u_y + cy + dy))
+    for x_e in {-pi, pi} | {-pi + k * pi / 2 for k in range(5)}:
+        for yy in np.linspace(-3 * pi / 4, 3 * pi / 4, 7):
+            for dx, dy in product(EDGE_OFFSETS, ALONG_OFFSETS):
+                seams.append((x_e + dx, yy + dy))
+    for y_e in (-3 * pi / 4, -pi / 4, pi / 4, 3 * pi / 4):
+        for xx in np.linspace(-pi, pi, 7):
+            for dx, dy in product(ALONG_OFFSETS, EDGE_OFFSETS):
+                seams.append((xx + dx, y_e + dy))
+    sx = np.array([q[0] for q in seams])
+    sy = np.array([q[1] for q in seams])
+    kw = {"north_square": north_square, "south_square": south_square}
+    inside = np.array([pjr.in_rhealpix_image(a, b, **kw) for a, b in zip(sx, sy)])
+
+    def accepted(a, b):
+        # Inside the rHEALPix image by its 1e-15 fuzz, yet the uncombined
+        # point can fall outside the HEALPix image's 1e-10 fuzz.
+        try:
+            pjr.rhealpix_sphere_inverse(a, b, **kw)
+        except ValueError:
+            return False
+        return True
+
+    ok = inside & np.array([accepted(a, b) for a, b in zip(sx, sy)])
+    planar = (np.concatenate([x, sx[ok]]), np.concatenate([y, sy[ok]]))
+    rejected = (sx[inside & ~ok], sy[inside & ~ok])
+    return planar, (sx[~inside], sy[~inside]), rejected
+
+
+RHEALPIX_PLANAR = {}
+RHEALPIX_OUTSIDE = {}
+RHEALPIX_REJECTED = {}
+for _pair in SQUARE_PAIRS:
+    RHEALPIX_PLANAR[_pair], RHEALPIX_OUTSIDE[_pair], RHEALPIX_REJECTED[_pair] = (
+        rhealpix_planar_points(*_pair)
+    )
+# Random (interior) points only: seam points within the fuzz margins are not
+# round-trippable by either path.
+LONLAT_INTERIOR = (LONLAT_SMALL[0][:2000], LONLAT_SMALL[1][:2000])
+N_INTERIOR_HEALPIX = 11000  # LONLAT's random points; the exact grid follows
+
+
+def accepts(f, x, y, radians):
+    try:
+        f(float(x), float(y), radians=radians, inverse=True)
+    except ValueError:
+        return False
+    return True
+
+
+def triangle_codes(x, y, north_square, south_square, inverse):
+    tri, region = [], []
+    for a, b in zip(x, y):
+        t, r = pjr.triangle(
+            float(a),
+            float(b),
+            north_square=north_square,
+            south_square=south_square,
+            inverse=inverse,
+        )
+        tri.append(-1 if t is None else t)
+        region.append(REGION_CODE[r])
+    return np.array(tri), np.array(region)
 
 
 class HealpixArrayTestCase(unittest.TestCase):
@@ -298,6 +396,235 @@ class HealpixArrayTestCase(unittest.TestCase):
         x, _ = f(np.asarray(10.0), np.asarray(80.0))
         self.assertEqual(np.ndim(x), 0)
         self.assertEqual(float(x), f(10.0, 80.0)[0])
+
+
+class RhealpixArrayTestCase(unittest.TestCase):
+    def test_in_rhealpix_image_array_matches_scalar(self):
+        for pair in SQUARE_PAIRS:
+            for x, y in (RHEALPIX_PLANAR[pair], RHEALPIX_OUTSIDE[pair], NOT_FINITE):
+                got = pjr._in_rhealpix_image_array(x, y, *pair)
+                want = np.array(
+                    [pjr.in_rhealpix_image(a, b, *pair) for a, b in zip(x, y)]
+                )
+                assert_array_equal(got, want)
+            self.assertTrue(
+                pjr._in_rhealpix_image_array(*RHEALPIX_PLANAR[pair], *pair).all()
+            )
+            self.assertFalse(
+                pjr._in_rhealpix_image_array(*RHEALPIX_OUTSIDE[pair], *pair).any()
+            )
+
+    def test_triangle_array_matches_scalar(self):
+        for pair in SQUARE_PAIRS:
+            tri, region = pjr._triangle_array(*HEALPIX_PLANAR, *pair, inverse=False)
+            want_tri, want_region = triangle_codes(
+                *HEALPIX_PLANAR, *pair, inverse=False
+            )
+            assert_array_equal(tri, want_tri)
+            assert_array_equal(region, want_region)
+            tri, region = pjr._triangle_array(
+                *RHEALPIX_PLANAR[pair], *pair, inverse=True
+            )
+            want_tri, want_region = triangle_codes(
+                *RHEALPIX_PLANAR[pair], *pair, inverse=True
+            )
+            assert_array_equal(tri, want_tri)
+            assert_array_equal(region, want_region)
+
+    def test_combine_triangles_array_is_bit_identical(self):
+        # Pure arithmetic on both sides: exact on every platform.
+        for pair in SQUARE_PAIRS:
+            got = pjr._combine_triangles_array(*HEALPIX_PLANAR, *pair)
+            want = scalar_map(
+                pjr.combine_triangles,
+                *HEALPIX_PLANAR,
+                north_square=pair[0],
+                south_square=pair[1],
+            )
+            for g, w in zip(got, want):
+                assert_array_equal(g, w)
+            planar = RHEALPIX_PLANAR[pair]
+            got = pjr._combine_triangles_array(*planar, *pair, inverse=True)
+            want = scalar_map(
+                pjr.combine_triangles,
+                *planar,
+                north_square=pair[0],
+                south_square=pair[1],
+                inverse=True,
+            )
+            for g, w in zip(got, want):
+                assert_array_equal(g, w)
+            # Round trip through the rearrangement on interior points (seam
+            # points within the fuzz can come back through another triangle).
+            hx, hy = (a[:N_INTERIOR_HEALPIX] for a in HEALPIX_PLANAR)
+            fx, fy = pjr._combine_triangles_array(hx, hy, *pair)
+            back = pjr._combine_triangles_array(fx, fy, *pair, inverse=True)
+            for b, h in zip(back, (hx, hy)):
+                assert_allclose(b, h, rtol=0, atol=1e-15)
+
+    def test_rhealpix_sphere_arrays_match_scalar(self):
+        for pair in SQUARE_PAIRS:
+            kw = {"north_square": pair[0], "south_square": pair[1]}
+            got = pjr._rhealpix_sphere_array(*LONLAT_SMALL, **kw)
+            want = scalar_map(pjr.rhealpix_sphere, *LONLAT_SMALL, **kw)
+            near = np.abs(np.abs(LONLAT_SMALL[1]) - pi / 2) < 1e-6
+            for g, w in zip(got, want):
+                assert_continuous(g, w, near_pole=near)
+            planar = RHEALPIX_PLANAR[pair]
+            got = pjr._rhealpix_sphere_inverse_array(*planar, **kw)
+            want = scalar_map(pjr.rhealpix_sphere_inverse, *planar, **kw)
+            near = np.abs(np.abs(want[1]) - pi / 2) < 1e-6
+            for g, w in zip(got, want):
+                assert_continuous(g, w, near_pole=near)
+
+    def test_rhealpix_ellipsoid_arrays_match_scalar(self):
+        for pair in ((0, 0), (1, 2), (3, 3)):
+            kw = {"north_square": pair[0], "south_square": pair[1]}
+            for e in E_VALUES:
+                got = pjr._rhealpix_ellipsoid_array(*LONLAT_SMALL, e=e, **kw)
+                want = scalar_map(pjr.rhealpix_ellipsoid, *LONLAT_SMALL, e=e, **kw)
+                near = np.abs(np.abs(LONLAT_SMALL[1]) - pi / 2) < 1e-6
+                for g, w in zip(got, want):
+                    assert_continuous(g, w, near_pole=near)
+                planar = RHEALPIX_PLANAR[pair]
+                got = pjr._rhealpix_ellipsoid_inverse_array(*planar, e=e, **kw)
+                want = scalar_map(pjr.rhealpix_ellipsoid_inverse, *planar, e=e, **kw)
+                near = np.abs(np.abs(want[1]) - pi / 2) < 1e-6
+                for g, w in zip(got, want):
+                    assert_continuous(g, w, near_pole=near)
+
+    def test_rhealpix_region_hint_arrays(self):
+        # region="equatorial" skips the polar rearrangement for every point.
+        lam, phi = LONLAT_SMALL
+        for pair in SQUARE_PAIRS:
+            kw = {
+                "north_square": pair[0],
+                "south_square": pair[1],
+                "region": "equatorial",
+            }
+            hinted = pjr._rhealpix_sphere_array(lam, phi, **kw)
+            plain = pjh._healpix_sphere_array(lam, phi)
+            for h, q in zip(hinted, plain):
+                assert_array_equal(h, q)
+            hinted = pjr._rhealpix_ellipsoid_array(lam, phi, e=WGS84_E, **kw)
+            plain = pjh._healpix_ellipsoid_array(lam, phi, e=WGS84_E)
+            for h, q in zip(hinted, plain):
+                assert_array_equal(h, q)
+            # Inverse with the hint on equatorial planar points equals the
+            # unhinted inverse there.
+            x, y = HEALPIX_PLANAR
+            band = (np.abs(y) <= pi / 4) & pjr._in_rhealpix_image_array(x, y, *pair)
+            hinted = pjr._rhealpix_sphere_inverse_array(x[band], y[band], **kw)
+            plain = pjr._rhealpix_sphere_inverse_array(
+                x[band], y[band], north_square=pair[0], south_square=pair[1]
+            )
+            for h, q in zip(hinted, plain):
+                assert_array_equal(h, q)
+
+    def test_rhealpix_factory_arrays_match_scalar(self):
+        cases = product(
+            (1.0, 6378137.0), (0.0, WGS84_E), ((0, 0), (1, 2)), (True, False)
+        )
+        for a, e, pair, radians in cases:
+            f = pjr.rhealpix(a=a, e=e, north_square=pair[0], south_square=pair[1])
+            R_A = auth_rad(a, e)
+            angle = 1.0 if radians else 180 / pi
+            lam, phi = LONLAT_SMALL[0] * angle, LONLAT_SMALL[1] * angle
+            near = np.abs(np.abs(LONLAT_SMALL[1]) - pi / 2) < 1e-6
+            got = f(lam, phi, radians=radians)
+            want = scalar_map(f, lam, phi, radians=radians)
+            for g, w in zip(got, want):
+                self.assertEqual(g.dtype, np.float64)
+                assert_continuous(g, w, atol=ATOL * R_A, near_pole=near)
+            # Scaling by R_A and back moves fuzz-edge seam points by an ulp,
+            # which can flip their triangle; keep the points the scalar
+            # closure accepts, as the array closure sees the same values.
+            x, y = RHEALPIX_PLANAR[pair][0] * R_A, RHEALPIX_PLANAR[pair][1] * R_A
+            keep = np.array([accepts(f, a, b, radians) for a, b in zip(x, y)])
+            x, y = x[keep], y[keep]
+            got = f(x, y, radians=radians, inverse=True)
+            want = scalar_map(f, x, y, radians=radians, inverse=True)
+            near = np.abs(np.abs(want[1]) - pi / 2 * angle) < 1e-6 * angle
+            for g, w in zip(got, want):
+                assert_continuous(g, w, atol=ATOL * angle, near_pole=near)
+            out = f(float(lam[0]), float(phi[0]), radians=radians)
+            self.assertIsInstance(out[0], np.float64)
+
+    def test_rhealpix_round_trips(self):
+        lam, phi = LONLAT_INTERIOR
+        off_pole = np.abs(phi) < pi / 2
+        near = np.abs(np.abs(phi) - pi / 2) < 1e-3
+        for pair in ((0, 0), (1, 2), (3, 3)):
+            kw = {"north_square": pair[0], "south_square": pair[1]}
+            x, y = pjr._rhealpix_sphere_array(lam, phi, **kw)
+            lam2, phi2 = pjr._rhealpix_sphere_inverse_array(x, y, **kw)
+            assert_allclose(lam2[off_pole], lam[off_pole], rtol=0, atol=1e-12)
+            assert_allclose(phi2, phi, rtol=0, atol=1e-12)
+            for e, atol in ((WGS84_E, 1e-12), (0.8, 1e-3)):
+                x, y = pjr._rhealpix_ellipsoid_array(lam, phi, e=e, **kw)
+                lam2, phi2 = pjr._rhealpix_ellipsoid_inverse_array(x, y, e=e, **kw)
+                assert_allclose(lam2[off_pole], lam[off_pole], rtol=0, atol=1e-12)
+                assert_allclose(phi2[~near], phi[~near], rtol=0, atol=atol)
+                assert_allclose(phi2[near], phi[near], rtol=0, atol=max(atol, 1e-6))
+
+    def test_rhealpix_array_matches_proj_c_reference(self):
+        lon, lat = LONLAT_SMALL[0] * 180 / pi, LONLAT_SMALL[1] * 180 / pi
+        for pair in SQUARE_PAIRS:
+            ref = Proj(proj="rhealpix", R=1, north_square=pair[0], south_square=pair[1])
+            x_ref, y_ref = ref(lon, lat)
+            x, y = pjr.rhealpix(a=1, e=0, north_square=pair[0], south_square=pair[1])(
+                lon, lat
+            )
+            assert_allclose(x, x_ref, rtol=1e-12, atol=1e-12)
+            assert_allclose(y, y_ref, rtol=1e-12, atol=1e-12)
+        a, e, pair = 5.0, WGS84_E, (1, 2)
+        f = pjr.rhealpix(a=a, e=e, north_square=pair[0], south_square=pair[1])
+        x, y = f(lon, lat)
+        lon2, lat2 = Proj(
+            proj="rhealpix", a=a, e=e, north_square=pair[0], south_square=pair[1]
+        )(x, y, inverse=True)
+        gaps = [geo_gap_deg(p, q) for p, q in zip(zip(lon, lat), zip(lon2, lat2))]
+        self.assertLess(max(gaps), 1e-5)
+
+    def test_rhealpix_value_error_parity(self):
+        rng = np.random.default_rng(SEED)
+        for pair in ((0, 0), (1, 2), (2, 3)):
+            good = RHEALPIX_PLANAR[pair]
+            outside = RHEALPIX_OUTSIDE[pair]
+            pick = rng.choice(len(outside[0]), 40, replace=False)
+            kw = {"north_square": pair[0], "south_square": pair[1]}
+            f = pjr.rhealpix(a=1, e=0, **kw)
+            inverses = [
+                lambda x, y, kw=kw: pjr._rhealpix_sphere_inverse_array(x, y, **kw),
+                lambda x, y, kw=kw: pjr._rhealpix_ellipsoid_inverse_array(
+                    x, y, e=WGS84_E, **kw
+                ),
+                lambda x, y, f=f: f(x, y, radians=True, inverse=True),
+            ]
+            for fn in inverses:
+                fn(*good)
+                for i in pick:
+                    bx, by = outside[0][i], outside[1][i]
+                    with self.assertRaises(ValueError):
+                        pjr.rhealpix_sphere_inverse(float(bx), float(by), **kw)
+                    x = np.concatenate([good[0][:5], [bx]])
+                    y = np.concatenate([good[1][:5], [by]])
+                    with self.assertRaises(ValueError) as cm:
+                        fn(x, y)
+                    self.assertIn("1 of 6 points", str(cm.exception))
+                    self.assertIn(f"({pair[0]}, {pair[1]})-rHEALPix", str(cm.exception))
+                with self.assertRaises(ValueError):
+                    fn(*NOT_FINITE)
+            # Points the rHEALPix check admits but the HEALPix check rejects
+            # after uncombining raise in both paths.
+            rejected = RHEALPIX_REJECTED[pair]
+            self.assertGreater(len(rejected[0]), 0)
+            with self.assertRaises(ValueError) as cm:
+                pjr._rhealpix_sphere_inverse_array(*rejected, **kw)
+            self.assertIn("HEALPix projection", str(cm.exception))
+            for a, b in zip(*rejected):
+                with self.assertRaises(ValueError):
+                    pjr.rhealpix_sphere_inverse(float(a), float(b), **kw)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

**A seam behaviour worth knowing**, surfaced by the tests: a planar point can pass `in_rhealpix_image` (1e-15 fuzz) yet, once uncombined into HEALPix coordinates, fail `in_healpix_image` (1e-10 fuzz) — e.g. a square's outer corner offset by 1e-10 along the diagonal lands in the notch between two HEALPix triangles. Both the scalar and the array path raise `ValueError` there (the array message names the HEALPix check); the parity test pins that, and the point sets classify seam points by "the scalar inverse accepts it" rather than by the first check alone.
