### PR TITLE
Accept arrays in Projection.__call__ and the DGGS projection methods (issue #88, part 4)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,14 @@ point-in-polygon query, cutting the two checks that every inverse
 projection performs from about 40% of its cost to almost nothing (issue
 #116). The accepted region is unchanged for rHEALPix and differs for
 HEALPix only within the 1e-10 fuzz margin outside the image.
+``RHEALPixDGGS.rhealpix``, ``RHEALPixDGGS.healpix``,
+``projection_wrapper.Projection.__call__`` and the callables returned by
+``pj_healpix.healpix`` and ``pj_rhealpix.rhealpix`` accept numpy arrays
+as well as floats and then project every point in one array pass,
+returning a pair of float64 arrays; scalar calls are unchanged. The
+array path evaluates the same expressions as the scalar one and
+reproduces it to the bit wherever numpy's array and scalar kernels agree
+(issue #88).
 
 0.7.1
 ^^^^^

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -173,7 +173,7 @@ from rhealpixdggs.ellipsoids import (
 )
 
 # my_round is doctest-only: the doctests use it from the module globals.
-from rhealpixdggs.utils import auth_lat, my_round  # noqa: F401
+from rhealpixdggs.utils import FloatArray, auth_lat, my_round  # noqa: F401
 
 
 class RHEALPixDGGS:
@@ -384,16 +384,33 @@ class RHEALPixDGGS:
     def __ne__(self, other: object) -> bool:
         return not self.__eq__(other)
 
-    def healpix(self, u: float, v: float, inverse: bool = False) -> tuple[float, float]:
+    @overload
+    def healpix(
+        self, u: float, v: float, inverse: bool = ...
+    ) -> tuple[float, float]: ...
+
+    @overload
+    def healpix(
+        self, u: FloatArray, v: FloatArray, inverse: bool = ...
+    ) -> tuple[FloatArray, FloatArray]: ...
+
+    def healpix(
+        self, u: float | FloatArray, v: float | FloatArray, inverse: bool = False
+    ) -> tuple[float, float] | tuple[FloatArray, FloatArray]:
         """
         Return the HEALPix projection of point `(u, v)` (or its inverse if
-        `inverse` = True) appropriate to this rHEALPix DGGS.
+        `inverse` = True) appropriate to this rHEALPix DGGS. `u` and `v` may
+        be floats or numpy arrays of a common shape; arrays are projected in
+        one pass and come back as a pair of float64 arrays.
 
         EXAMPLES::
 
             >>> rdggs = UNIT_003_RADIANS
             >>> print(tuple(x.tolist() for x in my_round(rdggs.healpix(-pi, pi/2), 14)))
             (-2.35619449019234, 1.5707963267949)
+            >>> x, y = rdggs.healpix(array([-pi, 0.0]), array([pi/2, 0.0]))
+            >>> print(x.round(14).tolist(), y.round(14).tolist())
+            [-2.35619449019234, 0.0] [1.5707963267949, 0.0]
 
         NOTE:
 
@@ -407,18 +424,39 @@ class RHEALPixDGGS:
         assert result is not None
         return result
 
+    @overload
     def rhealpix(
-        self, u: float, v: float, inverse: bool = False, region: str = "none"
-    ) -> tuple[float, float]:
+        self, u: float, v: float, inverse: bool = ..., region: str = ...
+    ) -> tuple[float, float]: ...
+
+    @overload
+    def rhealpix(
+        self, u: FloatArray, v: FloatArray, inverse: bool = ..., region: str = ...
+    ) -> tuple[FloatArray, FloatArray]: ...
+
+    def rhealpix(
+        self,
+        u: float | FloatArray,
+        v: float | FloatArray,
+        inverse: bool = False,
+        region: str = "none",
+    ) -> tuple[float, float] | tuple[FloatArray, FloatArray]:
         """
         Return the rHEALPix projection of the point `(u, v)` (or its inverse if
-        `inverse` = True) appropriate to this rHEALPix DGGS.
+        `inverse` = True) appropriate to this rHEALPix DGGS. `u` and `v` may
+        be floats or numpy arrays of a common shape; arrays are projected in
+        one pass and come back as a pair of float64 arrays. `region` hints
+        that every point lies in that region of the planar image (see
+        ``pj_rhealpix.rhealpix_ellipsoid``).
 
         EXAMPLES::
 
             >>> rdggs = UNIT_003_RADIANS
             >>> print(tuple(x.tolist() for x in my_round(rdggs.rhealpix(0, pi/3), 14)))
             (-1.858272006684, 2.06871881030324)
+            >>> x, y = rdggs.rhealpix(array([0.0, 0.0]), array([pi/3, 0.0]))
+            >>> print(x.round(14).tolist(), y.round(14).tolist())
+            [-1.858272006684, 0.0] [2.06871881030324, 0.0]
 
         NOTE:
 

--- a/rhealpixdggs/projection_wrapper.py
+++ b/rhealpixdggs/projection_wrapper.py
@@ -18,15 +18,23 @@ By 'ellipsoid' below, I mean an oblate ellipsoid of revolution.
 # *****************************************************************************
 
 import importlib
-from collections.abc import Callable
-from typing import Any
+from typing import Any, overload
 
+import numpy as np
 import pyproj
 
 from rhealpixdggs.ellipsoids import WGS84_ELLIPSOID, Ellipsoid
 
 # my_round is doctest-only: the doctests use it from the module globals.
-from rhealpixdggs.utils import my_round, wrap_latitude, wrap_longitude  # noqa: F401
+from rhealpixdggs.utils import (  # noqa: F401
+    FloatArray,
+    ProjectionFunction,
+    _wrap_latitude_array,
+    _wrap_longitude_array,
+    my_round,
+    wrap_latitude,
+    wrap_longitude,
+)
 
 # Homemade map projections, as opposed to those in the PROJ.4 library.
 # Remove 'healpix' and 'rhealpix' to use the PROJ.4 versions instead,
@@ -85,7 +93,7 @@ class Projection:
         # attributes this depends on) never change after construction, so
         # the underlying projection callable only ever needs to be built
         # once, no matter how many times __call__() is invoked.
-        self._f: Callable[..., tuple[float, float]] | pyproj.Proj | None = None
+        self._f: ProjectionFunction | pyproj.Proj | None = None
 
     def __str__(self) -> str:
         result = ["map projection:"]
@@ -96,7 +104,7 @@ class Projection:
             result.append(" " * 8 + k + " = " + str(v))
         return "\n".join(result)
 
-    def _get_f(self) -> Callable[..., tuple[float, float]] | pyproj.Proj | None:
+    def _get_f(self) -> ProjectionFunction | pyproj.Proj | None:
         """
         Return the underlying f(u, v, radians=False, inverse=False)
         callable for this projection, building it on first use and
@@ -121,9 +129,29 @@ class Projection:
                 self._f = pyproj.Proj(proj=self.proj, a=a, e=e, **self.kwargs)
         return self._f
 
+    @overload
     def __call__(
-        self, u: float, v: float, inverse: bool = False
-    ) -> tuple[float, float] | None:
+        self, u: float, v: float, inverse: bool = ...
+    ) -> tuple[float, float] | None: ...
+
+    @overload
+    def __call__(
+        self, u: FloatArray, v: FloatArray, inverse: bool = ...
+    ) -> tuple[FloatArray, FloatArray] | None: ...
+
+    @overload
+    def __call__(
+        self, u: float | FloatArray, v: float | FloatArray, inverse: bool = ...
+    ) -> tuple[float, float] | tuple[FloatArray, FloatArray] | None: ...
+
+    def __call__(
+        self, u: float | FloatArray, v: float | FloatArray, inverse: bool = False
+    ) -> tuple[float, float] | tuple[FloatArray, FloatArray] | None:
+        """
+        Project the point `(u, v)`, or invert it if `inverse` = True. `u` and
+        `v` may be floats or numpy arrays of a common shape; arrays are
+        projected in one pass and come back as a pair of float64 arrays.
+        """
         ellipsoid = self.ellipsoid
         lon_0 = ellipsoid.lon_0
         lat_0 = ellipsoid.lat_0
@@ -131,6 +159,23 @@ class Projection:
         f = self._get_f()
         if f is None:
             return None
+        if isinstance(u, np.ndarray) or isinstance(v, np.ndarray):
+            u_arr, v_arr = np.broadcast_arrays(
+                np.asarray(u, dtype=np.float64), np.asarray(v, dtype=np.float64)
+            )
+            if not inverse:
+                lam_arr = _wrap_longitude_array(u_arr - lon_0, radians=radians)
+                phi_arr = _wrap_latitude_array(v_arr - lat_0, radians=radians)
+                x, y = f(lam_arr, phi_arr, radians=radians)
+                return np.asarray(x, dtype=np.float64), np.asarray(y, dtype=np.float64)
+            lam_arr, phi_arr = f(u_arr, v_arr, radians=radians, inverse=True)
+            lam_arr = _wrap_longitude_array(
+                np.asarray(lam_arr, dtype=np.float64) + lon_0, radians=radians
+            )
+            phi_arr = _wrap_latitude_array(
+                np.asarray(phi_arr, dtype=np.float64) + lat_0, radians=radians
+            )
+            return lam_arr, phi_arr
         if not inverse:
             # Translate longitudes and latitudes so that
             # (lon_0, lat_0) maps to (0, 0) in the plane.

--- a/tests/test_projection_wrapper.py
+++ b/tests/test_projection_wrapper.py
@@ -6,6 +6,9 @@ Keep adding tests!
 
 import unittest
 
+import numpy as np
+from numpy.testing import assert_allclose
+
 from rhealpixdggs.ellipsoids import (
     WGS84_ELLIPSOID,
     WGS84_ELLIPSOID_RADIANS,
@@ -107,6 +110,86 @@ class MyTestCase(unittest.TestCase):
         self.assertIsNotNone(cached)
         p(0, 0.1)
         p(0.2, -0.1, inverse=True)
+        self.assertIs(p._f, cached)
+
+    def test_array_inputs_match_scalar_calls(self):
+        # Arrays go through the array path and must agree with a scalar call
+        # per point, forward and inverse, in both angle modes.
+        for ellipsoid, points, atol_angle in (
+            (
+                WGS84_ELLIPSOID,
+                [(0, 0), (30, 45), (-120, -60), (170, 80), (-180, 0)],
+                1e-12,
+            ),
+            (
+                WGS84_ELLIPSOID_RADIANS,
+                [(0.5, 0.7), (-2.0, -1.0), (3.0, 1.4), (-3.1, 0.0)],
+                1e-14,
+            ),
+        ):
+            for proj, kwargs in [
+                ("healpix", {}),
+                ("rhealpix", {"north_square": 1, "south_square": 2}),
+            ]:
+                f = Projection(ellipsoid=ellipsoid, proj=proj, **kwargs)
+                u = np.array([p[0] for p in points], dtype=float)
+                v = np.array([p[1] for p in points], dtype=float)
+                x, y = f(u, v)
+                self.assertEqual((x.dtype, y.dtype), (np.float64, np.float64))
+                scalar = [f(*p) for p in points]
+                assert_allclose(x, [q[0] for q in scalar], rtol=0, atol=1e-8)
+                assert_allclose(y, [q[1] for q in scalar], rtol=0, atol=1e-8)
+                lam, phi = f(x, y, inverse=True)
+                back = [f(*q, inverse=True) for q in scalar]
+                assert_allclose(lam, [b[0] for b in back], rtol=0, atol=atol_angle)
+                assert_allclose(phi, [b[1] for b in back], rtol=0, atol=atol_angle)
+                # A scalar mixed with an array broadcasts.
+                x2, _ = f(u, np.float64(points[1][1]) + np.zeros(len(points)))
+                self.assertEqual(x2.shape, (len(points),))
+
+    def test_array_round_trip(self):
+        rng = np.random.default_rng(20260811)
+        lon = rng.uniform(-180, 180, 500)
+        lat = np.degrees(np.arcsin(rng.uniform(-1, 1, 500)))
+        f = Projection(ellipsoid=WGS84_ELLIPSOID, proj="rhealpix", north_square=2)
+        x, y = f(lon, lat)
+        lon2, lat2 = f(x, y, inverse=True)
+        assert_allclose(lon2, lon, rtol=0, atol=1e-9)
+        assert_allclose(lat2, lat, rtol=0, atol=1e-9)
+
+    def test_pyproj_backed_projection_accepts_arrays(self):
+        f = Projection(ellipsoid=WGS84_ELLIPSOID, proj="cea")
+        lon = np.array([0.0, 30.0, -120.0])
+        lat = np.array([0.0, 45.0, -60.0])
+        x, y = f(lon, lat)
+        self.assertIsInstance(x, np.ndarray)
+        lon2, lat2 = f(x, y, inverse=True)
+        assert_allclose(lon2, lon, rtol=0, atol=1e-6)
+        assert_allclose(lat2, lat, rtol=0, atol=1e-6)
+
+    def test_ellipsoid_origin_translation_arrays(self):
+        # The recentring on (lon_0, lat_0) and the wrap back into range apply
+        # elementwise; a longitude that crosses the antimeridian after the
+        # shift wraps exactly as the scalar call does.
+        E = Ellipsoid(a=WGS84_ELLIPSOID.a, f=WGS84_ELLIPSOID.f, lon_0=50, lat_0=0)
+        f = Projection(ellipsoid=E, proj="rhealpix", north_square=0, south_square=0)
+        x, y = f(np.array([50.0, -170.0]), np.array([0.0, 20.0]))
+        self.assertEqual((x[0], y[0]), (0.0, 0.0))
+        self.assertEqual((x[1], y[1]), f(-170.0, 20.0))
+        lon, lat = f(np.array([0.0, x[1]]), np.array([0.0, y[1]]), inverse=True)
+        self.assertEqual((lon[0], lat[0]), (50.0, 0.0))
+        self.assertEqual((lon[1], lat[1]), f(x[1], y[1], inverse=True))
+
+    def test_unimplemented_homemade_projection_returns_none_for_arrays(self):
+        f = Projection(ellipsoid=WGS84_ELLIPSOID, proj="isea")
+        self.assertIsNone(f(np.array([0.0]), np.array([0.0])))
+
+    def test_underlying_callable_is_shared_by_scalar_and_array_calls(self):
+        p = Projection(ellipsoid=WGS84_ELLIPSOID, proj="rhealpix")
+        p(np.array([0.0]), np.array([0.0]))
+        cached = p._f
+        p(0, 0.1)
+        p(np.array([0.2]), np.array([-0.1]), inverse=True)
         self.assertIs(p._f, cached)
 
 


### PR DESCRIPTION
Part 4 of 7 for #88. **Stacked on #125** (base `vectorise-rhealpix`); retarget as the stack merges. This is the first user-visible step, so the 0.8.0 changelog gains its #88 entry here.

**`Projection.__call__`** dispatches on `isinstance(u, ndarray) or isinstance(v, ndarray)`: the array branch broadcasts the inputs, applies the `lon_0`/`lat_0` shift and wrapping elementwise via the array wrap helpers from part 1, and calls the underlying projection once on the whole batch — the homemade closures take their array bodies (parts 2–3); pyproj's `Proj` already accepts arrays and passes straight through. The scalar branch is unchanged. `_f` is typed `ProjectionFunction | pyproj.Proj | None`, and the `None` degradation for unimplemented homemade names applies to array calls too.

**`RHEALPixDGGS.healpix` / `.rhealpix`** forward arrays through the same per-region `Projection` cache; only their annotations and docstrings change (each gains one array doctest). All three callables carry `@overload`s for the scalar and array cases plus a union-typed variant so pass-through callers type-check under `disallow_untyped_defs`.

**Tests** (`tests/test_projection_wrapper.py`): array results equal per-point scalar calls forward and inverse, both angle modes, both homemade projections (`atol` 1e-8 m / 1e-12°); 500-point round trip; pyproj-backed `cea` with arrays; `lon_0=50` recentring and antimeridian wrap on arrays equal the scalar results exactly; `None` for `isea` with arrays; the cached callable is shared by scalar and array calls. Suite: 158 tests, ~27 s (the part-3 array module is ~16 s of that).

**Contract, as documented in the docstrings**: `u`, `v` floats or arrays of a common shape; arrays come back as a pair of float64 arrays; `region` stays a per-call hint. Callers are converted in parts 5–7; nothing in the package uses the array path yet, so no behaviour changes for existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
