### PR TITLE
Project cell boundaries, interiors and quad centroids as arrays (issue #88, part 5)

### DIFF
--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -11,8 +11,8 @@ if TYPE_CHECKING:
     from rhealpixdggs.dggs import RHEALPixDGGS
 
 # pi is doctest-only: the doctests use it from the module globals.
+import numpy as np
 from numpy import base_repr, pi  # noqa: F401
-from numpy import vectorize as numpy_vectorize
 from scipy import integrate
 
 from rhealpixdggs.utils import wrap_longitude
@@ -900,17 +900,17 @@ class Cell:
             i = (n - 1) * i  # Index of northwest vertex in result.
             result = result[i:] + result[:i]
             # Project to ellipsoid.
-            region = self.region()
-            result = [
-                self.rdggs.rhealpix(*p, inverse=True, region=region) for p in result
-            ]
+            xs = np.array([p[0] for p in result])
+            ys = np.array([p[1] for p in result])
+            lons, lats = self.rdggs.rhealpix(xs, ys, inverse=True, region=self.region())
+            return list(zip(lons, lats))
         return result
 
     def _quad_boundary(self, n: int, eps: float) -> list[tuple[float, float]]:
         """
         Return ``boundary(n, plane=False)`` for this quad cell, its planar
-        square shrunk inward by `eps`, projecting only the four corners and
-        the interior points of the west and north edges. See ``boundary()``.
+        square shrunk inward by `eps`, projecting only the north and west
+        edges in one array call. See ``boundary()``.
         """
         ul = self.ul_vertex(plane=True)
         w = self.width(plane=True)
@@ -919,15 +919,24 @@ class Cell:
         delta = (w - 2 * eps) / (n - 1)
         region = self.region()
 
-        def project(x: float, y: float) -> tuple[float, float]:
-            return self.rdggs.rhealpix(x, y, inverse=True, region=region)
-
-        nw = project(x_west, y_north)
-        ne = project(x_east, y_north)
-        se = project(x_east, y_south)
-        sw = project(x_west, y_south)
-        lats = [project(x_west, y_north - j * delta)[1] for j in range(1, n - 1)]
-        lons = [project(x_west + j * delta, y_north)[0] for j in range(1, n - 1)]
+        # One batch: the north edge west to east (n points, ending exactly at
+        # x_east), then the west edge below the north-west corner (n - 1
+        # points, ending exactly at y_south).
+        xs = np.concatenate(
+            [x_west + delta * np.arange(n - 1), [x_east], np.full(n - 1, x_west)]
+        )
+        ys = np.concatenate(
+            [np.full(n, y_north), y_north - delta * np.arange(1, n - 1), [y_south]]
+        )
+        all_lons, all_lats = self.rdggs.rhealpix(xs, ys, inverse=True, region=region)
+        lons = list(all_lons[1 : n - 1])
+        lats = list(all_lats[n:-1])
+        nw = (all_lons[0], all_lats[0])
+        ne = (all_lons[n - 1], all_lats[n - 1])
+        sw = (all_lons[-1], all_lats[-1])
+        # Longitude depends only on x and latitude only on y in the
+        # equatorial region, so the south-east corner needs no projection.
+        se = (ne[0], sw[1])
         return (
             [nw]
             + [(lon, nw[1]) for lon in lons]
@@ -973,23 +982,27 @@ class Cell:
         w = self.width(plane=True)
         eps = 1e-6
         delta = (w - 2 * eps) / (n - 1)
-
-        def g(x: float, y: float) -> tuple[float, float]:
-            if plane:
-                return (x, y)
-            else:
-                return self.rdggs.rhealpix(x, y, inverse=True)
-
-        if flatten:
+        if plane:
+            if flatten:
+                return [
+                    (ul[0] + eps + delta * j, ul[1] - eps - delta * i)
+                    for j in range(n)
+                    for i in range(n)
+                ]
             return [
-                g(ul[0] + eps + delta * j, ul[1] - eps - delta * i)
-                for j in range(n)
+                [(ul[0] + eps + delta * j, ul[1] - eps - delta * i) for j in range(n)]
                 for i in range(n)
             ]
-        return [
-            [g(ul[0] + eps + delta * j, ul[1] - eps - delta * i) for j in range(n)]
-            for i in range(n)
-        ]
+        # Project the whole grid in one call; row i, column j is (lons[i, j],
+        # lats[i, j]). The flattened order is column-major, as it always was.
+        xs, ys = np.meshgrid(
+            ul[0] + eps + delta * np.arange(n), ul[1] - eps - delta * np.arange(n)
+        )
+        lons, lats = self.rdggs.rhealpix(xs.ravel(), ys.ravel(), inverse=True)
+        lons, lats = lons.reshape(n, n), lats.reshape(n, n)
+        if flatten:
+            return [(lons[i, j], lats[i, j]) for j in range(n) for i in range(n)]
+        return [[(lons[i, j], lats[i, j]) for j in range(n)] for i in range(n)]
 
     def contains(self, p: tuple[float, float], plane: bool = True) -> bool:
         """
@@ -1235,7 +1248,10 @@ class Cell:
             # collide with the projection stack's floating-point noise
             # floor and trigger spurious IntegrationWarnings.
             x_mid = self.nucleus(plane=True)[0]
-            phi_of_y = numpy_vectorize(lambda y: phi(x_mid, y))
+
+            def phi_of_y(ys: np.ndarray) -> np.ndarray:
+                return self.rdggs.rhealpix(np.full_like(ys, x_mid), ys, inverse=True)[1]
+
             phi_bar = float(
                 (1 / (y2 - y1)) * integrate.fixed_quad(phi_of_y, y1, y2, n=20)[0]
             )

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -2,6 +2,7 @@ import unittest
 from itertools import pairwise, product
 from math import pi
 
+import numpy as np
 from scipy.spatial.distance import euclidean, norm
 
 from rhealpixdggs.cell import CELLS0, Cell
@@ -509,8 +510,9 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         self.assertTrue(all(0 < step < 90 for step in steps), steps)
         self.assertTrue(all(-180 <= p[0] < 180 for p in north_edge))
 
-        # Only the corners and the west and north edges are projected, and
-        # every returned coordinate is one of the projection's outputs.
+        # Only the north and west edges are projected (2n - 1 points in one
+        # call), and every returned coordinate is one of the projection's
+        # outputs.
         outputs = []
         rdggs = WGS84_003
         inner = rdggs.rhealpix
@@ -524,10 +526,13 @@ class SCENZGridCELLTestCase(unittest.TestCase):
             b = rdggs.cell((P, 4)).boundary(n=10, plane=False)
         finally:
             del rdggs.__dict__["rhealpix"]
-        self.assertEqual(len(outputs), 2 * 10)
-        lons = {p[0] for p in outputs}
-        lats = {p[1] for p in outputs}
+        self.assertEqual(len(outputs), 1)
+        lons = set(np.atleast_1d(outputs[0][0]).tolist())
+        lats = set(np.atleast_1d(outputs[0][1]).tolist())
+        self.assertEqual(len(lons) + len(lats), 2 * 10 - 1 + 1)  # x_west repeats
+        self.assertEqual(np.size(outputs[0][0]), 2 * 10 - 1)
         self.assertTrue(all(p[0] in lons and p[1] in lats for p in b))
+        self.assertTrue(all(isinstance(v, np.float64) for p in b for v in p))
 
     def test_boundary_quad_neighbors_share_points(self):
         # Adjacent quad cells' copies of their shared edge points are

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -18,6 +18,7 @@ import itertools
 import unittest
 from random import randint  # , uniform
 
+import numpy as np
 from numpy import array, pi
 
 # import rhealpixdggs.dggs as dggs
@@ -359,7 +360,8 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
                 self.count = 0
 
             def __call__(self, *args, **kwargs):
-                self.count += 1
+                # Count projected points, whether passed singly or as arrays.
+                self.count += np.size(args[0])
                 return self.inner(*args, **kwargs)
 
         for face, ratio in ((N, 0.6), (P, 0.15)):


### PR DESCRIPTION
Part 5 of 7 for #88. **Stacked on #126** (base `vectorise-wrapper`); retarget as the stack merges.

First callers on the array path, all in `cell.py`:

- **`Cell.boundary`** general path (dart, skew quad, cap): the `4n − 4` planar points go through one `rhealpix(xs, ys, inverse=True, region=…)` call; the result is `list(zip(lons, lats))`, so elements stay `np.float64` and every doctest's `.tolist()` still works.
- **`Cell._quad_boundary`**: one batch of `2n − 1` points — the north edge west→east, then the west edge below the NW corner. The last north-edge x is exactly `x_east` and the last west-edge y exactly `y_south` (not `x_west + (n−1)·δ`), so horizontal and vertical quad neighbours keep bit-identical shared points; the SE corner is `(ne.lon, sw.lat)`, which is exactly what projecting it returns because the equatorial inverse is separable. Every returned coordinate is still a projection output (pinned).
- **`Cell.interior`**: `meshgrid` → one call → reshape; the column-major `flatten=True` order is preserved.
- **`Cell.centroid`** (quad): `fixed_quad`'s 20 abscissae go to the projection as an array instead of through `numpy.vectorize`.
- `vertices(plane=False)` stays scalar: four points are under the array path's break-even.

**Tests**: the recorder in `test_boundary_quad_direct` now flattens array outputs, pins one call of `2n − 1` points and `np.float64` elements; `CountingProjection` in `test_cell_boundaries` counts projected points (`np.size(args[0])`) so its ratios keep their meaning (per-cell quads now project 7 points per cell at n=4 against the batch API's 55 for the block, ratio 0.10 < 0.15). The neighbour bit-identity tests and the 1e-12 agreement with per-point projection are unchanged and pass; under `RHP_STRICT_BITS=1` everything array-related is exact on this machine. Suite: 158 tests, ~29 s.

**Benchmark** (same machine, best of 3, `plane=False`):

| | master | branch |
|---|---|---|
| quad `boundary(n=10)` | 243 µs | 187 µs |
| dart `boundary(n=10)` | 996 µs | 508 µs |
| skew `boundary(n=10)` | 976 µs | 367 µs |
| dart `boundary(n=40)` | 3910 µs | 585 µs |
| quad `interior(n=5)` | 325 µs | 290 µs |
| dart `interior(n=5)` | 641 µs | 403 µs |
| quad `centroid` | 321 µs | 321 µs |
| res 2, 486 cells, per-cell `boundary(10)` | 243 ms | 129 ms |
| res 3, 4374 cells, per-cell `boundary(10)` | 2.20 s | 1.16 s |
| res 3, `cell_boundaries(10)` (unchanged until part 6) | 0.88 s | 0.93 s |

The quad centroid did not move: its 20-point quadrature was already cheap next to the rest of `centroid`. Dart boundaries keep the 4 scalar projections of `nw_vertex` (#122 tracks removing them).

**Docs figures**: the plan calls for regenerating `docs/make_figures.py` output and checking `git status` is clean. matplotlib (the `figures` Poetry group) is not installed in this environment, so that check is still to be run; on this machine the array path is bit-identical to the scalar one, so no diff is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
