### PR TITLE
Project cell_boundaries in one array call per resolution and region (issue #88, part 6)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,7 +32,9 @@ as well as floats and then project every point in one array pass,
 returning a pair of float64 arrays; scalar calls are unchanged. The
 array path evaluates the same expressions as the scalar one and
 reproduces it to the bit wherever numpy's array and scalar kernels agree
-(issue #88).
+(issue #88). ``Cell.boundary``, ``Cell.interior`` and
+``RHEALPixDGGS.cell_boundaries`` project their points that way, the last
+in one call per resolution and region.
 
 0.7.1
 ^^^^^

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -1495,15 +1495,16 @@ class RHEALPixDGGS:
         edges along those parallels are computed per region, exactly as
         ``boundary()`` computes them.
 
-        In the equatorial region the inverse projection is separable
-        (longitude depends only on `x`, latitude only on `y`), so there
-        each projected point also yields the longitude of every other
-        point in its column and the latitude of every other point in its
-        row. The number of projections for a block of equatorial cells
-        thus grows with the block's perimeter rather than its area, every
-        coordinate is still one the projection computed rather than an
-        interpolation, and all points in one lattice column (or row)
-        share one longitude (or latitude) value across the whole block.
+        The distinct points of all the cells are projected in one array
+        call per resolution and region. In the equatorial region the
+        inverse projection is separable (longitude depends only on `x`,
+        latitude only on `y`), so that call holds one point per distinct
+        lattice column and one per distinct row: the number of projected
+        points for a block of equatorial cells grows with the block's
+        perimeter rather than its area, every coordinate is still one the
+        projection computed rather than an interpolation, and all points in
+        one lattice column (or row) share one longitude (or latitude) value
+        across the whole block.
 
         `cells` may mix resolutions; sharing happens per resolution.
         For `plane` = True there is no projection work to share and this
@@ -1524,10 +1525,12 @@ class RHEALPixDGGS:
         R = self.ellipsoid.R_A
         x_anchor = -pi * R
         y_anchor = -3 * pi * R / 4
-        cache: dict[tuple[int | None, str, int, int], tuple[float, float]] = {}
-        lons: dict[tuple[int | None, int], float] = {}
-        lats: dict[tuple[int | None, int], float] = {}
-        result = {}
+        # Pass 1: gather every cell's lattice keys, keeping the first planar
+        # coordinates seen for each distinct key.
+        gathered: list[tuple[Cell, str, int | None, list[tuple[int, int]]]] = []
+        eq_cols: dict[tuple[int | None, int], tuple[float, float]] = {}
+        eq_rows: dict[tuple[int | None, int], tuple[float, float]] = {}
+        polar: dict[tuple[int | None, str, int, int], tuple[float, float]] = {}
         for cell in cells:
             # The same planar points, in the same order, as
             # cell.boundary(n=n, plane=False) computes: the planar
@@ -1538,31 +1541,63 @@ class RHEALPixDGGS:
             i = (n - 1) * v.index(nw)
             planar = planar[i:] + planar[:i]
             region = cell.region()
+            resolution = cell.resolution
             # All of this cell's boundary points lie on the fine lattice
             # of pitch w/(n - 1) anchored at the planar image's corner,
             # shared with every same-resolution neighbor's points, so an
             # integer lattice key identifies coincident points robustly.
             pitch = cell.width(plane=True) / (n - 1)
-            points = []
+            keys = []
             for p in planar:
                 col = round((p[0] - x_anchor) / pitch)
                 row = round((p[1] - y_anchor) / pitch)
+                keys.append((col, row))
                 if region == "equatorial":
-                    lon_key = (cell.resolution, col)
-                    lat_key = (cell.resolution, row)
-                    if lon_key not in lons or lat_key not in lats:
-                        lon, lat = self.rhealpix(
-                            p[0], p[1], inverse=True, region=region
-                        )
-                        lons.setdefault(lon_key, lon)
-                        lats.setdefault(lat_key, lat)
-                    points.append((lons[lon_key], lats[lat_key]))
-                    continue
-                key = (cell.resolution, region, col, row)
-                if key not in cache:
-                    cache[key] = self.rhealpix(p[0], p[1], inverse=True, region=region)
-                points.append(cache[key])
-            result[cell] = points
+                    eq_cols.setdefault((resolution, col), p)
+                    eq_rows.setdefault((resolution, row), p)
+                else:
+                    polar.setdefault((resolution, region, col, row), p)
+            gathered.append((cell, region, resolution, keys))
+        # Pass 2: one projection call per resolution and region. In the
+        # equatorial region longitude depends only on x and latitude only
+        # on y, so one point per distinct column and one per distinct row
+        # suffice.
+        lon_of: dict[tuple[int | None, int], float] = {}
+        lat_of: dict[tuple[int | None, int], float] = {}
+        for resolution in {k[0] for k in eq_cols}:
+            col_keys = [k for k in eq_cols if k[0] == resolution]
+            row_keys = [k for k in eq_rows if k[0] == resolution]
+            points = [eq_cols[k] for k in col_keys] + [eq_rows[k] for k in row_keys]
+            lons, lats = self.rhealpix(
+                array([p[0] for p in points]),
+                array([p[1] for p in points]),
+                inverse=True,
+                region="equatorial",
+            )
+            lon_of.update(zip(col_keys, lons[: len(col_keys)]))
+            lat_of.update(zip(row_keys, lats[len(col_keys) :]))
+        polar_of: dict[tuple[int | None, str, int, int], tuple[float, float]] = {}
+        for resolution, region in {k[:2] for k in polar}:
+            keys_in_group = [k for k in polar if k[:2] == (resolution, region)]
+            lons, lats = self.rhealpix(
+                array([polar[k][0] for k in keys_in_group]),
+                array([polar[k][1] for k in keys_in_group]),
+                inverse=True,
+                region=region,
+            )
+            polar_of.update(zip(keys_in_group, zip(lons, lats)))
+        # Pass 3: assemble each cell's boundary from the shared values.
+        result = {}
+        for cell, region, resolution, keys in gathered:
+            if region == "equatorial":
+                result[cell] = [
+                    (lon_of[(resolution, col)], lat_of[(resolution, row)])
+                    for col, row in keys
+                ]
+            else:
+                result[cell] = [
+                    polar_of[(resolution, region, col, row)] for col, row in keys
+                ]
         return result
 
     def cells_from_region(

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -358,10 +358,12 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
             def __init__(self, inner):
                 self.inner = inner
                 self.count = 0
+                self.calls = 0
 
             def __call__(self, *args, **kwargs):
                 # Count projected points, whether passed singly or as arrays.
                 self.count += np.size(args[0])
+                self.calls += 1
                 return self.inner(*args, **kwargs)
 
         for face, ratio in ((N, 0.6), (P, 0.15)):
@@ -373,11 +375,18 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
                     c.boundary(n=4, plane=False)
                 per_cell_calls = counter.count
                 counter.count = 0
+                counter.calls = 0
                 boundaries = rdggs.cell_boundaries(block, n=4, plane=False)
                 batched_calls = counter.count
+                batched_invocations = counter.calls
             finally:
                 del rdggs.__dict__["rhealpix"]
             self.assertLess(batched_calls, ratio * per_cell_calls, face)
+            # One resolution and one region: a single array call, plus the
+            # four scalar projections nw_vertex makes per dart cell while
+            # the planar boundaries are gathered (issue #122).
+            darts = sum(c.ellipsoidal_shape == "dart" for c in block)
+            self.assertEqual(batched_invocations, 1 + 4 * darts, face)
 
         # In the equatorial region the batch exploits the projection's
         # separability: every point in one lattice column gets one


### PR DESCRIPTION
Part 6 of 7 for #88. **Stacked on #127** (base `vectorise-cell-callers`); retarget as the stack merges.

`RHEALPixDGGS.cell_boundaries` becomes gather → project → scatter:

1. **Gather**: for each cell, the planar boundary (reordered to the NW vertex, as before) and its lattice keys `(col, row)`; the first planar coordinates seen for each distinct key are kept — per `(resolution, col)` and `(resolution, row)` for equatorial cells, per `(resolution, region, col, row)` for polar cells.
2. **Project**: one `rhealpix(xs, ys, inverse=True, region=…)` call per resolution and region. The equatorial call holds one point per distinct column plus one per distinct row (longitude depends only on x, latitude only on y), so its size grows with the block's perimeter rather than its area; polar calls hold each distinct point once.
3. **Scatter**: each cell's boundary is assembled from the shared values.

Values are unchanged from the previous per-point memo: every coordinate is a projection output, all points in a lattice column or row share one value across the whole block, and adjacent cells share identical points. The docstring describes the new mechanism; the existing agreement test against `boundary()` (`atol=1e-9`), the shared-point identity test and the 28-column/28-row identity test all pass unchanged.

**Tests**: `CountingProjection` also counts invocations; the block test asserts a single array call per (resolution, region), plus the four scalar projections `nw_vertex` still makes per dart cell while gathering planar boundaries (#122 tracks removing those). Point-count ratios unchanged.

**Benchmark** (same machine, `n=10`, `plane=False`):

| | master | branch |
|---|---|---|
| res 2, 486 cells | 117 ms | 33 ms |
| res 3, 4374 cells | 1.00 s | 0.24 s |
| res 4, 39366 cells | 8.7 s | 3.0 s |

Against the 0.7.1 release (32.5 s at res 4), the batch API is now ~11× faster. What remains is Python bookkeeping (planar boundaries and lattice keys per cell) plus the `nw_vertex` scalar projections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
