### PR TITLE
Project polygons once in get_finest_containing_cell; add the benchmark script (issue #88, part 7)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,9 +32,12 @@ as well as floats and then project every point in one array pass,
 returning a pair of float64 arrays; scalar calls are unchanged. The
 array path evaluates the same expressions as the scalar one and
 reproduces it to the bit wherever numpy's array and scalar kernels agree
-(issue #88). ``Cell.boundary``, ``Cell.interior`` and
-``RHEALPixDGGS.cell_boundaries`` project their points that way, the last
-in one call per resolution and region.
+(issue #88). ``Cell.boundary``, ``Cell.interior``,
+``RHEALPixDGGS.cell_boundaries`` and
+``conversion.get_finest_containing_cell`` project their points that way,
+the batch API in one call per resolution and region. ``scripts/benchmark.py``
+times the projection and the cell geometry it drives, for comparing two
+checkouts.
 
 0.7.1
 ^^^^^

--- a/docs/source/pj_healpix.rst
+++ b/docs/source/pj_healpix.rst
@@ -12,6 +12,16 @@ The pj_healpix Module
     healpix_sphere_inverse
     in_healpix_image
 
+Array inputs
+------------
+
+The callable returned by ``healpix`` accepts numpy arrays as well as floats:
+pass two arrays of a common shape and every point is projected (or
+inverted) in one array pass, returning a pair of float64 arrays. Scalar
+calls are unchanged. If any point of an inverse batch lies outside the
+projection's image the whole call raises ``ValueError``, naming the count
+and the first offending point.
+
 .. automodule:: rhealpixdggs.pj_healpix
     :members:
     :undoc-members:

--- a/docs/source/pj_rhealpix.rst
+++ b/docs/source/pj_rhealpix.rst
@@ -14,6 +14,16 @@ The pj_rhealpix Module
     rhealpix_sphere_inverse
     triangle
 
+Array inputs
+------------
+
+The callable returned by ``rhealpix`` accepts numpy arrays as well as floats:
+pass two arrays of a common shape and every point is projected (or
+inverted) in one array pass, returning a pair of float64 arrays. Scalar
+calls are unchanged. If any point of an inverse batch lies outside the
+projection's image the whole call raises ``ValueError``, naming the count
+and the first offending point.
+
 .. automodule:: rhealpixdggs.pj_rhealpix
     :members:
     :undoc-members:

--- a/docs/source/projection_wrapper.rst
+++ b/docs/source/projection_wrapper.rst
@@ -7,6 +7,15 @@ The projection_wrapper Module
 
     Projection
 
+Array inputs
+------------
+
+``Projection.__call__`` accepts numpy arrays as well as floats: the
+``lon_0``/``lat_0`` recentring and the longitude and latitude wrapping
+apply elementwise and the underlying projection runs once on the whole
+batch, returning a pair of float64 arrays. ``RHEALPixDGGS.rhealpix`` and
+``RHEALPixDGGS.healpix`` pass arrays straight through.
+
 .. automodule:: rhealpixdggs.projection_wrapper
     :members:
     :undoc-members:

--- a/rhealpixdggs/conversion.py
+++ b/rhealpixdggs/conversion.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 from itertools import compress
 from typing import TextIO
 
+import numpy as np
 from shapely.geometry import MultiPolygon, Point, Polygon
 
 from rhealpixdggs.cell import Cell
@@ -14,21 +15,22 @@ def get_finest_containing_cell(
     """
     Finds the finest DGGS Cell containing a given cartesian polygon
     """
+    # Cap cells span all longitudes at the pole, so their boundary cannot be
+    # represented as a simple polygon in geographic coordinates; containment
+    # is tested in the rHEALPix plane instead. Project the polygon there
+    # once, each part's ring in one array call. (MultiPolygon has no
+    # .exterior; check each part individually.)
+    parts = list(polygon.geoms) if hasattr(polygon, "geoms") else [polygon]
+    planar_parts = []
+    for part in parts:
+        coords = np.asarray(part.exterior.coords)
+        x, y = rdggs.rhealpix(coords[:, 0], coords[:, 1])
+        planar_parts.append(Polygon(np.column_stack([x, y])))
 
     def _cell_contains(cell: Cell, poly: Polygon | MultiPolygon) -> bool:
-        # Cap cells span all longitudes at the pole, so their boundary cannot
-        # be represented as a simple polygon in geographic coordinates.
-        # Project both sides to the rHEALPix plane and test containment there.
         if cell.ellipsoidal_shape == "cap":
             plane_cell = Polygon(cell.vertices(plane=True))
-            # MultiPolygon has no .exterior; check each part individually.
-            parts = list(poly.geoms) if hasattr(poly, "geoms") else [poly]
-            return all(
-                plane_cell.contains(
-                    Polygon([rdggs.rhealpix(x, y) for x, y in part.exterior.coords])
-                )
-                for part in parts
-            )
+            return all(plane_cell.contains(part) for part in planar_parts)
         return Polygon(cell.vertices(plane=False)).contains(poly)
 
     def _get_finest_cell(

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,154 @@
+"""
+Time the projection and the cell geometry built on it.
+
+Usage, comparing a branch against master::
+
+    git worktree add ../rhp-master master
+    python ../rhp-master/scripts/benchmark.py master
+    python scripts/benchmark.py branch
+    git worktree remove ../rhp-master
+
+The script measures the checkout it lives in, whatever package is
+installed. Each run prints one Markdown table; paste the two side by
+side. Timings
+are the best of three repeats. ``--res 4`` adds the 39,366-cell grid
+(tens of seconds per checkout); ``--count`` reports projected points
+instead of time, which is deterministic and machine-independent.
+
+Not part of the test suite: timings on shared CI runners are noise.
+"""
+
+import argparse
+import sys
+import timeit
+from collections.abc import Callable
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from rhealpixdggs.dggs import WGS84_003
+
+
+class PointCounter:
+    """Stand-in for RHEALPixDGGS.rhealpix that counts projected points."""
+
+    def __init__(self, inner: Callable) -> None:
+        self.inner = inner
+        self.points = 0
+
+    def __call__(self, *args, **kwargs):
+        self.points += int(np.size(args[0]))
+        return self.inner(*args, **kwargs)
+
+
+def best_of(fn: Callable[[], object], number: int, repeat: int = 3) -> float:
+    return min(timeit.repeat(fn, number=number, repeat=repeat)) / number
+
+
+def workloads(rdggs, resolutions):
+    quad, dart, skew = rdggs.cell(("P", 4)), rdggs.cell(("N", 0)), rdggs.cell(("N", 1))
+    x_eq, y_eq = rdggs.rhealpix(20.0, 10.0)
+    x_po, y_po = rdggs.rhealpix(20.0, 80.0)
+    rows = [
+        ("forward projection, equatorial", lambda: rdggs.rhealpix(20.0, 10.0), 2000),
+        ("forward projection, polar", lambda: rdggs.rhealpix(20.0, 80.0), 2000),
+        (
+            "inverse projection, equatorial",
+            lambda: rdggs.rhealpix(x_eq, y_eq, inverse=True),
+            2000,
+        ),
+        (
+            "inverse projection, polar",
+            lambda: rdggs.rhealpix(x_po, y_po, inverse=True),
+            2000,
+        ),
+        (
+            "quad boundary(n=10, plane=False)",
+            lambda: quad.boundary(n=10, plane=False),
+            200,
+        ),
+        (
+            "dart boundary(n=10, plane=False)",
+            lambda: dart.boundary(n=10, plane=False),
+            100,
+        ),
+        (
+            "skew boundary(n=10, plane=False)",
+            lambda: skew.boundary(n=10, plane=False),
+            100,
+        ),
+        ("quad vertices(plane=False)", lambda: quad.vertices(plane=False), 500),
+        (
+            "dart interior(n=5, plane=False)",
+            lambda: dart.interior(n=5, plane=False),
+            100,
+        ),
+        ("quad centroid(plane=False)", lambda: quad.centroid(plane=False), 100),
+        ("skew centroid(plane=False)", lambda: skew.centroid(plane=False), 5),
+        ("dart centroid(plane=False)", lambda: dart.centroid(plane=False), 1),
+        (
+            "cell_from_point(plane=False)",
+            lambda: rdggs.cell_from_point(3, (20.0, 80.0), plane=False),
+            500,
+        ),
+    ]
+    for res in resolutions:
+        grid = list(rdggs.grid(res))
+        n = 3 if res <= 2 else 1
+        rows.append(
+            (
+                f"res {res}, {len(grid)} cells, per-cell boundary(n=10)",
+                lambda grid=grid: [c.boundary(n=10, plane=False) for c in grid],
+                n,
+            )
+        )
+        rows.append(
+            (
+                f"res {res}, {len(grid)} cells, cell_boundaries(n=10)",
+                lambda grid=grid: rdggs.cell_boundaries(grid, n=10, plane=False),
+                n,
+            )
+        )
+    return rows
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    parser.add_argument("label", nargs="?", default="this checkout")
+    parser.add_argument(
+        "--res", type=int, nargs="*", default=[2, 3], help="grid resolutions"
+    )
+    parser.add_argument(
+        "--count", action="store_true", help="count projected points, not time"
+    )
+    args = parser.parse_args(argv)
+    rdggs = WGS84_003
+    rows = workloads(rdggs, args.res)
+    unit = "points" if args.count else "time"
+    print(f"| workload | {args.label} ({unit}) |")
+    print("|---|---|")
+    for name, fn, number in rows:
+        if args.count:
+            counter = PointCounter(rdggs.rhealpix)
+            rdggs.rhealpix = counter
+            try:
+                fn()
+            finally:
+                del rdggs.__dict__["rhealpix"]
+            print(f"| {name} | {counter.points} |")
+            continue
+        seconds = best_of(fn, number)
+        if seconds >= 0.1:
+            text = f"{seconds:.2f} s"
+        elif seconds >= 1e-3:
+            text = f"{seconds * 1e3:.1f} ms"
+        else:
+            text = f"{seconds * 1e6:.1f} us"
+        print(f"| {name} | {text} |", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -557,6 +557,30 @@ class ConversionUtilsTestCase(unittest.TestCase):
         assert result is not None, "Expected a cap cell, got None"
         assert str(result) == "N4", f"Expected N4 cap cell, got {result}"
 
+    def test_get_finest_containing_cell_projects_polygon_once(self):
+        # The cap-cell containment test works in the plane; the polygon's
+        # ring is projected once as an array, not once per candidate cell.
+        from shapely.geometry import Polygon as ShapelyPolygon
+
+        from rhealpixdggs.dggs import WGS84_003
+
+        calls = []
+        inner = WGS84_003.rhealpix
+
+        def recording(*a, **k):
+            calls.append((a, k))
+            return inner(*a, **k)
+
+        WGS84_003.rhealpix = recording
+        try:
+            north_poly = ShapelyPolygon([(29, 84), (31, 84), (31, 85), (29, 85)])
+            self.assertEqual(str(get_finest_containing_cell(north_poly)), "N4")
+        finally:
+            del WGS84_003.__dict__["rhealpix"]
+        forward = [a for a, k in calls if not k.get("inverse")]
+        self.assertEqual(len(forward), 1)
+        self.assertEqual(len(forward[0][0]), 5)
+
     def test_CellZoneFromPoly(self):
         """
         Tests correct cells are output for the Geofabric Contracted Catchment 12104622 at resolution 9, without ordering


### PR DESCRIPTION
Part 7 of 7 for #88. **Stacked on #128** (base `vectorise-cell-boundaries`); retarget as the stack merges. Closes #88.

- **`conversion.get_finest_containing_cell`** projects the polygon's rings to the plane once at the top, each ring in one array call, instead of once per candidate cap cell inside the recursive descent. A new test records the projection calls during a cap-region search and asserts exactly one forward call of five points.
- **`scripts/benchmark.py`** (new): scalar forward/inverse projections in both regions (the regression guard for the vectorisation — the scalar path must not slow down), per-call cell geometry (`boundary`, `vertices`, `interior`, `centroid` for the three shapes, `cell_from_point`), and whole-grid per-cell vs `cell_boundaries` at resolutions 2 and 3 (`--res 4` opt-in). `--count` reports projected points instead of times, which is deterministic. It inserts its own checkout on `sys.path`, so `python ../rhp-master/scripts/benchmark.py master` then `python scripts/benchmark.py branch` compares two worktrees regardless of what is installed. Not wired into CI: timings on shared runners are noise.
- **Docs**: "Array inputs" sections on the `pj_healpix`, `pj_rhealpix` and `projection_wrapper` pages (Sphinx build checked locally).
- **Changelog**: the #88 entry now lists the converted callers and the benchmark script.

**Deliberately not done**: `docs/make_figures.py`'s two coastline comprehensions (a ~0.1 s saving in a manually run script) — matplotlib is not installed here, so the change could not be verified against the byte-identical figure requirement; and `Cell.vertices`, `cell_from_point`, `minimal_cover`, `geo_to_rhp`, `cells_from_region` stay scalar by design (one projection per point, or below break-even). Follow-ups #119–#122 hold the remaining opportunities found while planning.

**Whole-series result** (this machine, `n=10`, `plane=False`, resolution 4 = 39,366 cells):

| | v0.7.1 | before #88 (master) | after part 7 |
|---|---|---|---|
| per-cell `boundary` | 48.8 s | 21.3 s | ~11 s |
| `cell_boundaries` | 32.5 s | 8.6 s | 3.0 s |
| dart `boundary(n=40)` | — | 3.9 ms | 0.59 ms |
| scalar inverse projection, equatorial / polar | 23.7 / 42.0 µs | 10.7 / 26.5 µs | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
