### PR TITLE
Clamp the HEALPix cap number to [0, 3] at both ends

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+0.8.1
+^^^^^
+``pj_healpix.healpix_sphere``, ``healpix_sphere_inverse`` and their array
+twins clamp the polar cap number to ``[0, 3]`` at both ends; previously only
+the upper end was clamped, so an input a hair west of ``-pi`` was assigned
+cap ``-1`` and a cap centre one cap too far west. The forward function
+then jumped by ``(pi/2)(1 - sigma)`` (1.24 radians at latitude 1.4) for a
+longitude one ulp below ``-pi``; the inverse could only reach the case
+through the ``1e-10`` image margin, where the trailing longitude clamp
+already hid it. ``in_healpix_image`` was clamping both ends all along, so
+the projection functions now agree with it (issue #119).
+
 0.8.0
 ^^^^^
 ``Ellipsoid`` raises ``ValueError`` for a nonzero ``lat_0``. The parameter

--- a/rhealpixdggs/pj_healpix.py
+++ b/rhealpixdggs/pj_healpix.py
@@ -64,10 +64,11 @@ def _cap_number(lam: FloatArray) -> FloatArray:
     """
     The polar cap (0-3) each longitude or planar x falls in, as
     ``healpix_sphere`` and ``healpix_sphere_inverse`` compute it: floor,
-    clamped from above only.
+    clamped to [0, 3] so that rounding just past -pi or pi stays in the
+    outermost cap rather than jumping a whole cap west or east.
     """
     cap = np.floor(2 * lam / pi + 2)
-    return np.asarray(np.where(cap >= 4, 3.0, cap), dtype=np.float64)
+    return np.asarray(np.clip(cap, 0.0, 3.0), dtype=np.float64)
 
 
 def healpix_sphere(lam: float, phi: float) -> tuple[float, float]:
@@ -94,10 +95,8 @@ def healpix_sphere(lam: float, phi: float) -> tuple[float, float]:
     # Polar region.
     else:
         sigma = sqrt(3 * (1 - abs(sin(phi))))
-        cap_number = floor(2 * lam / pi + 2)
-        if cap_number >= 4:
-            # Rounding error
-            cap_number = 3
+        # Rounding error just past -pi or pi: stay in the outermost cap.
+        cap_number = min(max(floor(2 * lam / pi + 2), 0), 3)
         lamc = -3 * pi / 4 + (pi / 2) * cap_number
         x = lamc + (lam - lamc) * sigma
         y = sign(phi) * pi / 4 * (2 - sigma)
@@ -152,10 +151,9 @@ def healpix_sphere_inverse(x: float, y: float) -> tuple[float, float]:
         phi = arcsin(8 * y / (3 * pi))
     # Polar region but not the poles.
     elif abs(y) < pi / 2:
-        cap_number = floor(2 * x / pi + 2)
-        if cap_number >= 4:
-            # Rounding error.
-            cap_number = 3
+        # Rounding error just past -pi or pi (the image check admits a
+        # 1e-10 margin): stay in the outermost cap.
+        cap_number = min(max(floor(2 * x / pi + 2), 0), 3)
         xc = -3 * pi / 4 + (pi / 2) * cap_number
         tau = 2 - 4 * abs(y) / pi
         lam = xc + (x - xc) / tau

--- a/tests/test_pj_array.py
+++ b/tests/test_pj_array.py
@@ -224,10 +224,13 @@ class HealpixArrayTestCase(unittest.TestCase):
         self.assertFalse(pjh._in_healpix_image_array(*HEALPIX_OUTSIDE).any())
 
     def test_cap_number_matches_scalar(self):
-        for values in (LONLAT[0], HEALPIX_PLANAR[0], HEALPIX_OUTSIDE[0]):
-            want = np.floor(2 * values / pi + 2)
-            want = np.where(want >= 4, 3.0, want)
+        # Clamped to [0, 3] at both ends (issue #119): inputs a hair past
+        # -pi or pi stay in the outermost cap.
+        past_ends = np.array([-pi - 1e-16, -pi - 1e-10, -4.0, pi + 1e-16, 4.0])
+        for values in (LONLAT[0], HEALPIX_PLANAR[0], HEALPIX_OUTSIDE[0], past_ends):
+            want = np.clip(np.floor(2 * values / pi + 2), 0.0, 3.0)
             assert_array_equal(pjh._cap_number(values), want)
+        assert_array_equal(pjh._cap_number(past_ends), [0.0, 0.0, 0.0, 3.0, 3.0])
 
     def test_healpix_sphere_array_matches_scalar(self):
         got = pjh._healpix_sphere_array(*LONLAT)

--- a/tests/test_pj_healpix.py
+++ b/tests/test_pj_healpix.py
@@ -276,6 +276,37 @@ class MyTestCase(unittest.TestCase):
             self.assertFalse(pjh.in_healpix_image(x, y), (x, y))
             self.assertFalse(shapely_in_healpix_image(x, y), (x, y))
 
+    def test_cap_number_clamped_at_minus_pi(self):
+        # Issue #119: the polar cap number is clamped to [0, 3] at both
+        # ends. Before, a longitude or planar x a hair below -pi fell in
+        # cap -1, and the forward function jumped by a whole
+        # (pi/2)(1 - sigma) between lam = -pi and lam = -pi - 1e-15.
+        for phi in (0.8, 1.4, -1.0):
+            x0, y0 = pjh.healpix_sphere(-pi, phi)
+            for d in (1e-16, 1e-12, 1e-10):
+                x, y = pjh.healpix_sphere(-pi - d, phi)
+                self.assertAlmostEqual(x, x0, delta=1e-9, msg=(phi, d))
+                self.assertEqual(y, y0)
+                xa, ya = pjh._healpix_sphere_array(array([-pi - d]), array([phi]))
+                self.assertAlmostEqual(xa[0], x, places=12, msg=(phi, d))
+                self.assertEqual(ya[0], y)
+        # Inverse: the fuzzed (-pi, +/-pi/4) corners, admitted by the
+        # 1e-10 image margin (offsetting both coordinates by d puts the
+        # point 2d outside the triangle edge, so d stays at or below
+        # 5e-11), lie in cap 0, land on lam = -pi exactly and take the
+        # cap-0 latitude, in the scalar and array paths alike.
+        for s in (1, -1):
+            for d in (1e-16, 2e-11, 5e-11):
+                x, y = -pi - d, s * (pi / 4 + d)
+                self.assertTrue(pjh.in_healpix_image(x, y), (x, y))
+                lam, phi = pjh.healpix_sphere_inverse(x, y)
+                self.assertEqual(lam, -pi, (x, y))
+                tau = 2 - 4 * abs(y) / pi
+                self.assertEqual(phi, s * arcsin(1 - tau**2 / 3), (x, y))
+                la, pa = pjh._healpix_sphere_inverse_array(array([x]), array([y]))
+                self.assertEqual(la[0], lam, (x, y))
+                self.assertAlmostEqual(pa[0], phi, places=14, msg=(x, y))
+
     def test_out_of_bounds_raises_value_error(self):
         # Regression test for issue #52: out-of-bounds coordinates used to
         # print an error message and return a sentinel (float("inf"), or


### PR DESCRIPTION
Closes #119. First item of milestone v0.8.1.

## Problem

`healpix_sphere` and `healpix_sphere_inverse` compute the polar cap as `floor(2*x/pi + 2)` and clamped only `>= 4` down to 3. An input a hair west of `-pi` got cap `-1`, i.e. a cap centre at `-5pi/4`, one cap too far west.

- **Forward**: visible and large. `healpix_sphere(-pi - 1e-15, 1.4)` returned `x = -3.7629` against `x = -2.5203` at `lam = -pi`, a jump of `(pi/2)(1 - sigma) = 1.24`. Only direct callers see it, since `Projection` wraps longitude first.
- **Inverse**: reachable only through the `1e-10` image margin near the `(-pi, ±pi/4)` corners, where the trailing `[-pi, pi]` clamp already hid the effect (the probe in #119 returns exactly `-pi` on master).

`in_healpix_image` was clamping its cap to `[0, 3]` all along, so the projection functions disagreed with the membership test only for `x < -pi`.

## Change

Clamp both ends in the two scalar functions and in `_cap_number`, which the array twins share, so scalar and array paths change together. The accepted region of `in_healpix_image` is unchanged. Inputs far outside `[-pi, pi)` remain the caller's responsibility to wrap, as documented; the clamp only removes the discontinuity at the boundary.

## Tests

- `test_cap_number_matches_scalar` (array suite) now pins the two-sided clamp and probes inputs past both ends.
- New `test_cap_number_clamped_at_minus_pi`: forward continuity at `-pi` for three polar latitudes and offsets down to `1e-10`, scalar and array; inverse at the fuzzed corners lands on `lam == -pi` exactly with the cap-0 latitude, scalar against array.

## Verification

161 unit tests and all doctests pass; ruff, black and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
