### PR TITLE
Integrate dart and skew quad centroids with a fixed product rule on one batch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,18 @@ longitude one ulp below ``-pi``; the inverse could only reach the case
 through the ``1e-10`` image margin, where the trailing longitude clamp
 already hid it. ``in_healpix_image`` was clamping both ends all along, so
 the projection functions now agree with it (issue #119).
+``Cell.centroid(plane=False)`` on dart and skew quad cells integrates with
+a fixed 20-point Gauss-Legendre product rule on one batch of projected
+points, splitting a dart's square along the polar-square diagonal where the
+projection has a kink, instead of adaptive ``scipy.integrate.dblquad``
+probing the scalar projection point by point. A dart centroid drops from
+about 70 ms and 20,000 projections to under 1 ms and 800; a skew quad from
+10 ms to under 1 ms. Skew quad results agree with tight-tolerance adaptive
+quadrature to about 1e-14 degrees, the projection's floating-point floor.
+Dart latitudes move by up to a few times 1e-7 degrees: the previous
+whole-square adaptive integration could not converge across the kink and
+delivered only its default tolerance, and the new values agree with
+adaptive integration of the two smooth halves to 1e-9 (issue #120).
 
 0.8.0
 ^^^^^

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -2,8 +2,9 @@
 
 from collections.abc import Iterator
 from colorsys import hsv_to_rgb
-from functools import cached_property, total_ordering
+from functools import cache, cached_property, total_ordering
 from itertools import product
+from math import fsum
 from random import uniform
 from typing import TYPE_CHECKING, ClassVar, Literal, cast, overload
 
@@ -19,6 +20,23 @@ from rhealpixdggs.utils import wrap_longitude
 
 # Level 0 cell IDs, which are anomalous.
 CELLS0 = ["N", "O", "P", "Q", "R", "S"]
+
+# Points per axis of the Gauss-Legendre product rule that integrates the
+# centroid of a dart or skew quad cell over its planar square (issue #120).
+# The integrand is smooth within one polar triangle, so the rule converges
+# exponentially: 20 points agree with 40 to about 1e-14 degrees, the
+# projection's own floating-point floor.
+_CENTROID_QUADRATURE_ORDER = 20
+
+
+@cache
+def _gauss_legendre_unit(n: int) -> tuple[np.ndarray, np.ndarray]:
+    """
+    The `n`-point Gauss-Legendre nodes and weights on [0, 1]; the weights
+    sum to 1, so a weighted sum of function values is the mean over [0, 1].
+    """
+    nodes, weights = np.polynomial.legendre.leggauss(n)
+    return (nodes + 1) / 2, weights / 2
 
 
 @total_ordering
@@ -1219,13 +1237,6 @@ class Cell:
         x2 = max([v[0] for v in planar_vertices])
         y1 = min([v[1] for v in planar_vertices])
         y2 = max([v[1] for v in planar_vertices])
-        area = (x2 - x1) ** 2
-
-        def lam(x: float, y: float) -> float:
-            return self.rdggs.rhealpix(x, y, inverse=True)[0]
-
-        def phi(x: float, y: float) -> float:
-            return self.rdggs.rhealpix(x, y, inverse=True)[1]
 
         if shape == "quad":
             # A quad cell is symmetric about its nucleus meridian, and its
@@ -1256,22 +1267,63 @@ class Cell:
                 (1 / (y2 - y1)) * integrate.fixed_quad(phi_of_y, y1, y2, n=20)[0]
             )
             return lam_bar, phi_bar
+        # Dart or skew quad: the mean latitude (and, for a skew quad, the
+        # mean longitude) is an area-weighted integral over the planar
+        # square, evaluated by a fixed Gauss-Legendre product rule on one
+        # batch of projected points.
+        xs, ys, weights = self._centroid_quadrature(x1, x2, y1, y2)
+        lons, lats = self.rdggs.rhealpix(xs, ys, inverse=True, region=self.region())
+        # fsum is exactly rounded, so the result is the same on every
+        # platform regardless of summation order.
+        phi_bar = fsum(weights * lats)
         if shape == "dart":
-            lam_bar = float(nucleus[0])
-            phi_bar = (1 / area) * integrate.dblquad(
-                phi, y1, y2, lambda x: x1, lambda x: x2
-            )[0]
-            return lam_bar, phi_bar
-        # Now shape == 'skew_quad'.
-        # phi_bar formula same as dart case.
-        phi_bar = (1 / area) * integrate.dblquad(
-            phi, y1, y2, lambda x: x1, lambda x: x2
-        )[0]
-        # lam_bar formula changes; compute by numerical integration.
-        lam_bar = (1 / area) * integrate.dblquad(
-            lam, y1, y2, lambda x: x1, lambda x: x2
-        )[0]
-        return lam_bar, phi_bar
+            # A dart is symmetric about its nucleus meridian.
+            return float(nucleus[0]), phi_bar
+        return fsum(weights * lons), phi_bar
+
+    def _centroid_quadrature(
+        self, x1: float, x2: float, y1: float, y2: float
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Planar sample points and weights (summing to 1) whose weighted sum
+        of a function's values is its mean over this dart or skew quad
+        cell's planar square [x1, x2] x [y1, y2].
+
+        A skew quad lies within one polar triangle, where the inverse
+        projection is smooth, so a plain product rule over the square
+        serves. A dart straddles a diagonal of its polar square, along
+        which the projection has a kink; its square is split along that
+        diagonal (which passes through the dart's nucleus and so runs
+        corner to corner of the square) into two triangles, each mapped
+        from the unit square by the Duffy transform (u, v) -> (u, u*v),
+        whose Jacobian u folds into the weights.
+        """
+        t, w = _gauss_legendre_unit(_CENTROID_QUADRATURE_ORDER)
+        u, v = np.meshgrid(t, t, indexing="ij")
+        if self.ellipsoidal_shape == "skew_quad":
+            s, r = u.ravel(), v.ravel()
+            weights = np.outer(w, w).ravel()
+        else:
+            # Which diagonal: the nucleus's offset from the polar square's
+            # centre has equal-sign components on the rising (slope +1)
+            # diagonal and opposite-sign components on the falling one.
+            cx, cy = self.rdggs.cell([self.suid[0]]).nucleus(plane=True)
+            nx, ny = self.nucleus(plane=True)
+            rising = (nx - cx) * (ny - cy) > 0
+            # In unit-square coordinates (s, r) the rising diagonal is
+            # r = s; the triangle below it is the Duffy image (u, u*v) and
+            # the one above is its transpose (u*v, u).
+            a, b = u.ravel(), (u * v).ravel()
+            s = np.concatenate([a, b])
+            r = np.concatenate([b, a])
+            if not rising:
+                # The falling diagonal r = 1 - s is the mirror image.
+                s = 1 - s
+            triangle_weights = (np.outer(w, w) * t[:, None]).ravel()
+            weights = np.concatenate([triangle_weights, triangle_weights])
+        xs = x1 + (x2 - x1) * s
+        ys = y1 + (y2 - y1) * r
+        return xs, ys, weights
 
     def rotate_entry(self, x: str | int, quarter_turns: int) -> str | int:
         """

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -82,9 +82,9 @@ def rhp_to_geo(
     EXAMPLES::
 
         >>> rhp_to_geo('S001450634', True, False)
-        (-176.2606635452476, -43.73654505358369)
+        (-176.2606635452476, -43.7365450535837)
         >>> rhp_to_geo('S001450635', True, False)
-        (-176.25592420875037, -43.73654505358369)
+        (-176.25592420875034, -43.7365450535837)
         >>> rhp_to_geo('NotACellId', True, False)
     """
     # Stop early if the cell index is invalid

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1113,6 +1113,85 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         self.assertLess(abs(wrap_longitude(lon - mc_lon, radians=False)), 6 * se_lon)
         self.assertLess(abs(lat - mc_lat), 6 * se_lat)
 
+    def test_centroid_polar_against_adaptive_quadrature(self):
+        # centroid() integrates dart and skew quad cells with a fixed
+        # Gauss-Legendre product rule. Deterministic ground truth: adaptive
+        # quadrature of the same integrals over the same planar square,
+        # which is smooth within one polar triangle. A skew quad lies in
+        # one triangle, so its square integrates directly; a dart straddles
+        # a diagonal of its polar square, where the projection has a kink,
+        # so its square is integrated as the two triangles on either side
+        # (a different split from centroid()'s Duffy map).
+        rdggs = WGS84_003
+        for suid in [(N, 7), (N, 1, 5), (S, 3, 3, 3), (N, 6), (N, 0, 0), (S, 2, 4)]:
+            self._check_polar_centroid(rdggs.cell(suid))
+
+    def _check_polar_centroid(self, X):
+        from unittest.mock import patch
+
+        from scipy import integrate
+
+        import rhealpixdggs.cell as cell_module
+        from rhealpixdggs.cell import _CENTROID_QUADRATURE_ORDER
+
+        rdggs = X.rdggs
+        shape = X.ellipsoidal_shape
+        self.assertIn(shape, ("dart", "skew_quad"), str(X))
+        pv = X.vertices(plane=True)
+        x1, x2 = min(v[0] for v in pv), max(v[0] for v in pv)
+        y1, y2 = min(v[1] for v in pv), max(v[1] for v in pv)
+        area = (x2 - x1) * (y2 - y1)
+
+        def bottom(x):
+            return y1
+
+        def top(x):
+            return y2
+
+        if shape == "skew_quad":
+            pieces = [(bottom, top)]
+        else:
+            cx, cy = rdggs.cell([X.suid[0]]).nucleus(plane=True)
+            nx, ny = X.nucleus(plane=True)
+            rising = (nx - cx) * (ny - cy) > 0
+
+            def diagonal(x):
+                return y1 + (x - x1) if rising else y1 + (x2 - x)
+
+            pieces = [(bottom, diagonal), (diagonal, top)]
+
+        def mean_of(i):
+            def f(y, x):
+                return rdggs.rhealpix(x, y, inverse=True)[i]
+
+            total = 0.0
+            for lower, upper in pieces:
+                total += integrate.dblquad(
+                    f, x1, x2, lower, upper, epsabs=1e-11, epsrel=1e-11
+                )[0]
+            return total / area
+
+        lon, lat = X.centroid(plane=False)
+        self.assertAlmostEqual(lat, mean_of(1), places=9, msg=str(X))
+        if shape == "skew_quad":
+            self.assertAlmostEqual(lon, mean_of(0), places=9, msg=str(X))
+        else:
+            self.assertEqual(lon, X.nucleus(plane=False)[0], str(X))
+
+        # The rule's own convergence: doubling the order moves the result
+        # by no more than the projection's floating-point floor.
+        xs, _, weights = X._centroid_quadrature(x1, x2, y1, y2)
+        self.assertAlmostEqual(float(weights.sum()), 1.0, places=14)
+        with patch.object(
+            cell_module, "_CENTROID_QUADRATURE_ORDER", 2 * _CENTROID_QUADRATURE_ORDER
+        ):
+            xs2, ys2, weights2 = X._centroid_quadrature(x1, x2, y1, y2)
+        self.assertEqual(len(xs2), 4 * len(xs))
+        lons2, lats2 = rdggs.rhealpix(xs2, ys2, inverse=True)
+        self.assertAlmostEqual(float(weights2 @ lats2), lat, places=12, msg=str(X))
+        if shape == "skew_quad":
+            self.assertAlmostEqual(float(weights2 @ lons2), lon, places=12, msg=str(X))
+
     def test_random_point(self):
         # Output should lie in the cell at least.
         for E in [WGS84_ASPHERE_RADIANS, WGS84_ELLIPSOID]:

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -13,7 +13,6 @@ Keep adding tests!
 
 import unittest
 
-import numpy as np
 import shapely as sh
 
 import rhealpixdggs.dggs as gs
@@ -58,11 +57,11 @@ class RhpWrappersTestCase(unittest.TestCase):
 
         # Dart cell without geojson
         centroid = rhpw.rhp_to_geo("N0", geo_json=False, plane=False)
-        self.assertEqual(centroid, (np.float64(53.00810765458496), np.float64(90.0)))
+        self.assertEqual(centroid, (53.00810744904724, 90.0))
 
         # Dart cell with geojson
         centroid = rhpw.rhp_to_geo("N0", plane=False)
-        self.assertEqual(centroid, (90.0, 53.00810765458496))
+        self.assertEqual(centroid, (90.0, 53.00810744904724))
 
         # Equatorial cell without geojson. Q is symmetric about the
         # equator, so its centroid latitude is 0 -- up to the floating-


### PR DESCRIPTION
Closes #120. Second item of milestone v0.8.1.

## Problem

`Cell.centroid(plane=False)` on dart and skew quad cells used adaptive `scipy.integrate.dblquad`, which probes the scalar inverse projection point by point: ~900 projections / 10 ms for a skew quad and ~20,000 / 70 ms for a dart, against 0.2 ms for a quad. It also aimed below the projection's floating-point noise floor, and on a dart it hit the kink along the polar-square diagonal, where its error estimate broke down and it delivered only its 1.5e-8 default tolerance. Every polar `polyfill` paid this, and #98 (v0.9.0) will make `centroid` a hot path.

## Change

A fixed 20-point Gauss-Legendre product rule on one array projection:

- **Skew quad**: lies within one polar triangle where the projection is smooth, so a plain product rule over its square converges exponentially.
- **Dart**: the square is split along the diagonal through its nucleus into two smooth triangles, each mapped from the unit square by a Duffy transform whose Jacobian folds into the weights.
- Weighted sums use `math.fsum`, so results are bit-identical across platforms regardless of BLAS summation order.

| | before | after |
|---|---|---|
| dart centroid | 70 ms, ~20,000 projections | 0.34 ms, 800 |
| skew quad centroid | 10 ms, ~900 projections | 0.24 ms, 400 |
| polyfill 60° box at 70–85°N, res 3 | 0.74 s | 0.01 s |

## Precision

- Skew quads: match tight-tolerance adaptive quadrature to ~1e-14 degrees (the projection's floating-point floor); values unchanged to 1e-13.
- Darts: latitudes move by 2e-7 to 3e-7 degrees (about 2 cm), which was the previous whole-square integration's error. New values agree with adaptive integration of the two smooth halves to 1e-9 and with the rule at double order to 1e-12.

## Tests

- New `test_centroid_polar_against_adaptive_quadrature`: six polar cells checked against adaptive quadrature on the smooth pieces (1e-9), the weights sum to 1, and doubling the rule's order moves the result by < 1e-12.
- Existing Monte Carlo centroid oracle passes unchanged.
- Two pinned dart values in the wrappers test and one skew-quad doctest updated to the new values.

## Verification

162 unit tests and all doctests pass; ruff, black and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
