### PR TITLE
Pick a dart's northwest vertex in the plane instead of projecting four points

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,13 @@ Dart latitudes move by up to a few times 1e-7 degrees: the previous
 whole-square adaptive integration could not converge across the kink and
 delivered only its default tolerance, and the new values agree with
 adaptive integration of the two smooth halves to 1e-9 (issue #120).
+``Cell.nw_vertex`` on dart cells finds the polewards vertex in the plane,
+as the vertex nearest the polar square's centre in Chebyshev distance,
+instead of projecting all four vertices to compare latitudes: 5 µs
+instead of 47 µs, about a quarter of a dart's ``boundary(plane=False)``
+call. The choice is identical for every dart to resolution 4 in all
+polar-square placements, to resolution 5 in the default, and for
+``N_side = 2`` (issue #122).
 
 0.8.0
 ^^^^^

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -667,10 +667,14 @@ class Cell:
                 i = (triangle - ss) % 4
                 result = v[i]
         else:
-            # shape == 'dart':
-            # Map cell to ellipsoid and get the polewards vertex.
-            ev = [self.rdggs.rhealpix(*vv, inverse=True) for vv in v]
-            i = max((abs(ev[j][1]), j) for j in range(4))[1]
+            # shape == 'dart': find the polewards vertex in the plane.
+            # Parallels in a polar square are concentric squares about its
+            # centre, the pole, so the vertex nearest the pole is the one
+            # with the smallest Chebyshev distance to that centre. It is
+            # unique: only the dart's two base vertices, farthest from the
+            # pole, are equidistant.
+            cx, cy = self.rdggs.cell([self.suid[0]]).nucleus(plane=True)
+            i = min(range(4), key=lambda j: max(abs(v[j][0] - cx), abs(v[j][1] - cy)))
             if self.region() == "north_polar":
                 # Northwest vertex is the polewards vertex.
                 result = v[i]

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -1192,6 +1192,55 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         if shape == "skew_quad":
             self.assertAlmostEqual(float(weights2 @ lons2), lon, places=12, msg=str(X))
 
+    def test_nw_vertex_dart_matches_projected_choice(self):
+        # nw_vertex() picks a dart's polewards vertex in the plane, as the
+        # vertex with the smallest Chebyshev distance to the polar square's
+        # centre (issue #122). Gate it against the definition: project the
+        # four planar vertices and take the one of greatest absolute
+        # latitude (then, in the south, one step clockwise), for every
+        # dart to resolution 4 in all sixteen polar-square placements and
+        # to resolution 5 in the default one, and for N_side = 2, whose
+        # darts are not centred on their base. The polewards vertex must
+        # also be strictly nearest: no tie for the planar test to break.
+        import itertools
+
+        def projected_choice(cell):
+            v = cell.vertices(plane=True)
+            ev = [cell.rdggs.rhealpix(*vv, inverse=True) for vv in v]
+            i = max((abs(ev[j][1]), j) for j in range(4))[1]
+            return v[i] if cell.region() == "north_polar" else v[(i + 1) % 4]
+
+        def check(cell):
+            self.assertEqual(cell.ellipsoidal_shape, "dart", str(cell))
+            v = cell.vertices(plane=True)
+            cx, cy = cell.rdggs.cell([cell.suid[0]]).nucleus(plane=True)
+            d = sorted(max(abs(x - cx), abs(y - cy)) for x, y in v)
+            self.assertLess(d[0], d[1], str(cell))
+            self.assertEqual(
+                cell.nw_vertex(plane=True), projected_choice(cell), str(cell)
+            )
+
+        # N_side = 3: a dart's digits are all in {0, 4, 8} or all in
+        # {2, 4, 6} (it lies on a diagonal of the polar square), excluding
+        # the all-4s cap.
+        for ns, ss in itertools.product(range(4), repeat=2):
+            rdggs = RHEALPixDGGS(WGS84_ELLIPSOID, north_square=ns, south_square=ss)
+            top = 5 if (ns, ss) == (0, 0) else 4
+            for face, digits, res in itertools.product(
+                (N, S), ("048", "246"), range(1, top + 1)
+            ):
+                for tail in itertools.product(digits, repeat=res):
+                    if set(tail) != {"4"}:
+                        check(rdggs.cell([face] + [int(t) for t in tail]))
+
+        # N_side = 2: every polar cell to resolution 3, filtered by shape.
+        rdggs = WGS84_122
+        for face, res in itertools.product((N, S), range(1, 4)):
+            for tail in itertools.product(range(4), repeat=res):
+                cell = rdggs.cell([face] + list(tail))
+                if cell.ellipsoidal_shape == "dart":
+                    check(cell)
+
     def test_random_point(self):
         # Output should lie in the cell at least.
         for E in [WGS84_ASPHERE_RADIANS, WGS84_ELLIPSOID]:

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -400,11 +400,10 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
             finally:
                 del rdggs.__dict__["rhealpix"]
             self.assertLess(batched_calls, ratio * per_cell_calls, face)
-            # One resolution and one region: a single array call, plus the
-            # four scalar projections nw_vertex makes per dart cell while
-            # the planar boundaries are gathered (issue #122).
-            darts = sum(c.ellipsoidal_shape == "dart" for c in block)
-            self.assertEqual(batched_invocations, 1 + 4 * darts, face)
+            # One resolution and one region: a single array call. Gathering
+            # the planar boundaries projects nothing, since nw_vertex picks a
+            # dart's polewards vertex in the plane (issue #122).
+            self.assertEqual(batched_invocations, 1, face)
 
         # In the equatorial region the batch exploits the projection's
         # separability: every point in one lattice column gets one


### PR DESCRIPTION
Closes #122. Third item of milestone v0.8.1.

## Problem

`Cell.nw_vertex` on a dart cell found the polewards vertex by projecting all four planar vertices onto the ellipsoid and taking the one of greatest absolute latitude: four scalar inverse projections, 47 µs, about a quarter of a dart's `boundary(plane=False)` after #120.

## Change

Parallels in a polar square are concentric squares about its centre, the pole, so the vertex nearest the pole is the one with the smallest Chebyshev distance to that centre. That needs no projection and takes 5 µs. The minimum is unique: only the dart's two base vertices, farthest from the pole, are equidistant, so there is no tie for the planar test to break.

| | before | after |
|---|---|---|
| dart `nw_vertex(plane=True)` | 47 µs | 5 µs |
| dart `boundary(n=10, plane=False)` | 227 µs | 171 µs |
| projections in `cell_boundaries` on a polar block | 1 array call + 4 scalar per dart | 1 array call |

## Tests

- New `test_nw_vertex_dart_matches_projected_choice`: the planar choice equals the projected one for every dart to resolution 4 in all sixteen polar-square placements (8392 darts), to resolution 5 in the default placement, and for `N_side = 2` to resolution 3 (56 darts); and the nearest vertex is strictly nearest in every case.
- `test_cell_boundaries` in test_dggs now expects exactly one projection call for a polar block, as the issue predicted.

## Verification

163 unit tests and all doctests pass; ruff, black and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
