### PR TITLE
Add cells_from_points: cell_from_point for many points at once (issue #139)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ the nuclei of many cells the same way, as a ``(len(indices), 2)`` array,
 and ``RHEALPixDGGS.centroids(indices, plane)`` their centroids,
 evaluating ``Cell.centroid``'s quadrature rules for all cells of each
 shape in one projection call (issue #140).
+``RHEALPixDGGS.cells_from_points(u, v, resolution, plane)`` is the array
+form of ``cell_from_point``: it returns the index strings of the cells
+containing many points, an empty string where no cell does, making
+exactly the decisions ``cell_from_point`` makes (issue #139).
 Building geometries from the array is where the time goes: for a
 resolution-4 grid ``shapely.polygons`` takes 35 ms against ~840 ms for a
 Python loop constructing one ``Polygon`` per cell.

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -977,6 +977,99 @@ class RHEALPixDGGS:
             suid.append(cast(int, digit))
         return Cell(self, suid)
 
+    def cells_from_points(
+        self,
+        u: FloatArray,
+        v: FloatArray,
+        resolution: int,
+        plane: bool = True,
+    ) -> np.ndarray:
+        """
+        Return the index strings of the resolution `resolution` cells
+        containing the points ``(u[k], v[k])``, as a numpy string array in
+        input order: the ``str()`` of ``cell_from_point(resolution, (u[k],
+        v[k]), plane=plane)`` for each point, or an empty string where that
+        would be None (the point lies outside the planar image). `u` and `v`
+        are planar `x` and `y` if `plane` = True, else longitude and
+        latitude. The decisions are those of ``cell_from_point``, made for
+        every point at once.
+
+        EXAMPLES::
+
+            >>> rdggs = WGS84_003
+            >>> lon, lat = np.array([0.0, 174.8]), np.array([0.0, -41.3])
+            >>> rdggs.cells_from_points(lon, lat, 3, plane=False).tolist()
+            ['Q333', 'R887']
+            >>> x, y = np.array([0.0, 1e8]), np.array([0.0, 0.0])
+            >>> rdggs.cells_from_points(x, y, 2, plane=True).tolist()
+            ['Q33', '']
+
+        """
+        x_in, y_in = np.broadcast_arrays(
+            np.asarray(u, dtype=np.float64), np.asarray(v, dtype=np.float64)
+        )
+        if not plane:
+            x, y = self.rhealpix(x_in, y_in)
+        else:
+            x, y = x_in, y_in
+        count = x.size
+        x, y = x.ravel(), y.ravel()
+        ns, ss = self.north_square, self.south_square
+        R = self.ellipsoid.R_A
+        # The resolution 0 cell of each point, by cell_from_point's tests in
+        # its order (strict at the polar squares' edges, half-open along the
+        # equatorial band); -1 where none matches.
+        band = (y >= -R * pi / 4) & (y <= R * pi / 4)
+        tests = [
+            (y > R * pi / 4)
+            & (y < R * 3 * pi / 4)
+            & (x > R * (-pi + ns * (pi / 2)))
+            & (x < R * (-pi / 2 + ns * (pi / 2))),
+            (y > -R * 3 * pi / 4)
+            & (y < -R * pi / 4)
+            & (x > R * (-pi + ss * (pi / 2)))
+            & (x < R * (-pi / 2 + ss * (pi / 2))),
+            band & (x >= -R * pi) & (x < -R * pi / 2),
+            band & (x >= -R * pi / 2) & (x < 0),
+            band & (x >= 0) & (x < R * pi / 2),
+            band & (x >= R * pi / 2) & (x < R * pi),
+        ]
+        codes = [0, 5, 1, 2, 3, 4]
+        face = np.full(count, -1, dtype=np.int64)
+        for test, code in zip(reversed(tests), reversed(codes)):
+            face[test] = code
+        valid = face >= 0
+        # Offsets from the base cell's corner as fractions of its width,
+        # nudged off exactly 1, then truncated to base-N digits; a fraction
+        # that rounds up to N**resolution keeps only its leading digits, as
+        # the string slicing in cell_from_point does.
+        letters = np.array(list("".join(CELLS0)), dtype=str)
+        out = np.full(count, "", dtype=f"<U{resolution + 1}")
+        if valid.any() and resolution == 0:
+            out[valid] = letters[face[valid]]
+        elif valid.any():
+            N = self.N_side
+            w = self.cell_width(0)
+            corners = np.array([self.ul_vertex[letter] for letter in CELLS0])
+            dx = np.abs(x[valid] - corners[face[valid], 0]) / w
+            dy = np.abs(y[valid] - corners[face[valid], 1]) / w
+            smidgen = 0.5 * self.cell_width(self.max_resolution) / w
+            dx = np.where(dx == 1, dx - smidgen, dx)
+            dy = np.where(dy == 1, dy - smidgen, dy)
+            col_index = (dx * N**resolution).astype(np.int64)
+            row_index = (dy * N**resolution).astype(np.int64)
+            col_index = np.where(col_index >= N**resolution, col_index // N, col_index)
+            row_index = np.where(row_index >= N**resolution, row_index // N, row_index)
+            powers = N ** np.arange(resolution - 1, -1, -1)
+            col = (col_index[:, None] // powers) % N
+            row = (row_index[:, None] // powers) % N
+            digits = row * N + col
+            chars = np.empty((int(valid.sum()), resolution + 1), dtype=np.uint32)
+            chars[:, 0] = np.array([ord(c) for c in CELLS0])[face[valid]]
+            chars[:, 1:] = digits + ord("0")
+            out[valid] = chars.view(f"<U{resolution + 1}").ravel()
+        return out.reshape(x_in.shape)
+
     def cell_from_region(
         self, ul: tuple[float, float], dr: tuple[float, float], plane: bool = True
     ) -> Cell | None:

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -577,6 +577,67 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
         self.assertTrue(np.isnan(c[1]).all())
         self.assertFalse(np.isnan(c[[0, 2]]).any())
 
+    def test_cells_from_points_matches_cell_from_point(self):
+        # cells_from_points makes cell_from_point's decisions for every
+        # point at once: index strings must agree exactly, including at
+        # lattice edges (nudged by one ulp either way), outside the image
+        # (empty string for None) and for NaN input.
+        from numpy.testing import assert_array_equal
+
+        rng = np.random.default_rng(20260811)
+
+        def scalar(rdggs, res, xs, ys, plane):
+            cells = [
+                rdggs.cell_from_point(res, (float(a), float(b)), plane=plane)
+                for a, b in zip(xs, ys)
+            ]
+            return np.array(["" if c is None else str(c) for c in cells])
+
+        for rdggs in (WGS84_003, WGS84_003_RADIANS, WGS84_123, WGS84_122):
+            R = rdggs.ellipsoid.R_A
+            angle = 1.0 if rdggs.ellipsoid.radians else 180 / pi
+            lon = rng.uniform(-pi, pi, 400) * angle
+            lat = np.arcsin(rng.uniform(-1, 1, 400)) * angle
+            w = rdggs.cell_width(2)
+            gx = -pi * R + w * np.arange(0, 4 * rdggs.N_side**2 + 1, 3)
+            gy = -3 * pi * R / 4 + w * np.arange(0, 6 * rdggs.N_side**2 + 1, 4)
+            ex, ey = (a.ravel() for a in np.meshgrid(gx, gy))
+            px = np.concatenate(
+                [
+                    rng.uniform(-pi * R - 1, pi * R + 1, 400),
+                    ex,
+                    np.nextafter(ex, np.inf),
+                    np.nextafter(ex, -np.inf),
+                    [np.nan, 0.0],
+                ]
+            )
+            py = np.concatenate(
+                [
+                    rng.uniform(-3 * pi * R / 4 - 1, 3 * pi * R / 4 + 1, 400),
+                    ey,
+                    ey,
+                    np.nextafter(ey, -np.inf),
+                    [0.0, np.nan],
+                ]
+            )
+            for res in (0, 1, 2, 4, 7):
+                assert_array_equal(
+                    rdggs.cells_from_points(lon, lat, res, plane=False),
+                    scalar(rdggs, res, lon, lat, False),
+                )
+                assert_array_equal(
+                    rdggs.cells_from_points(px, py, res, plane=True),
+                    scalar(rdggs, res, px, py, True),
+                )
+        # Shape is preserved and the result is a string array.
+        out = WGS84_003.cells_from_points(
+            np.zeros((2, 3)), np.full((2, 3), 10.0), 2, plane=False
+        )
+        self.assertEqual(out.shape, (2, 3))
+        self.assertTrue(out.dtype.kind == "U")
+        expected = str(WGS84_003.cell_from_point(2, (0.0, 10.0), plane=False))
+        self.assertTrue((out == expected).all())
+
     def test_boundary_array(self):
         import shapely
         from numpy.testing import assert_allclose, assert_array_equal


### PR DESCRIPTION
Closes #139. **Stacked on #141** (base `index-arrays`, shared changelog section only); retarget to master once that merges.

**`RHEALPixDGGS.cells_from_points(u, v, resolution, plane=True) -> ndarray[str]`**: the index strings of the cells containing the points `(u[k], v[k])`, in input order and input shape, with `""` where `cell_from_point` would return `None`. `u`, `v` are planar x, y or longitude, latitude per `plane`.

**Faithful to `cell_from_point` step for step**: one forward projection call; the base cell by the same six tests in the same order (strict inequalities at the polar squares' edges, half-open along the equatorial band); offset fractions with the same nudge off exactly 1; the same truncation to base-N digits, including the corner case where a fraction rounds up to `N**resolution` and the string slicing in `cell_from_point` keeps only its leading digits; the same row-major child numbering. No `Cell` objects; strings are assembled from character codes.

**Parity**: index strings agree **exactly** with `cell_from_point` on random geographic points, random planar points inside and outside the image, resolution-2 lattice edge points nudged one ulp either way, and NaN input, at resolutions 0, 1, 2, 4, 7 (0–8 in a wider check), for WGS84_003, its radians twin, a `(1, 2)` square placement and `N_side=2`. A note for anyone reading the doctest: latitude 91 is not "outside" — the projection wrapper wraps it to −89 and it lands in a south polar cell, same as the scalar path.

**Benchmark** (same machine):

| points | resolution | `cells_from_points` | `geo_to_rhp` loop |
|---|---|---|---|
| 4,000 | 3 | 2.5 ms | 137 ms |
| 40,000 | 3 | 22 ms | 1.39 s |
| 40,000 | 8 | 31 ms | 1.60 s |

With #138 and #141 this completes array paths for rHP-Pandas' three hot operations: `geo_to_rhp` → `cells_from_points`, `rhp_to_geo` → `centroids`, `rhp_to_geo_boundary` → `boundary_array`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
