### PR TITLE
Project the polar centroid quadrature in chunks

### DIFF
--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -1922,24 +1922,28 @@ class RHEALPixDGGS:
             "rising": (shape == 2) & rising,
             "falling": (shape == 2) & ~rising,
         }
+        # Project each group in chunks of about a million points, so the
+        # working set stays a few tens of megabytes however many cells there
+        # are (each dart or skew quad needs several hundred points).
         for kind, members in kinds.items():
+            s_u, r_u, weights_u = rules[kind]
+            chunk = max(1, 1_000_000 // len(s_u))
             for code, region_name in ((1, "north_polar"), (-1, "south_polar")):
-                group = members & (region == code)
-                if not group.any():
-                    continue
-                s_u, r_u, weights_u = rules[kind]
-                x1 = x[group][:, None]
-                y1 = (y[group] - width[group])[:, None]
-                wg = width[group][:, None]
-                xs = x1 + wg * s_u
-                ys = y1 + wg * r_u
-                lons, lats = self.rhealpix(
-                    xs.ravel(), ys.ravel(), inverse=True, region=region_name
-                )
-                lons, lats = lons.reshape(xs.shape), lats.reshape(xs.shape)
-                out_lat[group] = np.sum(weights_u * lats, axis=1)
-                if kind == "skew":
-                    out_lon[group] = np.sum(weights_u * lons, axis=1)
+                group = np.flatnonzero(members & (region == code))
+                for start in range(0, len(group), chunk):
+                    rows = group[start : start + chunk]
+                    x1 = x[rows][:, None]
+                    y1 = (y[rows] - width[rows])[:, None]
+                    wg = width[rows][:, None]
+                    xs = x1 + wg * s_u
+                    ys = y1 + wg * r_u
+                    lons, lats = self.rhealpix(
+                        xs.ravel(), ys.ravel(), inverse=True, region=region_name
+                    )
+                    lons, lats = lons.reshape(xs.shape), lats.reshape(xs.shape)
+                    out_lat[rows] = np.sum(weights_u * lats, axis=1)
+                    if kind == "skew":
+                        out_lon[rows] = np.sum(weights_u * lons, axis=1)
         result[valid, 0] = out_lon
         result[valid, 1] = out_lat
         return result


### PR DESCRIPTION
Found while checking whether the 0.8.3 batch methods are genuinely faster end to end (they are — table below — but this one scaled badly).

`centroids()` projected every dart's and skew quad's 800 quadrature points in one call per group. With 100,000 random resolution-6 cells that is ~27 million points, and the array temporaries pushed the working set into paging:

| rows | before | after |
|---|---|---|
| 10,000 | 0.52 s | 0.52 s |
| 100,000 | 22.3 s | 4.8 s |

Each group is now projected in chunks of about a million points, so the working set stays a few tens of megabytes however many cells there are. Results are unchanged (same per-row arithmetic, just batched differently); the centroid parity test passes.

For the record, the end-to-end comparison that prompted this, an rHP-Pandas-style workflow (per-row `geo_to_rhp` / `rhp_to_geo` / `_cell_boundaries` + `Polygon` against the new array methods + `shapely.polygons`/`points`), identical answers verified:

| rows | `geo_to_rhp` old → new | boundaries old → new | centroids old → new |
|---|---|---|---|
| 1 | 82 µs → 530 µs | 1.4 → 1.3 ms | 1.0 → 1.8 ms |
| 10 | 0.6 → 0.5 ms | 2.8 → 2.5 ms | 6.9 → 3.4 ms |
| 100 | 5.7 → 0.6 ms | 6.8 → 2.9 ms | 75 → 8.7 ms |
| 1,000 | 72 → 1.5 ms | 63 → 7.4 ms | 732 → 62 ms |
| 10,000 | 405 → 9.2 ms | 373 → 28 ms | 6.2 s → 0.53 s |
| 100,000 | 3.8 s → 63 ms | 2.9 s → 0.28 s | — → 4.8 s (after this PR) |

Break-even is around ten rows; a single row is slower on the array path (fixed array overhead of ~0.5 ms), which is the expected trade for batch APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
