### PR TITLE
Vectorise polyfill and add H3-style containment modes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,40 @@
+0.8.5
+^^^^^
+``rhp_wrappers.polyfill`` gains a ``containment`` parameter with H3's three
+modes: ``"center"`` (the default, and the previous behaviour: cells whose
+centroid is inside the geometry), ``"full"`` (cells lying wholly within it)
+and ``"overlapping"`` (cells meeting it at all). ``full`` and
+``overlapping`` test cell boundary polygons, exact in the plane and for
+equatorial cells, a 6-point-per-edge approximation for the curved edges of
+polar cells; cap cells and antimeridian-straddling cells are handled
+apart.
+
+``polyfill`` is also vectorised end to end: the candidate cells of the
+geometry's bounding box come from the new
+``RHEALPixDGGS.cells_in_box(resolution, ul, dr, plane)`` (the index strings
+of every cell meeting the box's planar image, a superset of
+``cells_from_region`` computed without ``Cell`` objects), their centroids
+from ``RHEALPixDGGS.centroids`` and their boundaries from
+``RHEALPixDGGS.boundary_array``, and shapely's vectorised predicates decide
+all candidates at once. In the default mode a cell's centroid, the mean
+of longitude and latitude over the cell, lies within the cell's
+longitude-latitude bounding box, so cells whose box is wholly inside or
+wholly outside the geometry are decided from four corner points and only
+the cells along the geometry's boundary have their centroid integrated.
+Candidates are carried as arrays from the lattice to the geometry code,
+not round-tripped through index strings, and are processed in chunks of
+250,000, so the working set is bounded whatever the resolution: a
+378,000-cell resolution-8 fill of New Zealand peaks at about 200 MB.
+Default results are unchanged: a 42,000-cell resolution-7 fill of New
+Zealand drops from 25.5 s to 0.3 s, a 60,000-cell resolution-6
+equatorial box from 11.2 s to 0.14 s, a 1,700-cell resolution-5 polar box
+from 0.77 s to 0.02 s. One behaviour differs: a planar geometry reaching
+outside the planar image used to yield no cells at all (``cells_from_region``
+found no cell at a bounding-box corner); the cells inside the image are
+now found. ``RHEALPixDGGS.centroids`` integrates the mean latitude of
+equatorial quads once per planar row rather than once per cell, as
+latitude is independent of x there.
+
 0.8.4
 ^^^^^
 ``RHEALPixDGGS.centroids`` projects the quadrature points of dart and skew

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -166,6 +166,11 @@ import numpy as np
 
 # assert_allclose is doctest-only: the doctests use it from the module globals.
 from numpy.testing import assert_allclose  # noqa: F401
+
+# Cells per chunk when enumerating the lattice cells of a planar box
+# (``RHEALPixDGGS._lattice_cells``), bounding the working set of callers such
+# as ``rhp_wrappers.polyfill`` however many cells a box holds.
+_LATTICE_CHUNK = 250_000
 from scipy.special import roots_legendre
 
 import rhealpixdggs.pj_rhealpix as pjr
@@ -1012,8 +1017,26 @@ class RHEALPixDGGS:
             x, y = self.rhealpix(x_in, y_in)
         else:
             x, y = x_in, y_in
+        valid, face, digits = self._parse_planar_points(
+            x.ravel(), y.ravel(), resolution
+        )
+        out = np.full(x.size, "", dtype=f"<U{resolution + 1}")
+        if valid.any():
+            out[valid] = self._format_indices(face[valid], digits[valid], resolution)
+        return out.reshape(x_in.shape)
+
+    def _parse_planar_points(
+        self, x: FloatArray, y: FloatArray, resolution: int
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        The resolution `resolution` cells containing the planar points
+        ``(x[k], y[k])``, in the form ``_parse_indices`` produces: a validity
+        mask (False where no cell contains the point), the base cell as a
+        code 0-5 (-1 where invalid) and the digits as an int64 array of
+        ``max(resolution, 1)`` columns (zero beyond the resolution and where
+        invalid).
+        """
         count = x.size
-        x, y = x.ravel(), y.ravel()
         ns, ss = self.north_square, self.south_square
         R = self.ellipsoid.R_A
         # The resolution 0 cell of each point, by cell_from_point's tests in
@@ -1039,15 +1062,12 @@ class RHEALPixDGGS:
         for test, code in zip(reversed(tests), reversed(codes)):
             face[test] = code
         valid = face >= 0
+        digits = np.zeros((count, max(resolution, 1)), dtype=np.int64)
         # Offsets from the base cell's corner as fractions of its width,
         # nudged off exactly 1, then truncated to base-N digits; a fraction
         # that rounds up to N**resolution keeps only its leading digits, as
         # the string slicing in cell_from_point does.
-        letters = np.array(list("".join(CELLS0)), dtype=str)
-        out = np.full(count, "", dtype=f"<U{resolution + 1}")
-        if valid.any() and resolution == 0:
-            out[valid] = letters[face[valid]]
-        elif valid.any():
+        if valid.any() and resolution > 0:
             N = self.N_side
             w = self.cell_width(0)
             corners = np.array([self.ul_vertex[letter] for letter in CELLS0])
@@ -1063,12 +1083,199 @@ class RHEALPixDGGS:
             powers = N ** np.arange(resolution - 1, -1, -1)
             col = (col_index[:, None] // powers) % N
             row = (row_index[:, None] // powers) % N
-            digits = row * N + col
-            chars = np.empty((int(valid.sum()), resolution + 1), dtype=np.uint32)
-            chars[:, 0] = np.array([ord(c) for c in CELLS0])[face[valid]]
-            chars[:, 1:] = digits + ord("0")
-            out[valid] = chars.view(f"<U{resolution + 1}").ravel()
-        return out.reshape(x_in.shape)
+            digits[valid] = row * N + col
+        return valid, face, digits
+
+    @staticmethod
+    def _format_indices(
+        face: np.ndarray, digits: np.ndarray, resolution: int
+    ) -> np.ndarray:
+        """
+        The index strings of valid cells given as base cell codes and digit
+        rows, all of resolution `resolution` (digit columns beyond it are
+        ignored: ``_parse_planar_points`` always yields at least one).
+        """
+        chars = np.empty((len(face), resolution + 1), dtype=np.uint32)
+        chars[:, 0] = np.array([ord(c) for c in CELLS0])[face]
+        chars[:, 1:] = digits[:, :resolution] + ord("0")
+        return chars.view(f"<U{resolution + 1}").ravel()
+
+    def cells_in_box(
+        self,
+        resolution: int,
+        ul: tuple[float, float],
+        dr: tuple[float, float],
+        plane: bool = True,
+    ) -> np.ndarray:
+        """
+        Return the index strings, as a numpy string array in no particular
+        order, of every resolution `resolution` cell whose planar square
+        meets the planar image of the axis-aligned box with upper-left
+        vertex `ul` and lower-right vertex `dr` -- a planar rectangle if
+        `plane` = True, else a longitude-latitude quadrangle -- plus a
+        one-cell margin around that image. The set is a superset of the
+        cells ``cells_from_region`` returns for the same box, computed
+        without constructing ``Cell`` objects, and is meant as the candidate
+        set for tests such as ``rhp_wrappers.polyfill``'s.
+
+        The image of a longitude-latitude box is bounded by the images of
+        its edges: parallels map to horizontal lines in the equatorial
+        region and to segments of concentric squares in the polar regions,
+        meridians to vertical lines or to straight rays to the pole. The
+        box is therefore split at the region boundaries ``+/-phi_0`` and, in
+        the equatorial band, at the meridian opposite ``lon_0`` where the
+        planar image wraps; each part's planar bounding box is that of its
+        projected corners and of the points where the polar squares'
+        diagonal meridians cross its latitude edges. A part reaching a pole
+        or spanning all longitudes is the whole polar square.
+
+        EXAMPLES::
+
+            >>> rdggs = WGS84_003
+            >>> found = set(rdggs.cells_in_box(1, (0, 60), (90, 0), plane=False))
+            >>> rows = rdggs.cells_from_region(1, (0, 60), (90, 0), plane=False)
+            >>> set(str(c) for row in rows for c in row) <= found
+            True
+            >>> sorted(rdggs.cells_in_box(0, (0, 60), (90, 0), plane=False).tolist())
+            ['N', 'O', 'P', 'Q', 'R']
+
+        """
+        boxes = self._candidate_boxes(ul, dr, plane)
+        found = [
+            self._format_indices(face, digits, resolution)
+            for face, digits in self._lattice_cells(boxes, resolution)
+        ]
+        if not found:
+            return np.array([], dtype="<U1")
+        return np.unique(np.concatenate(found))
+
+    def _candidate_boxes(
+        self, ul: tuple[float, float], dr: tuple[float, float], plane: bool
+    ) -> list[tuple[float, float, float, float]]:
+        """
+        Planar boxes ``(x1, x2, y1, y2)`` whose union contains the planar
+        image of the box with upper-left vertex `ul` and lower-right vertex
+        `dr` (a planar rectangle if `plane`, else a longitude-latitude
+        quadrangle), as ``cells_in_box`` describes.
+        """
+        R = self.ellipsoid.R_A
+        boxes: list[tuple[float, float, float, float]] = []
+        if plane:
+            boxes.append((ul[0], dr[0], dr[1], ul[1]))
+        else:
+            half = self.ellipsoid.pi()
+            quarter = half / 2
+            lon_0 = self.ellipsoid.lon_0
+            phi_0 = self.ellipsoid.phi_0
+            lon_lo, lon_hi = ul[0], dr[0]
+            lat_lo, lat_hi = dr[1], ul[1]
+            whole = lon_hi - lon_lo >= 2 * half
+            # Meridians whose images are the polar squares' diagonals, and
+            # the wrap meridian, as longitudes in the box's range.
+            diagonals = [lon_0 + k * quarter for k in range(-8, 9)]
+            wrap_meridians = [lon_0 + (2 * k + 1) * half for k in range(-2, 3)]
+
+            def polar(square: str, lo: float, hi: float) -> None:
+                if (
+                    whole
+                    or lo <= -half / 2
+                    and square == "S"
+                    or hi >= half / 2
+                    and square == "N"
+                ):
+                    x, y = self.ul_vertex[square]
+                    boxes.append((x, x + self.cell_width(0), y - self.cell_width(0), y))
+                    return
+                # Sample strictly inside the polar region: at exactly +/-phi_0
+                # the projection uses the equatorial formula, whose image of
+                # that parallel is the band's edge, a cut for most longitudes
+                # rather than the polar square's perimeter. The margin below
+                # covers the nudge.
+                nudge = half * 1e-12
+                if square == "N":
+                    lo = max(lo, phi_0 + nudge)
+                else:
+                    hi = min(hi, -phi_0 - nudge)
+                lons = [lon_lo, lon_hi] + [m for m in diagonals if lon_lo < m < lon_hi]
+                pts_lon = np.repeat(np.array(lons, dtype=np.float64), 2)
+                pts_lat = np.tile(np.array([lo, hi], dtype=np.float64), len(lons))
+                x, y = self.rhealpix(pts_lon, pts_lat)
+                boxes.append((x.min(), x.max(), y.min(), y.max()))
+
+            def equatorial(lo: float, hi: float) -> None:
+                cuts = (
+                    [lon_lo]
+                    + [m for m in wrap_meridians if lon_lo < m < lon_hi]
+                    + [lon_hi]
+                )
+                if whole:
+                    cuts = [lon_0 - half, lon_0 + half]
+                y = self.rhealpix(np.array([lon_lo, lon_lo]), np.array([lo, hi]))[1]
+                at_wrap = [m for m in wrap_meridians if abs(m - lon_hi) <= half * 1e-12]
+                if at_wrap:
+                    cuts[-1] = at_wrap[0]
+                for a, b in pairwise(cuts):
+                    # x is longitude relative to lon_0, wrapped into
+                    # [-pi, pi) and scaled; a piece ending at the wrap
+                    # meridian runs to the image's right edge.
+                    xa = self.rhealpix(np.array([a]), np.array([lo]))[0][0]
+                    xb = (
+                        pi * R
+                        if b in wrap_meridians
+                        else self.rhealpix(np.array([b]), np.array([lo]))[0][0]
+                    )
+                    boxes.append((xa, xb, y.min(), y.max()))
+                if at_wrap:
+                    # The wrap meridian itself projects to the image's left
+                    # edge, so a box reaching it also meets the first column.
+                    boxes.append((-pi * R, -pi * R, y.min(), y.max()))
+
+            if lat_hi > phi_0:
+                polar("N", max(lat_lo, phi_0), lat_hi)
+            if lat_lo < -phi_0:
+                polar("S", lat_lo, min(lat_hi, -phi_0))
+            if lat_lo <= phi_0 and lat_hi >= -phi_0:
+                equatorial(max(lat_lo, -phi_0), min(lat_hi, phi_0))
+        return boxes
+
+    def _lattice_cells(
+        self,
+        boxes: list[tuple[float, float, float, float]],
+        resolution: int,
+        chunk: int | None = None,
+    ) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """
+        Yield the resolution `resolution` cells whose planar squares meet
+        the planar boxes ``(x1, x2, y1, y2)``, each widened by one cell and
+        clipped to the image, as ``(face, digits)`` arrays in the form of
+        ``_parse_indices`` (valid cells only), in chunks of at most about
+        `chunk` cells so that the working set stays bounded however large
+        the boxes are. A cell met by two boxes is yielded twice.
+        """
+        if chunk is None:
+            chunk = _LATTICE_CHUNK
+        R = self.ellipsoid.R_A
+        w = self.cell_width(resolution)
+        x_anchor, y_anchor = -pi * R, -3 * pi * R / 4
+        for x1, x2, y1, y2 in boxes:
+            x1, x2 = max(x1 - w, -pi * R), min(x2 + w, pi * R)
+            y1, y2 = max(y1 - w, -3 * pi * R / 4), min(y2 + w, 3 * pi * R / 4)
+            if x2 < x1 or y2 < y1:
+                continue
+            i0, i1 = floor((x1 - x_anchor) / w), floor((x2 - x_anchor) / w)
+            j0, j1 = floor((y1 - y_anchor) / w), floor((y2 - y_anchor) / w)
+            xs = x_anchor + (np.arange(i0, i1 + 1) + 0.5) * w
+            rows_per_chunk = max(1, chunk // len(xs))
+            for j in range(j0, j1 + 1, rows_per_chunk):
+                ys = (
+                    y_anchor + (np.arange(j, min(j + rows_per_chunk, j1 + 1)) + 0.5) * w
+                )
+                gx, gy = np.meshgrid(xs, ys, indexing="ij")
+                valid, face, digits = self._parse_planar_points(
+                    gx.ravel(), gy.ravel(), resolution
+                )
+                if valid.any():
+                    yield face[valid], digits[valid]
 
     def cell_from_region(
         self, ul: tuple[float, float], dr: tuple[float, float], plane: bool = True
@@ -1874,14 +2081,29 @@ class RHEALPixDGGS:
         """
         valid, face, digits, resolution = self._parse_indices(indices)
         result = np.full((len(valid), 2), np.nan)
-        if not valid.any():
-            return result
-        face, digits, resolution = face[valid], digits[valid], resolution[valid]
+        if valid.any():
+            result[valid] = self._centroids(
+                face[valid], digits[valid], resolution[valid], plane
+            )
+        return result
+
+    def _centroids(
+        self,
+        face: np.ndarray,
+        digits: np.ndarray,
+        resolution: np.ndarray,
+        plane: bool,
+    ) -> FloatArray:
+        """
+        ``centroids`` for the valid cells parsed by ``_parse_indices``, as a
+        ``(len(face), 2)`` array.
+        """
+        result = np.empty((len(face), 2))
         x, y, width, region = self._index_geometry(face, digits, resolution)
         nucleus_x, nucleus_y = x + width / 2, y - width / 2
         if plane:
-            result[valid, 0] = nucleus_x
-            result[valid, 1] = nucleus_y
+            result[:, 0] = nucleus_x
+            result[:, 1] = nucleus_y
             return result
         lon, lat = self.rhealpix(nucleus_x, nucleus_y, inverse=True)
         out_lon, out_lat = lon.copy(), lat.copy()
@@ -1891,16 +2113,26 @@ class RHEALPixDGGS:
         # evaluates it; the mean longitude is the nucleus longitude.
         quad = shape == 0
         if quad.any():
+            # Latitude is independent of x in the equatorial region, so
+            # quads in one planar row (same y and width) share their mean
+            # latitude: integrate once per distinct row and broadcast.
+            rows, inverse = np.unique(
+                np.column_stack([y[quad], width[quad], nucleus_x[quad] * 0]),
+                axis=0,
+                return_inverse=True,
+            )
             nodes, weights = roots_legendre(20)
-            y1 = (y[quad] - width[quad])[:, None]
-            y2 = y[quad][:, None]
+            y1 = (rows[:, 0] - rows[:, 1])[:, None]
+            y2 = rows[:, 0][:, None]
             ys = (y2 - y1) * (nodes + 1) / 2.0 + y1
-            xs = np.broadcast_to(nucleus_x[quad][:, None], ys.shape)
+            x_rep = np.zeros(len(rows))
+            np.put(x_rep, inverse, nucleus_x[quad])
+            xs = np.broadcast_to(x_rep[:, None], ys.shape)
             phis = self.rhealpix(xs.ravel(), ys.ravel(), inverse=True)[1].reshape(
                 ys.shape
             )
             integral = (y2 - y1)[:, 0] / 2.0 * np.sum(weights * phis, axis=1)
-            out_lat[quad] = (1 / (y2 - y1)[:, 0]) * integral
+            out_lat[quad] = ((1 / (y2 - y1)[:, 0]) * integral)[inverse.ravel()]
         # Darts and skew quads: area-weighted means over the planar square by
         # the fixed product rules of Cell._centroid_quadrature.
         t, w = _gauss_legendre_unit(_CENTROID_QUADRATURE_ORDER)
@@ -1944,8 +2176,8 @@ class RHEALPixDGGS:
                     out_lat[rows] = np.sum(weights_u * lats, axis=1)
                     if kind == "skew":
                         out_lon[rows] = np.sum(weights_u * lons, axis=1)
-        result[valid, 0] = out_lon
-        result[valid, 1] = out_lat
+        result[:, 0] = out_lon
+        result[:, 1] = out_lat
         return result
 
     def _shape_code(

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -1,8 +1,11 @@
 from typing import Literal
 from warnings import warn
 
+import numpy as np
+import shapely
 from shapely import is_valid_reason
-from shapely.geometry import LineString, MultiLineString, MultiPolygon, Point, Polygon
+from shapely.affinity import translate
+from shapely.geometry import LineString, MultiLineString, MultiPolygon, Polygon, box
 
 # List of resolution 0 cell addresses (i.e. cube faces)
 from rhealpixdggs.cell import CELLS0, Cell
@@ -440,11 +443,34 @@ def polyfill(
     compress: bool = False,
     verbose: bool = False,
     dggs: RHEALPixDGGS = WGS84_003,
+    containment: Literal["center", "full", "overlapping"] = "center",
 ) -> set[str] | None:
     """
     Turns the area contained in a shapely polygon or multipolygon into a set of cell
-    indices at the requested resolution. A cell index is included if its centroid is
-    inside the geometry defined by the boundaries and holes.
+    indices at the requested resolution. Which cells count is chosen by
+    `containment`, following H3's modes:
+
+    - ``"center"`` (default): a cell is included if its centroid is inside the
+      geometry defined by the boundaries and holes.
+    - ``"full"``: a cell is included if the whole cell lies within the geometry
+      (its boundary may touch the geometry's).
+    - ``"overlapping"``: a cell is included if any part of it meets the
+      geometry, so the result covers the geometry.
+
+    ``full`` and ``overlapping`` test the cell's boundary polygon. In the plane
+    that polygon is exact. On the ellipsoid, equatorial cells are
+    longitude-latitude aligned and exact too; polar cells have curved edges,
+    which are represented by ``6`` points per edge (``Cell.boundary(n=6)``), so
+    a decision there is made against that piecewise-linear approximation. A
+    cap cell, which spans every longitude, is fully inside only a geometry
+    that covers the whole latitude band from the cap's boundary to the pole,
+    and overlaps any geometry reaching that latitude.
+
+    The candidate cells are those of the geometry's bounding box
+    (``RHEALPixDGGS.cells_in_box``), and every test runs on all candidates
+    at once: centroids from ``RHEALPixDGGS.centroids``, boundaries from
+    ``RHEALPixDGGS.boundary_array``, predicates from shapely's vectorised
+    functions.
 
     Returns an empty set if no cell centroids fall within the input geometry.
 
@@ -512,6 +538,11 @@ def polyfill(
 
         return None
 
+    if containment not in ("center", "full", "overlapping"):
+        raise ValueError(
+            f"containment must be 'center', 'full' or 'overlapping', not {containment!r}"
+        )
+
     # Extract list of polygons from geometry: Polygon needs to be wrapped in
     # one, MultiPolygon has it stashed in a property
     if isinstance(geometry, Polygon):
@@ -520,32 +551,151 @@ def polyfill(
         geoms = list(geometry.geoms)
 
     # Collect cells in regions of interest
-    cells = set()
+    cells: set[str] = set()
     for geom in geoms:
-        # Region of interest is the bounding box around the geometry
-        bbox = geom.bounds
-
-        # rhealpixdggs wants nw and se corners of region of interest
-        nw = (bbox[0], bbox[3])
-        se = (bbox[2], bbox[1])
-
-        # Cells in bounding box at requested resolution
-        roi_cells = dggs.cells_from_region(res, nw, se, plane)
-
-        if roi_cells:
-            # Flatten list of lists of cells in bbox
-            flat_cells = [cell for nested_list in roi_cells for cell in nested_list]
-
-            # Check each cell against geometry, add to results if inside polygon
-            for cell in flat_cells:
-                if geom.contains(Point(cell.centroid(plane))):
-                    cells.add(str(cell))
+        # Candidates: every cell of the geometry's bounding box, as the
+        # arrays cells_in_box builds its index strings from, in chunks that
+        # bound the working set; only the kept cells are turned into strings.
+        minx, miny, maxx, maxy = geom.bounds
+        boxes = dggs._candidate_boxes((minx, maxy), (maxx, miny), plane)
+        shapely.prepare(geom)
+        for face, digits in dggs._lattice_cells(boxes, res):
+            resolution = np.full(len(face), res)
+            if containment == "center":
+                keep = _cells_with_centroid_inside(
+                    geom, dggs, plane, face, digits, resolution
+                )
+            else:
+                keep = _cells_within_or_overlapping(
+                    geom, dggs, plane, face, digits, resolution, containment == "full"
+                )
+            if keep.any():
+                cells.update(
+                    dggs._format_indices(face[keep], digits[keep], res).tolist()
+                )
 
     # Merge cells inside polygon into larger ones where possible
     if compress:
         cells = compact_cells(cells, N_side=dggs.N_side)
 
     return cells
+
+
+def _cells_with_centroid_inside(
+    geom: Polygon,
+    dggs: RHEALPixDGGS,
+    plane: bool,
+    face: np.ndarray,
+    digits: np.ndarray,
+    resolution: np.ndarray,
+) -> np.ndarray:
+    """
+    For each cell, given as the arrays ``RHEALPixDGGS._parse_indices``
+    produces, whether its centroid lies inside `geom`.
+
+    In the plane the centroid is the nucleus. On the ellipsoid the centroid
+    is the mean of longitude and latitude over the cell, so it lies within
+    the cell's longitude-latitude bounding box: a cell whose box is wholly
+    inside `geom` is in, one whose box is disjoint from it is out, and only
+    the cells whose box meets the boundary need their centroid computed.
+    Boxes spanning more than half a turn of longitude (cells straddling the
+    antimeridian) are not trusted and always get the exact test.
+    """
+    if plane:
+        x, y, width, _ = dggs._index_geometry(face, digits, resolution)
+        return shapely.contains_xy(geom, x + width / 2, y - width / 2)
+    corners = dggs._boundary_array(face, digits, resolution, 2, False)
+    lo = corners.min(axis=1)
+    hi = corners.max(axis=1)
+    trusted = hi[:, 0] - lo[:, 0] <= dggs.ellipsoid.pi()
+    keep = np.zeros(len(face), dtype=bool)
+    undecided = ~trusted
+    if trusted.any():
+        boxes = shapely.box(
+            lo[trusted, 0], lo[trusted, 1], hi[trusted, 0], hi[trusted, 1]
+        )
+        inside = shapely.contains(geom, boxes)
+        outside = shapely.disjoint(geom, boxes)
+        keep[np.flatnonzero(trusted)[inside]] = True
+        undecided[np.flatnonzero(trusted)[~inside & ~outside]] = True
+    if undecided.any():
+        centroids = dggs._centroids(
+            face[undecided], digits[undecided], resolution[undecided], False
+        )
+        keep[undecided] = shapely.contains_xy(geom, centroids[:, 0], centroids[:, 1])
+    return keep
+
+
+def _cells_within_or_overlapping(
+    geom: Polygon,
+    dggs: RHEALPixDGGS,
+    plane: bool,
+    face: np.ndarray,
+    digits: np.ndarray,
+    resolution: np.ndarray,
+    full: bool,
+) -> np.ndarray:
+    """
+    For each cell, given as the arrays ``RHEALPixDGGS._parse_indices``
+    produces, whether it lies fully within `geom` (`full` = True) or meets
+    it at all (`full` = False), tested on the cells' boundary polygons:
+    exact in the plane and for equatorial cells, a 6-point-per-edge
+    approximation of the curved edges of polar cells. Cap cells and cells
+    crossing the antimeridian are handled apart, as their rings are not
+    polygons in longitude-latitude coordinates.
+    """
+    polar = (face == 0) | (face == 5)
+    n = 6 if (not plane and polar.any()) else 2
+    rings = dggs._boundary_array(face, digits, resolution, n, plane)
+    if plane:
+        polys = shapely.polygons(rings)
+        return np.asarray(
+            shapely.contains(geom, polys) if full else shapely.intersects(geom, polys)
+        )
+
+    keep = np.zeros(len(face), dtype=bool)
+    cap = dggs._shape_code(face, digits, resolution) == 1
+    half = dggs.ellipsoid.pi()
+    # A ring whose longitudes jump between -180 and 180 is unwrapped
+    # eastwards past 180. A cell whose east edge lies exactly on the
+    # antimeridian then reads as an ordinary polygon within [-180, 180];
+    # one that genuinely crosses it reaches beyond 180.
+    lon = rings[:, :, 0]
+    wraps = ~cap & (lon.max(axis=1) - lon.min(axis=1) > half)
+    rings[wraps, :, 0] = np.where(lon[wraps] < 0, lon[wraps] + 2 * half, lon[wraps])
+    crosses = wraps & (rings[:, :, 0].max(axis=1) > half * (1 + 1e-12))
+    plain = ~cap & ~crosses
+
+    if plain.any():
+        polys = shapely.polygons(rings[plain])
+        keep[plain] = (
+            shapely.contains(geom, polys) if full else shapely.intersects(geom, polys)
+        )
+    if crosses.any() and not full:
+        # A crossing cell can only be fully inside a geometry that itself
+        # crosses, which callers must have split, so it is never `full`; it
+        # overlaps the geometry if its unwrapped ring meets the geometry or
+        # the geometry shifted one turn east.
+        polys = shapely.polygons(rings[crosses])
+        shifted = translate(geom, xoff=2 * half)
+        keep[crosses] = shapely.intersects(geom, polys) | shapely.intersects(
+            shifted, polys
+        )
+    if cap.any():
+        _, miny, _, maxy = geom.bounds
+        for k in np.flatnonzero(cap):
+            lat_c = rings[k, 0, 1]
+            north = face[k] == 0
+            band = (
+                box(-half, lat_c, half, half / 2)
+                if north
+                else box(-half, -half / 2, half, lat_c)
+            )
+            if full:
+                keep[k] = geom.covers(band)
+            else:
+                keep[k] = maxy >= lat_c if north else miny <= lat_c
+    return keep
 
 
 def linetrace(

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -223,6 +223,51 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
         c2 = rdggs.cell_from_point(1, p2, plane=False)
         self.assertEqual(c1, c2)
 
+    def test_cells_in_box(self):
+        # cells_in_box enumerates candidate cells with array arithmetic; it
+        # must contain every cell cells_from_region returns for the same box,
+        # in all three regions, across the wrap meridian of a rotated grid,
+        # and for boxes touching the poles or longitude 180.
+        from random import Random
+
+        rotated = RHEALPixDGGS(
+            Ellipsoid(lon_0=129, radians=False), north_square=0, south_square=0
+        )
+        rng = Random(20260908)
+        for rdggs in (WGS84_003, rotated):
+            for _ in range(60):
+                lon1 = rng.uniform(-180, 170)
+                lon2 = min(180, lon1 + rng.uniform(0.5, 60))
+                lat1 = rng.uniform(-90, 85)
+                lat2 = min(90, lat1 + rng.uniform(0.5, 40))
+                res = rng.randint(1, 3)
+                rows = rdggs.cells_from_region(
+                    res, (lon1, lat2), (lon2, lat1), plane=False
+                )
+                want = {str(c) for row in rows for c in row}
+                have = set(
+                    rdggs.cells_in_box(res, (lon1, lat2), (lon2, lat1), plane=False)
+                )
+                self.assertTrue(
+                    want <= have, (lon1, lat2, lon2, lat1, res, want - have)
+                )
+        # Whole-globe box: every cell.
+        self.assertEqual(
+            len(WGS84_003.cells_in_box(2, (-180, 90), (180, -90), plane=False)), 6 * 81
+        )
+        # Planar box inside one face, and one reaching outside the image.
+        R = WGS84_003.ellipsoid.R_A
+        inside = set(WGS84_003.cells_in_box(1, (0.1 * R, 0.5 * R), (0.6 * R, 0.1 * R)))
+        rows = WGS84_003.cells_from_region(1, (0.1 * R, 0.5 * R), (0.6 * R, 0.1 * R))
+        self.assertTrue({str(c) for row in rows for c in row} <= inside)
+        # Reaching above the band, where cells_from_region finds no corner
+        # cell: the cells of the in-image part are still enumerated, with
+        # the one-cell margin reaching into face P but not into a polar
+        # square.
+        beyond = set(WGS84_003.cells_in_box(1, (0.1 * R, 3 * R), (0.6 * R, 0.1 * R)))
+        self.assertTrue(inside <= beyond)
+        self.assertEqual({index[0] for index in beyond}, {"P", "Q"})
+
     def test_cells_from_line(self):
         rdggs = WGS84_003
 

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -629,6 +629,237 @@ class RhpWrappersTestCase(unittest.TestCase):
         self.assertEqual(rhpw.polyfill(plane_poly, 1), set())
         self.assertEqual(rhpw.polyfill(geom_res_mismatch, 0, False), set())
 
+    @staticmethod
+    def _polyfill_by_cells(geom, res, plane, dggs):
+        # The algorithm polyfill used before it was vectorised: the cells of
+        # the bounding box from cells_from_region, one Cell.centroid and one
+        # shapely point test each. Kept here as the oracle for the default
+        # "center" mode.
+        geoms = [geom] if isinstance(geom, sh.Polygon) else list(geom.geoms)
+        out = set()
+        for g in geoms:
+            b = g.bounds
+            for row in dggs.cells_from_region(res, (b[0], b[3]), (b[2], b[1]), plane):
+                for cell in row:
+                    if g.contains(sh.Point(cell.centroid(plane))):
+                        out.add(str(cell))
+        return out
+
+    def test_polyfill_matches_cell_by_cell_algorithm(self):
+        from rhealpixdggs.ellipsoids import WGS84_A, WGS84_F, Ellipsoid
+
+        nz = sh.Polygon(
+            [
+                (166.0, -46.8),
+                (169.5, -47.5),
+                (174.5, -42.0),
+                (178.8, -37.8),
+                (177.0, -35.5),
+                (173.5, -34.0),
+                (171.5, -36.5),
+                (166.5, -43.5),
+            ]
+        )
+        holed = sh.Polygon(
+            [(-10, -10), (50, -10), (50, 40), (-10, 40)],
+            holes=[[(-5, 5), (25, 20), (45, 5)], [(-5, 25), (25, 30), (45, 25)]],
+        )
+        polar = sh.box(-30, 70, 30, 85)
+        near_pole = sh.Polygon([(-170, 80), (170, 80), (170, 89.9), (-170, 89.9)])
+        south = sh.Polygon(
+            [(30, -42), (0, -75), (90, -75), (60, -42)],
+            holes=[[(10, -70), (20, -65), (10, -65)]],
+        )
+        multi = sh.MultiPolygon(
+            [holed, sh.Polygon([(0, 75), (-30, 42), (0, 42), (30, 42)])]
+        )
+        to_antimeridian = sh.box(150, -30, 180, 10)
+        rotated = gs.RHEALPixDGGS(
+            Ellipsoid(a=WGS84_A, f=WGS84_F, radians=False, lon_0=129),
+            north_square=0,
+            south_square=0,
+        )
+        R = gs.WGS84_003.ellipsoid.R_A
+        planar = sh.Polygon(
+            [(0.1 * R, 0.1 * R), (0.9 * R, 0.2 * R), (0.5 * R, 0.7 * R)]
+        )
+        cases = [
+            (nz, gs.WGS84_003, False),
+            (holed, gs.WGS84_003, False),
+            (polar, gs.WGS84_003, False),
+            (near_pole, gs.WGS84_003, False),
+            (south, gs.WGS84_003, False),
+            (multi, gs.WGS84_003, False),
+            (to_antimeridian, gs.WGS84_003, False),
+            (nz, rotated, False),
+            (holed, rotated, False),
+            (nz, gs.WGS84_002, False),
+            (planar, gs.WGS84_003, True),
+        ]
+        for geom, dggs, plane in cases:
+            for res in (2, 3, 4):
+                self.assertEqual(
+                    rhpw.polyfill(geom, res, plane=plane, dggs=dggs),
+                    self._polyfill_by_cells(geom, res, plane, dggs),
+                    (geom.bounds, dggs.ellipsoid.lon_0, plane, res),
+                )
+
+        # A planar geometry reaching outside the image: cells_from_region
+        # gave up (a bounding-box corner had no cell) and polyfill returned
+        # nothing; the vectorised fill finds the cells that are inside.
+        R = gs.WGS84_003.ellipsoid.R_A
+        outside = sh.Polygon(
+            [(0.1 * R, 0.1 * R), (0.9 * R, 0.2 * R), (0.5 * R, 0.9 * R)]
+        )
+        got = rhpw.polyfill(outside, 2, plane=True)
+        want = {
+            str(c)
+            for c in gs.WGS84_003.grid(2)
+            if outside.contains(sh.Point(c.nucleus(plane=True)))
+        }
+        self.assertTrue(want)
+        self.assertEqual(got, want)
+
+    def test_polyfill_containment_modes(self):
+        from rhealpixdggs.ellipsoids import WGS84_A, WGS84_F, Ellipsoid
+
+        dggs = gs.WGS84_003
+        nz = sh.Polygon(
+            [
+                (166.0, -46.8),
+                (169.5, -47.5),
+                (174.5, -42.0),
+                (178.8, -37.8),
+                (177.0, -35.5),
+                (173.5, -34.0),
+                (171.5, -36.5),
+                (166.5, -43.5),
+            ]
+        )
+        holed = sh.Polygon(
+            [(-10, -10), (50, -10), (50, 40), (-10, 40)],
+            holes=[[(-5, 5), (25, 20), (45, 5)], [(-5, 25), (25, 30), (45, 25)]],
+        )
+        for geom, res in ((nz, 4), (nz, 5), (holed, 3)):
+            center = rhpw.polyfill(geom, res, plane=False, containment="center")
+            full = rhpw.polyfill(geom, res, plane=False, containment="full")
+            over = rhpw.polyfill(geom, res, plane=False, containment="overlapping")
+            self.assertEqual(center, rhpw.polyfill(geom, res, plane=False))
+            self.assertTrue(full <= center <= over, res)
+            self.assertLess(len(full), len(over))
+            # Every candidate is decided by its (6-point-per-edge) boundary
+            # polygon: within the geometry for full, meeting it for
+            # overlapping, and no other candidate meets it.
+            b = geom.bounds
+            candidates = dggs.cells_in_box(res, (b[0], b[3]), (b[2], b[1]), plane=False)
+            rings = dggs.boundary_array(candidates, n=6, plane=False)
+            for index, ring in zip(candidates, rings):
+                # A cell whose east edge is the antimeridian reads back at
+                # longitude -180; unwrap it as polyfill does.
+                lons = ring[:, 0]
+                if lons.max() - lons.min() > 180:
+                    ring = ring.copy()
+                    ring[:, 0] = [lon + 360 if lon < 0 else lon for lon in lons]
+                poly = sh.Polygon(ring)
+                self.assertTrue(poly.is_valid, index)
+                self.assertEqual(index in full, geom.contains(poly), index)
+                self.assertEqual(index in over, geom.intersects(poly), index)
+
+        # In the plane: a cell's nine children are fully inside its square
+        # and have their centroids inside it; grown by a millionth of a
+        # child's width, the square also overlaps the sixteen cells around
+        # them (a square exactly on the lattice touches its neighbours only
+        # up to the last bit of two independently computed coordinates, so
+        # that case is bounded rather than pinned).
+        cell = dggs.cell(("N", 2, 1, 6, 0, 5, 5, 6, 1, 1))
+        square = sh.Polygon(cell.vertices(plane=True))
+        eps = 1e-6 * dggs.cell_width(10)
+        minx, miny, maxx, maxy = square.bounds
+        grown = sh.box(minx - eps, miny - eps, maxx + eps, maxy + eps)
+        children = {str(c) for c in cell.subcells()}
+        for geom in (square, grown):
+            self.assertEqual(rhpw.polyfill(geom, 10, containment="full"), children)
+            self.assertEqual(rhpw.polyfill(geom, 10, containment="center"), children)
+        over = rhpw.polyfill(grown, 10, containment="overlapping")
+        self.assertTrue(children <= over)
+        self.assertEqual(len(over), 25)
+        exact = rhpw.polyfill(square, 10, containment="overlapping")
+        self.assertTrue(children <= exact <= over)
+        self.assertEqual(rhpw.polyfill(grown, 9, containment="full"), {str(cell)})
+
+        # Cap cells: the resolution 1 north cap N4 is bounded by one parallel.
+        cap = dggs.cell(("N", 4))
+        cap_lat = cap.boundary(n=2, plane=False)[0][1]
+        band = sh.Polygon(
+            [(-180, cap_lat - 1), (180, cap_lat - 1), (180, 90), (-180, 90)]
+        )
+        thin = sh.Polygon([(-180, 88), (180, 88), (180, 90), (-180, 90)])
+        self.assertIn("N4", rhpw.polyfill(band, 1, plane=False, containment="full"))
+        self.assertIn(
+            "N4", rhpw.polyfill(band, 1, plane=False, containment="overlapping")
+        )
+        self.assertNotIn("N4", rhpw.polyfill(thin, 1, plane=False, containment="full"))
+        self.assertIn(
+            "N4", rhpw.polyfill(thin, 1, plane=False, containment="overlapping")
+        )
+        # A polygon that stops short of the cap does not overlap it.
+        short = sh.Polygon(
+            [(-30, 42), (30, 42), (30, cap_lat - 0.5), (-30, cap_lat - 0.5)]
+        )
+        self.assertNotIn(
+            "N4", rhpw.polyfill(short, 1, plane=False, containment="overlapping")
+        )
+
+        # Antimeridian: on a grid rotated to lon_0 = 129 some cells straddle
+        # longitude 180. A box up to 180 overlaps them; none is fully inside.
+        rotated = gs.RHEALPixDGGS(
+            Ellipsoid(a=WGS84_A, f=WGS84_F, radians=False, lon_0=129),
+            north_square=0,
+            south_square=0,
+        )
+        geom = sh.box(170, -10, 180, 10)
+        over = rhpw.polyfill(
+            geom, 3, plane=False, dggs=rotated, containment="overlapping"
+        )
+        full = rhpw.polyfill(geom, 3, plane=False, dggs=rotated, containment="full")
+        rings = rotated.boundary_array(sorted(over), n=2, plane=False)
+        span = rings[:, :, 0].max(axis=1) - rings[:, :, 0].min(axis=1)
+        self.assertTrue((span > 180).any())
+        self.assertTrue(full <= over)
+        for index, s in zip(sorted(over), span):
+            self.assertFalse(s > 180 and index in full, index)
+
+        with self.assertRaises(ValueError):
+            rhpw.polyfill(nz, 3, plane=False, containment="inside")
+
+    def test_polyfill_is_independent_of_chunking(self):
+        # polyfill works through the candidate cells in chunks that bound
+        # its working set; the result must not depend on the chunk size.
+        from unittest.mock import patch
+
+        nz = sh.Polygon(
+            [
+                (166.0, -46.8),
+                (169.5, -47.5),
+                (174.5, -42.0),
+                (178.8, -37.8),
+                (177.0, -35.5),
+                (173.5, -34.0),
+                (171.5, -36.5),
+                (166.5, -43.5),
+            ]
+        )
+        expected = {
+            mode: rhpw.polyfill(nz, 5, plane=False, containment=mode)
+            for mode in ("center", "full", "overlapping")
+        }
+        self.assertGreater(len(expected["center"]), 500)
+        with patch.object(gs, "_LATTICE_CHUNK", 97):
+            for mode, cells in expected.items():
+                self.assertEqual(
+                    rhpw.polyfill(nz, 5, plane=False, containment=mode), cells, mode
+                )
+
     def test_linetrace(self):
         # Test data
         p_ls = sh.LineString(


### PR DESCRIPTION
Follow-up work is tracked in #144 (hierarchical covering, array output).

## Assessment

`polyfill` already had the right algorithm: enumerate the cells of the geometry's bounding box, keep those whose centroid is inside, optionally compact. That is what H3 v4's `polygonToCells` does. It just ran every step one cell at a time in Python (`cells_from_region` building a `Cell` per bounding-box cell, `Cell.centroid` per cell, a shapely point test per cell), about 0.5 ms per candidate. S2's `RegionCoverer` (hierarchical, multi-resolution) and DGGRID's clipping with a coarse pre-filter were considered; the hierarchical route is deferred to #144, since the vectorised fill plus `compress=True` reaches the same representation.

## Changes

- **`RHEALPixDGGS.cells_in_box(resolution, ul, dr, plane)`**: candidate cells of a planar or lon-lat box as index strings, a superset of `cells_from_region`'s cells computed without `Cell` objects. The box is split at the region boundaries and the wrap meridian; each part's planar bounding box comes from its projected corners and the crossings of the polar squares' diagonal meridians with its latitude edges (polar parts sampled a hair inside the region, since the projection at exactly ±phi_0 is the equatorial one). Internally the lattice cells are produced as face/digit arrays in chunks of 250,000 (`_lattice_cells`).
- **`polyfill` rewrite** consuming those arrays directly (no round trip through index strings; only kept cells become strings), with a new `containment` parameter following H3:
  - `center` (default, output unchanged): a centroid is a mean of lon/lat, so it lies inside the cell's lon-lat bounding box; cells whose box is wholly inside or outside the geometry are decided from four corners and only boundary cells have their centroid integrated.
  - `full` / `overlapping`: boundary polygons from `boundary_array`, exact in the plane and for equatorial cells, six points per edge for curved polar edges. Cap cells are tested against their latitude band; rings that wrap are unwrapped past 180 so a cell whose east edge is the antimeridian is an ordinary polygon, while a cell crossing it is never `full` and overlaps if the unwrapped ring meets the geometry or the geometry shifted one turn.
- **`RHEALPixDGGS.centroids`** integrates equatorial quads once per planar row (latitude is independent of x there). `cells_from_points` and `centroids` now share their array cores with `polyfill`.
- **One behaviour change**: a planar geometry reaching outside the image used to return no cells at all (`cells_from_region` found no cell at a bounding-box corner); the cells inside are now found.

## Results (WGS84_003, plane=False)

| case | before | after | peak memory |
|---|---|---|---|
| New Zealand, res 7, 42,000 cells | 25.5 s | 0.3 s | 68 MB |
| 40°×20° equatorial box, res 6, 60,600 cells | 11.2 s | 0.14 s | 45 MB |
| polar box 70–85°N, res 5, 1,660 cells | 0.77 s | 0.02 s | |
| New Zealand, res 8, 378,000 cells | — | 2.2 s | 212 MB |
| New Zealand, res 9, 3.4 M cells | — | 19.2 s | 501 MB |

Time is linear in candidates; memory is bounded by the chunk size, and at res 9 the floor is the result set itself (#144).

## Tests

- The previous cell-by-cell algorithm is kept in the test suite as an oracle; the default mode equals it on eleven geometries (equatorial with holes, region-crossing, polar, near-pole, MultiPolygon, reaching the antimeridian, a rotated grid, `N_side=2`, planar) at resolutions 2–4.
- `cells_in_box` is a superset of `cells_from_region` on 120 seeded random boxes on the standard and a rotated grid, plus whole-globe and planar cases.
- Containment modes: `full ⊆ center ⊆ overlapping`; every candidate's decision matches shapely on its (unwrapped) boundary polygon; planar exact-square and grown-square cases; cap cells; antimeridian-touching and -crossing cells on a rotated grid; `ValueError` for an unknown mode.
- Results are independent of the chunk size (patched down to 97).

## Verification

175 unit tests and all doctests pass; ruff, black and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
