### PR TITLE
Make polyfill a hierarchical fill with min_res, and add polyfill_array

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,31 +9,59 @@ equatorial cells, a 6-point-per-edge approximation for the curved edges of
 polar cells; cap cells and antimeridian-straddling cells are handled
 apart.
 
-``polyfill`` is also vectorised end to end: the candidate cells of the
-geometry's bounding box come from the new
-``RHEALPixDGGS.cells_in_box(resolution, ul, dr, plane)`` (the index strings
-of every cell meeting the box's planar image, a superset of
-``cells_from_region`` computed without ``Cell`` objects), their centroids
-from ``RHEALPixDGGS.centroids`` and their boundaries from
-``RHEALPixDGGS.boundary_array``, and shapely's vectorised predicates decide
-all candidates at once. In the default mode a cell's centroid, the mean
-of longitude and latitude over the cell, lies within the cell's
-longitude-latitude bounding box, so cells whose box is wholly inside or
-wholly outside the geometry are decided from four corner points and only
-the cells along the geometry's boundary have their centroid integrated.
-Candidates are carried as arrays from the lattice to the geometry code,
-not round-tripped through index strings, and are processed in chunks of
-250,000, so the working set is bounded whatever the resolution: a
-378,000-cell resolution-8 fill of New Zealand peaks at about 200 MB.
-Default results are unchanged: a 42,000-cell resolution-7 fill of New
-Zealand drops from 25.5 s to 0.3 s, a 60,000-cell resolution-6
-equatorial box from 11.2 s to 0.14 s, a 1,700-cell resolution-5 polar box
-from 0.77 s to 0.02 s. One behaviour differs: a planar geometry reaching
-outside the planar image used to yield no cells at all (``cells_from_region``
-found no cell at a bounding-box corner); the cells inside the image are
-now found. ``RHEALPixDGGS.centroids`` integrates the mean latitude of
-equatorial quads once per planar row rather than once per cell, as
-latitude is independent of x there.
+``polyfill`` is rebuilt as a hierarchical fill on arrays. It descends from
+resolution ``min_res`` (a new parameter, default 0): a cell wholly inside
+the geometry is kept whole, a cell missing it is dropped, and only the
+cells the boundary passes through are split, down to ``res``, where the
+remaining cells are decided by ``containment``. So the work grows with the
+length of the boundary rather than the area. With ``compress=False`` the
+kept coarse cells are expanded into their resolution-``res`` descendants,
+giving exactly the cells a cell-by-cell test at ``res`` gives (the cells
+themselves are unchanged from earlier releases, with one exception below).
+With ``compress=True`` the coarse cells are returned as they are: a
+mixed-resolution cover with no cell coarser than ``min_res`` and no complete
+sibling group left unmerged, so that every cell of the result has exactly
+one ancestor at resolution ``min_res``, which suits partitioning by that
+resolution. This changes what ``compress=True`` returns in the default
+``center`` mode along the boundary only: compaction merged nine siblings
+whose centroids were all inside even when the boundary clipped their
+parent's corner; the cover splits such a parent, since it is not wholly
+inside. In ``full`` mode the two agree exactly. "Wholly inside" is judged
+by the cell's boundary polygon for ``full`` and ``overlapping``, and for
+``center`` by the cell's longitude-latitude bounding box, within which
+every descendant's centroid lies, so the centroid rule is kept exactly;
+above the leaves a cell is accepted or rejected only when clear of the
+geometry's boundary by about a centimetre, so an edge coinciding with a
+cell edge is left to the exact test at the leaves.
+
+Underneath, the new ``RHEALPixDGGS.cells_in_box(resolution, ul, dr, plane)``
+enumerates the cells meeting a box's planar image without ``Cell``
+objects (a superset of ``cells_from_region``), centroids come from
+``RHEALPixDGGS.centroids`` and boundaries from
+``RHEALPixDGGS.boundary_array``, shapely's vectorised predicates decide a
+whole frontier at once, cells are carried as arrays and held as one integer
+key each, and every frontier and expansion is processed in chunks of
+250,000 cells, so the working set is bounded whatever the resolution. The
+new ``rhp_wrappers.polyfill_array`` takes ``polyfill``'s arguments and
+returns the cells as a sorted numpy string array instead of a set, at about
+40 bytes per cell against some 100 for a set entry. ``RHEALPixDGGS.centroids``
+integrates the mean latitude of equatorial quads once per planar row, as
+latitude is independent of x there, and projects polar quadrature points in
+batches of 200,000 rather than a million, which bounds its peak memory.
+
+Measured on the New Zealand polygon (WGS84_003, ``plane=False``), against
+0.8.4: a 42,000-cell resolution-7 fill drops from 24.5 s to 0.33 s; the
+compressed fill at resolution 7 from 24.5 s to 0.32 s; a 60,000-cell
+resolution-6 equatorial box from 11.4 s to 0.02 s; a 1,700-cell
+resolution-5 polar box from 0.96 s to 0.05 s. Beyond 0.8.4's reach: the 3.4
+million cells of resolution 9 take 3.1 s (the result set is then the memory
+floor, about 490 MB as a set, 250 MB as an array); the resolution-9 cover
+of 18,000 cells takes 2.4 s and 70 MB, against 35 s and 660 MB by
+compaction of the flat fill; the resolution-10 cover of 55,000 cells takes
+6.4 s, or 1.9 s with ``min_res=5``. One behaviour differs from 0.8.4
+besides ``compress``: a planar geometry reaching outside the planar image
+used to yield no cells at all (``cells_from_region`` found no cell at a
+bounding-box corner); the cells inside the image are now found.
 
 0.8.4
 ^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,12 +27,27 @@ resolution. This changes what ``compress=True`` returns in the default
 whose centroids were all inside even when the boundary clipped their
 parent's corner; the cover splits such a parent, since it is not wholly
 inside. In ``full`` mode the two agree exactly. "Wholly inside" is judged
-by the cell's boundary polygon for ``full`` and ``overlapping``, and for
-``center`` by the cell's longitude-latitude bounding box, within which
-every descendant's centroid lies, so the centroid rule is kept exactly;
-above the leaves a cell is accepted or rejected only when clear of the
-geometry's boundary by about a centimetre, so an edge coinciding with a
-cell edge is left to the exact test at the leaves.
+by the cell's boundary polygon for ``full`` and ``overlapping`` where that
+is exact (the plane, equatorial cells), and otherwise by the cell's
+longitude-latitude bounding box, which contains the cell: for polar cells,
+whose 6-point polygon can lie a degree off the true edge of a coarse cell,
+and for ``center``, where the box also contains every descendant's
+centroid, so the centroid rule is kept exactly; above the leaves a cell is
+accepted or rejected only when clear of the geometry's boundary by about a
+centimetre, so an edge coinciding with a cell edge is left to the exact
+test at the leaves.
+
+``RHEALPixDGGS.boundary_array`` (and so ``cell_boundaries``) projects each
+boundary point from the planar coordinates its lattice key denotes, rather
+than from whichever cell of the batch first produced it, so a cell's
+longitude-latitude boundary is the same whether it is computed alone or
+with any other cells; the coordinates of a point shared with a neighbour
+can move by a last bit. ``polyfill``'s ``full`` and ``overlapping`` tests
+sample 6 points per edge for every cell on the ellipsoid, not only when the
+batch holds polar cells, for the same reason: a geometry edge lying exactly
+on a cell edge, as a box drawn at whole degrees does, previously counted or
+not depending on which cells were tested together, so the fill could differ
+between ``min_res`` values or chunk sizes by such cells.
 
 Underneath, the new ``RHEALPixDGGS.cells_in_box(resolution, ul, dr, plane)``
 enumerates the cells meeting a box's planar image without ``Cell``

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -2254,41 +2254,61 @@ class RHEALPixDGGS:
         # All boundary points lie on the fine lattice of pitch w/(n - 1)
         # anchored at the planar image's corner, shared with every
         # same-resolution neighbour's points, so integer lattice keys
-        # identify coincident points robustly.
+        # identify coincident points robustly. Each point is projected once,
+        # from the planar coordinates its key denotes rather than from any
+        # one cell's arithmetic for it (which differs from a neighbour's in
+        # the last bit), so a cell's boundary is the same whatever cells it
+        # is computed with, and a shared edge gets one set of coordinates.
         R = self.ellipsoid.R_A
-        cols = np.rint((x + pi * R) / delta[:, None]).astype(np.int64)
-        rows = np.rint((y + 3 * pi * R / 4) / delta[:, None]).astype(np.int64)
+        x_anchor, y_anchor = -pi * R, -3 * pi * R / 4
+        cols = np.rint((x - x_anchor) / delta[:, None]).astype(np.int64)
+        rows = np.rint((y - y_anchor) / delta[:, None]).astype(np.int64)
+
+        # The planar point a lattice key denotes, kept within the image,
+        # which the rounding can overshoot by a bit at its edges.
+        def lattice_x(col: np.ndarray, pitch: float) -> FloatArray:
+            return np.minimum(x_anchor + col * pitch, -x_anchor)
+
+        def lattice_y(row: np.ndarray, pitch: float) -> FloatArray:
+            return np.minimum(y_anchor + row * pitch, -y_anchor)
+
         lon = np.empty((count, m))
         lat = np.empty((count, m))
         for res in np.unique(resolution):
-            equatorial = (resolution == res) & (region_code == 0)
+            at = resolution == res
+            pitch = delta[at][0]
+            equatorial = at & (region_code == 0)
             if equatorial.any():
+                # Longitude depends on x alone here and latitude on y alone,
+                # so each column and each row is projected once.
                 xs, ys = x[equatorial].ravel(), y[equatorial].ravel()
                 col_ids, col_first, col_inv = np.unique(
                     cols[equatorial].ravel(), return_index=True, return_inverse=True
                 )
-                _, row_first, row_inv = np.unique(
+                row_ids, row_first, row_inv = np.unique(
                     rows[equatorial].ravel(), return_index=True, return_inverse=True
                 )
                 lons, lats = self.rhealpix(
-                    np.concatenate([xs[col_first], xs[row_first]]),
-                    np.concatenate([ys[col_first], ys[row_first]]),
+                    np.concatenate([lattice_x(col_ids, pitch), xs[row_first]]),
+                    np.concatenate([ys[col_first], lattice_y(row_ids, pitch)]),
                     inverse=True,
                     region="equatorial",
                 )
                 lon[equatorial] = lons[: len(col_ids)][col_inv].reshape(-1, m)
                 lat[equatorial] = lats[len(col_ids) :][row_inv].reshape(-1, m)
             for code, region in ((1, "north_polar"), (-1, "south_polar")):
-                polar = (resolution == res) & (region_code == code)
+                polar = at & (region_code == code)
                 if not polar.any():
                     continue
-                xs, ys = x[polar].ravel(), y[polar].ravel()
-                keys = cols[polar].ravel() * (1 << 32) + rows[polar].ravel()
+                c, r = cols[polar].ravel(), rows[polar].ravel()
                 _, first, inverse = np.unique(
-                    keys, return_index=True, return_inverse=True
+                    c * (1 << 32) + r, return_index=True, return_inverse=True
                 )
                 lons, lats = self.rhealpix(
-                    xs[first], ys[first], inverse=True, region=region
+                    lattice_x(c[first], pitch),
+                    lattice_y(r[first], pitch),
+                    inverse=True,
+                    region=region,
                 )
                 lon[polar] = lons[inverse].reshape(-1, m)
                 lat[polar] = lats[inverse].reshape(-1, m)

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -1097,7 +1097,10 @@ class RHEALPixDGGS:
         """
         chars = np.empty((len(face), resolution + 1), dtype=np.uint32)
         chars[:, 0] = np.array([ord(c) for c in CELLS0])[face]
-        chars[:, 1:] = digits[:, :resolution] + ord("0")
+        # Column by column: a whole-array temporary would be int64 and, for
+        # millions of cells, the largest allocation of the caller.
+        for k in range(resolution):
+            chars[:, k + 1] = digits[:, k] + ord("0")
         return chars.view(f"<U{resolution + 1}").ravel()
 
     def cells_in_box(
@@ -2154,12 +2157,14 @@ class RHEALPixDGGS:
             "rising": (shape == 2) & rising,
             "falling": (shape == 2) & ~rising,
         }
-        # Project each group in chunks of about a million points, so the
+        # Project each group in chunks of about 200,000 points, so the
         # working set stays a few tens of megabytes however many cells there
-        # are (each dart or skew quad needs several hundred points).
+        # are (each dart or skew quad needs several hundred points, and the
+        # array projection holds a dozen or so temporaries the size of its
+        # input).
         for kind, members in kinds.items():
             s_u, r_u, weights_u = rules[kind]
-            chunk = max(1, 1_000_000 // len(s_u))
+            chunk = max(1, 200_000 // len(s_u))
             for code, region_name in ((1, "north_polar"), (-1, "south_polar")):
                 group = np.flatnonzero(members & (region == code))
                 for start in range(0, len(group), chunk):

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal
 from warnings import warn
 
 import numpy as np
@@ -7,16 +7,16 @@ from shapely import is_valid_reason
 from shapely.affinity import translate
 from shapely.geometry import LineString, MultiLineString, MultiPolygon, Polygon, box
 
-# List of resolution 0 cell addresses (i.e. cube faces)
-from rhealpixdggs.cell import CELLS0, Cell
-from rhealpixdggs.conversion import compact_cells
-
 # ======== Messages and constants ======== #
 # Pre-defined DGGS with WGS84 ellipsoid, coordinates in degrees, n == 3 to subdivide
 # cell sides, and both N and S polar cube face attached to O equatorial cube face:
 # N
 # O P Q R
 # S
+import rhealpixdggs.dggs as rhp_dggs
+
+# List of resolution 0 cell addresses (i.e. cube faces)
+from rhealpixdggs.cell import CELLS0, Cell
 from rhealpixdggs.dggs import WGS84_003, RHEALPixDGGS
 
 # Warnings
@@ -444,6 +444,7 @@ def polyfill(
     verbose: bool = False,
     dggs: RHEALPixDGGS = WGS84_003,
     containment: Literal["center", "full", "overlapping"] = "center",
+    min_res: int = 0,
 ) -> set[str] | None:
     """
     Turns the area contained in a shapely polygon or multipolygon into a set of cell
@@ -491,6 +492,25 @@ def polyfill(
     antimeridian by the caller first, as is standard for planar GIS
     geometry.
 
+    The fill descends the hierarchy from resolution `min_res`: a cell wholly
+    inside the geometry is kept whole, a cell missing it is dropped, and only
+    the cells the boundary passes through are split, down to resolution
+    `res`, where the remaining cells are decided by `containment`. So the
+    work grows with the length of the boundary, not the area. With
+    `compress` = False every kept coarse cell is expanded into its
+    resolution-`res` descendants, giving exactly the cells a cell-by-cell
+    test at `res` would give. With `compress` = True the coarse cells are
+    returned as they are, a mixed-resolution cover with no cell coarser than
+    `min_res` and no complete group of siblings left unmerged; so every cell
+    of the result has exactly one ancestor at resolution `min_res`, which
+    suits partitioning by that resolution. "Wholly inside" is judged by the
+    cell's boundary polygon for ``full`` and ``overlapping`` and, for
+    ``center``, by the cell's longitude-latitude bounding box, which every
+    descendant's centroid lies within, so the centroid rule is kept exactly.
+
+    ``polyfill_array`` returns the same cells as a sorted numpy string array,
+    which costs less than half the memory per cell for large fills.
+
     EXAMPLES::
         >>> from shapely import Polygon
         >>> coords = ((0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.))
@@ -527,6 +547,98 @@ def polyfill(
         >>> 'Q3330600' not in result7  # original res-7 cell absorbed
         True
     """
+    found = _polyfill_arrays(
+        geometry, res, plane, verbose, dggs, containment, compress, min_res
+    )
+    if found is None:
+        return None
+    return set(_index_strings(dggs, *found).tolist())
+
+
+def polyfill_array(
+    geometry: Polygon | MultiPolygon,
+    res: int,
+    plane: bool = True,
+    compress: bool = False,
+    verbose: bool = False,
+    dggs: RHEALPixDGGS = WGS84_003,
+    containment: Literal["center", "full", "overlapping"] = "center",
+    min_res: int = 0,
+) -> np.ndarray | None:
+    """
+    ``polyfill`` returning the cell indices as a numpy string array instead of
+    a set: the same cells for the same arguments, sorted (by base cell, then
+    digit by digit, the order ``Cell`` objects sort in; with `compress` a
+    coarse cell comes where its descendants would) and without duplicates,
+    or ``None`` where ``polyfill`` returns ``None``. An empty array means no
+    cell qualified.
+
+    The array costs about ``4 * (res + 2)`` bytes per cell against roughly a
+    hundred for a set entry, and feeds array-based callers such as
+    ``RHEALPixDGGS.boundary_array``, ``RHEALPixDGGS.centroids`` or a data
+    frame column directly. Like the rest of the index-string API, this is
+    for DGGSs with single-character digits, ``N_side`` 2 or 3.
+
+    EXAMPLES::
+        >>> from shapely import Polygon
+        >>> polygon = Polygon(((0., 0.), (0., 1.), (1., 1.), (1., 0.), (0., 0.)))
+        >>> polyfill_array(polygon, res=5, plane=False).tolist()
+        ['Q33303', 'Q33304', 'Q33305', 'Q33306', 'Q33307', 'Q33308', 'Q33330', 'Q33331', 'Q33332']
+        >>> polyfill_array(polygon, res=2, plane=False).size
+        0
+        >>> polyfill_array(Polygon(), res=2, plane=False) is None
+        True
+    """
+    found = _polyfill_arrays(
+        geometry, res, plane, verbose, dggs, containment, compress, min_res
+    )
+    if found is None:
+        return None
+    return _index_strings(dggs, *found)
+
+
+def _index_strings(
+    dggs: RHEALPixDGGS, face: np.ndarray, digits: np.ndarray, resolution: np.ndarray
+) -> np.ndarray:
+    """
+    The index strings of cells given as base cell codes, digit rows and
+    per-cell resolutions, in input order, as one array wide enough for the
+    deepest.
+    """
+    width = int(resolution.max()) + 1 if len(resolution) else 1
+    out = np.empty(len(face), dtype=f"<U{width}")
+    for r in np.unique(resolution):
+        rows = resolution == r
+        out[rows] = dggs._format_indices(face[rows], digits[rows], int(r))
+    return out
+
+
+def _polyfill_arrays(
+    geometry: Polygon | MultiPolygon,
+    res: int,
+    plane: bool,
+    verbose: bool,
+    dggs: RHEALPixDGGS,
+    containment: str,
+    compress: bool,
+    min_res: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | None:
+    """
+    The cells ``polyfill`` selects, as ``(face, digits, resolution)`` arrays
+    in the form of ``RHEALPixDGGS._parse_indices`` (digits zero-padded to
+    `res` columns), sorted by base cell and then digit by digit and without
+    duplicates; ``None`` for a malformed geometry.
+
+    The fill descends from resolution `min_res`. At each level a cell wholly
+    inside the geometry is accepted, a cell disjoint from it dropped, and the
+    rest split into their children, until `res`, where the leaves are decided
+    by `containment`. Accepted cells are kept as they are when `compress`,
+    else expanded to their descendants at `res`. Every cell is held as one
+    int64 key: its base cell followed by its digits as a base N**2 number,
+    zero-padded to `res` digits, so that the keys' numeric order is the order
+    of base cell then digit by digit and a cover, having no cell that is an
+    ancestor of another, has no ties.
+    """
     # Stop early if the geometry is malformed
     if _malformed_geometry(geometry):
         if verbose:
@@ -542,6 +654,11 @@ def polyfill(
         raise ValueError(
             f"containment must be 'center', 'full' or 'overlapping', not {containment!r}"
         )
+    if not 0 <= min_res <= res:
+        raise ValueError(f"min_res must be between 0 and res={res}, not {min_res!r}")
+    N2 = dggs.N_side**2
+    if 6 * N2**res >= 2**62:
+        raise ValueError(f"resolution {res} is too deep for N_side={dggs.N_side}")
 
     # Extract list of polygons from geometry: Polygon needs to be wrapped in
     # one, MultiPolygon has it stashed in a property
@@ -550,35 +667,203 @@ def polyfill(
     else:
         geoms = list(geometry.geoms)
 
-    # Collect cells in regions of interest
-    cells: set[str] = set()
+    chunk = rhp_dggs._LATTICE_CHUNK
+    keys_out: list[np.ndarray] = []
+    res_out: list[np.ndarray] = []
+
+    def emit(keys: np.ndarray, level: int) -> None:
+        keys_out.append(keys)
+        res_out.append(np.full(len(keys), level, dtype=np.int8))
+
+    # Above the leaves a cell is accepted or rejected only when it is clear
+    # of the geometry's boundary by this margin (about a centimetre), so
+    # that a cell edge coinciding with a polygon edge, whose coordinates
+    # differ by an ulp between a parent and its children, is left to the
+    # exact test at the leaves.
+    margin = 1e-9 * (dggs.cell_width(0) if plane else dggs.ellipsoid.pi() / 2)
     for geom in geoms:
-        # Candidates: every cell of the geometry's bounding box, as the
-        # arrays cells_in_box builds its index strings from, in chunks that
-        # bound the working set; only the kept cells are turned into strings.
+        shapely.prepare(geom)
         minx, miny, maxx, maxy = geom.bounds
         boxes = dggs._candidate_boxes((minx, maxy), (maxx, miny), plane)
-        shapely.prepare(geom)
-        for face, digits in dggs._lattice_cells(boxes, res):
-            resolution = np.full(len(face), res)
-            if containment == "center":
-                keep = _cells_with_centroid_inside(
-                    geom, dggs, plane, face, digits, resolution
+        # The frontier at min_res: the lattice cells of the bounding box.
+        frontier = [
+            (face, digits[:, :min_res])
+            for face, digits in dggs._lattice_cells(boxes, min_res)
+        ]
+        for level in range(min_res, res + 1):
+            if not frontier:
+                break
+            face = np.concatenate([f for f, _ in frontier])
+            digits = np.concatenate([d for _, d in frontier])
+            frontier = []
+            scale = N2 ** (res - level)  # descendants at res per cell here
+            # A cell accepted for the flat fill is expanded into `scale`
+            # keys; below a chunk per cell that is done here, above it the
+            # cell is split instead, so no expansion exceeds a chunk.
+            expand_here = compress or scale <= chunk
+            for start in range(0, len(face), chunk):
+                f = face[start : start + chunk]
+                d = digits[start : start + chunk]
+                resolution = np.full(len(f), level)
+                if level == res:
+                    if containment == "center":
+                        keep = _cells_with_centroid_inside(
+                            geom, dggs, plane, f, d, resolution
+                        )
+                    else:
+                        keep = _cells_within_or_overlapping(
+                            geom, dggs, plane, f, d, resolution, containment == "full"
+                        )
+                    if keep.any():
+                        emit(_keys(f[keep], d[keep], level, res, N2), res)
+                    continue
+                accept, reject = _classify(
+                    geom, dggs, plane, f, d, resolution, containment, margin
                 )
-            else:
-                keep = _cells_within_or_overlapping(
-                    geom, dggs, plane, face, digits, resolution, containment == "full"
-                )
-            if keep.any():
-                cells.update(
-                    dggs._format_indices(face[keep], digits[keep], res).tolist()
-                )
+                if not expand_here:
+                    accept = np.zeros_like(accept)
+                if accept.any():
+                    base = _keys(f[accept], d[accept], level, res, N2)
+                    if compress:
+                        emit(base, level)
+                    else:
+                        # Expand in groups whose total stays within a chunk.
+                        per_group = max(1, chunk // scale)
+                        for g0 in range(0, len(base), per_group):
+                            group = base[g0 : g0 + per_group]
+                            emit(
+                                (
+                                    group[:, None] + np.arange(scale, dtype=np.int64)
+                                ).ravel(),
+                                res,
+                            )
+                split = ~accept & ~reject
+                if split.any():
+                    frontier.append(_children(f[split], d[split], N2))
 
-    # Merge cells inside polygon into larger ones where possible
+    width = max(res, 1)
+    if not keys_out:
+        empty = np.empty(0, dtype=np.int64)
+        return empty, np.empty((0, width), dtype=np.int16), empty.astype(np.int8)
+    keys = np.concatenate(keys_out)
+    levels = np.concatenate(res_out)
     if compress:
-        cells = compact_cells(cells, N_side=dggs.N_side)
+        keys, levels = _merge_sibling_groups(keys, levels, res, min_res, N2)
+    else:
+        keys = np.unique(keys)  # a cell met by two parts appears twice
+        levels = np.full(len(keys), res, dtype=np.int8)
+    return _decode(keys, levels, res, N2)
 
-    return cells
+
+def _keys(
+    face: np.ndarray, digits: np.ndarray, level: int, res: int, N2: int
+) -> np.ndarray:
+    """The res-padded int64 keys of resolution-`level` cells."""
+    weights = N2 ** np.arange(res - 1, res - 1 - level, -1, dtype=np.int64)
+    return face.astype(np.int64) * N2**res + (
+        digits[:, :level].astype(np.int64) * weights
+    ).sum(axis=1)
+
+
+def _children(
+    face: np.ndarray, digits: np.ndarray, N2: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """The N2 children of each cell: a digit column appended, cells repeated."""
+    n = len(face)
+    child = np.tile(np.arange(N2, dtype=digits.dtype), n)
+    face = np.repeat(face, N2)
+    digits = np.column_stack([np.repeat(digits, N2, axis=0), child])
+    return face, digits
+
+
+def _classify(
+    geom: Polygon,
+    dggs: RHEALPixDGGS,
+    plane: bool,
+    face: np.ndarray,
+    digits: np.ndarray,
+    resolution: np.ndarray,
+    containment: str,
+    margin: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    For cells above the leaf resolution: `accept` marks cells wholly inside
+    `geom` and clear of its boundary by `margin`, so that every descendant
+    qualifies under `containment`, and `reject` cells farther than `margin`
+    from it, so that none does. For ``center`` the test is on the cell's
+    longitude-latitude bounding box (planar square in the plane), which
+    contains every descendant's centroid; for ``full`` and ``overlapping`` on
+    the cell's boundary polygon, as the leaf test is. Cells whose box cannot
+    be trusted (spanning more than half a turn) are neither.
+    """
+    if containment == "center":
+        if plane:
+            x, y, width, _ = dggs._index_geometry(face, digits, resolution)
+            boxes = shapely.box(x, y - width, x + width, y)
+            trusted = np.ones(len(face), dtype=bool)
+        else:
+            corners = dggs._boundary_array(face, digits, resolution, 2, False)
+            lo = corners.min(axis=1)
+            hi = corners.max(axis=1)
+            trusted = hi[:, 0] - lo[:, 0] <= dggs.ellipsoid.pi()
+            boxes = shapely.box(lo[:, 0], lo[:, 1], hi[:, 0], hi[:, 1])
+        boundary = geom.boundary
+        shapely.prepare(boundary)
+        inside = np.asarray(shapely.contains(geom, boxes))
+        near = np.asarray(shapely.dwithin(boundary, boxes, margin))
+        close = np.asarray(shapely.dwithin(geom, boxes, margin))
+        return inside & ~near & trusted, ~close & trusted
+    accept = _cells_within_or_overlapping(
+        geom, dggs, plane, face, digits, resolution, True, margin
+    )
+    meets = _cells_within_or_overlapping(
+        geom, dggs, plane, face, digits, resolution, False, margin
+    )
+    return accept, ~meets
+
+
+def _merge_sibling_groups(
+    keys: np.ndarray, levels: np.ndarray, res: int, min_res: int, N2: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Deduplicate a cover and merge every complete group of N2 siblings into
+    its parent, repeatedly, never above `min_res`; return the keys sorted.
+    """
+    pairs = np.unique(np.column_stack([keys, levels.astype(np.int64)]), axis=0)
+    keys, levels = pairs[:, 0], pairs[:, 1]
+    for level in range(res, min_res, -1):
+        at = levels == level
+        if not at.any():
+            continue
+        stride = N2 ** (res - level + 1)
+        parents = (keys[at] // stride) * stride
+        unique_parents, counts = np.unique(parents, return_counts=True)
+        complete = counts == N2
+        if not complete.any():
+            continue
+        merged = np.isin(parents, unique_parents[complete])
+        keep = np.ones(len(keys), dtype=bool)
+        keep[np.flatnonzero(at)[merged]] = False
+        keys = np.concatenate([keys[keep], unique_parents[complete]])
+        levels = np.concatenate(
+            [levels[keep], np.full(int(complete.sum()), level - 1, dtype=np.int64)]
+        )
+    order = np.argsort(keys, kind="stable")
+    return keys[order], levels[order].astype(np.int8)
+
+
+def _decode(
+    keys: np.ndarray, levels: np.ndarray, res: int, N2: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Base cell codes and zero-padded int16 digit rows from res-padded keys."""
+    width = max(res, 1)
+    face = keys // N2**res
+    digits = np.zeros((len(keys), width), dtype=np.int16)
+    # One digit column at a time, so that no intermediate is wider than the
+    # keys themselves.
+    for k in range(res):
+        digits[:, k] = (keys // N2 ** (res - 1 - k)) % N2
+    return face, digits, levels.astype(np.int8)
 
 
 def _cells_with_centroid_inside(
@@ -634,6 +919,7 @@ def _cells_within_or_overlapping(
     digits: np.ndarray,
     resolution: np.ndarray,
     full: bool,
+    margin: float = 0.0,
 ) -> np.ndarray:
     """
     For each cell, given as the arrays ``RHEALPixDGGS._parse_indices``
@@ -643,15 +929,33 @@ def _cells_within_or_overlapping(
     approximation of the curved edges of polar cells. Cap cells and cells
     crossing the antimeridian are handled apart, as their rings are not
     polygons in longitude-latitude coordinates.
+
+    With a positive `margin` the tests are those the hierarchical descent
+    needs: "fully within" also requires the cell to be clear of `geom`'s
+    boundary by `margin`, and "meets" becomes "within `margin` of `geom`";
+    cap cells then count as neither fully within nor clear of it.
     """
     polar = (face == 0) | (face == 5)
     n = 6 if (not plane and polar.any()) else 2
     rings = dggs._boundary_array(face, digits, resolution, n, plane)
+    boundary = geom.boundary if margin > 0 else None
+    if boundary is not None:
+        shapely.prepare(boundary)
+
+    def within(polys: Any) -> np.ndarray:
+        inside = np.asarray(shapely.contains(geom, polys))
+        if boundary is None:
+            return inside
+        return inside & ~np.asarray(shapely.dwithin(boundary, polys, margin))
+
+    def meets(g: Polygon, polys: Any) -> np.ndarray:
+        if boundary is None:
+            return np.asarray(shapely.intersects(g, polys))
+        return np.asarray(shapely.dwithin(g, polys, margin))
+
     if plane:
         polys = shapely.polygons(rings)
-        return np.asarray(
-            shapely.contains(geom, polys) if full else shapely.intersects(geom, polys)
-        )
+        return within(polys) if full else meets(geom, polys)
 
     keep = np.zeros(len(face), dtype=bool)
     cap = dggs._shape_code(face, digits, resolution) == 1
@@ -668,9 +972,7 @@ def _cells_within_or_overlapping(
 
     if plain.any():
         polys = shapely.polygons(rings[plain])
-        keep[plain] = (
-            shapely.contains(geom, polys) if full else shapely.intersects(geom, polys)
-        )
+        keep[plain] = within(polys) if full else meets(geom, polys)
     if crosses.any() and not full:
         # A crossing cell can only be fully inside a geometry that itself
         # crosses, which callers must have split, so it is never `full`; it
@@ -678,12 +980,15 @@ def _cells_within_or_overlapping(
         # the geometry shifted one turn east.
         polys = shapely.polygons(rings[crosses])
         shifted = translate(geom, xoff=2 * half)
-        keep[crosses] = shapely.intersects(geom, polys) | shapely.intersects(
-            shifted, polys
-        )
+        keep[crosses] = meets(geom, polys) | meets(shifted, polys)
     if cap.any():
         _, miny, _, maxy = geom.bounds
         for k in np.flatnonzero(cap):
+            if boundary is not None:
+                # Neither clear of the boundary nor clear of the geometry:
+                # a cap is only ever decided at the leaves.
+                keep[k] = not full
+                continue
             lat_c = rings[k, 0, 1]
             north = face[k] == 0
             band = (

--- a/rhealpixdggs/rhp_wrappers.py
+++ b/rhealpixdggs/rhp_wrappers.py
@@ -504,9 +504,12 @@ def polyfill(
     `min_res` and no complete group of siblings left unmerged; so every cell
     of the result has exactly one ancestor at resolution `min_res`, which
     suits partitioning by that resolution. "Wholly inside" is judged by the
-    cell's boundary polygon for ``full`` and ``overlapping`` and, for
-    ``center``, by the cell's longitude-latitude bounding box, which every
-    descendant's centroid lies within, so the centroid rule is kept exactly.
+    cell's boundary polygon for ``full`` and ``overlapping`` where that is
+    exact (the plane, equatorial cells), and otherwise by the cell's
+    longitude-latitude bounding box, which contains the cell: for polar
+    cells, whose 6-point polygon is only approximate, and for ``center``,
+    where the box also contains every descendant's centroid, so the centroid
+    rule is kept exactly.
 
     ``polyfill_array`` returns the same cells as a sorted numpy string array,
     which costs less than half the memory per cell for large fills.
@@ -793,8 +796,11 @@ def _classify(
     from it, so that none does. For ``center`` the test is on the cell's
     longitude-latitude bounding box (planar square in the plane), which
     contains every descendant's centroid; for ``full`` and ``overlapping`` on
-    the cell's boundary polygon, as the leaf test is. Cells whose box cannot
-    be trusted (spanning more than half a turn) are neither.
+    the cell's boundary polygon where that is exact (the plane, equatorial
+    cells) and otherwise on its longitude-latitude bounding box, which
+    contains the cell, so that no decision here contradicts the leaf test.
+    Cells whose box cannot be trusted (spanning more than half a turn) are
+    neither.
     """
     if containment == "center":
         if plane:
@@ -933,10 +939,21 @@ def _cells_within_or_overlapping(
     With a positive `margin` the tests are those the hierarchical descent
     needs: "fully within" also requires the cell to be clear of `geom`'s
     boundary by `margin`, and "meets" becomes "within `margin` of `geom`";
-    cap cells then count as neither fully within nor clear of it.
+    cap cells then count as neither fully within nor clear of it, and polar
+    cells are judged by their longitude-latitude bounding box rather than
+    their 6-point polygon. The box contains the whole cell, as a polar
+    cell's curved edges are monotone in longitude and latitude, whereas the
+    polygon of a coarse cell can miss the true edge by a degree, so a
+    decision on it could drop or accept descendants the leaf test would
+    decide the other way.
     """
     polar = (face == 0) | (face == 5)
-    n = 6 if (not plane and polar.any()) else 2
+    # Always 6 points per edge on the ellipsoid, not only when the batch
+    # has polar cells: the lattice the points are projected from has pitch
+    # width / (n - 1), so a cell's coordinates depend on n in the last bit,
+    # and a decision about a cell must not depend on which cells it is
+    # tested with.
+    n = 2 if plane else 6
     rings = dggs._boundary_array(face, digits, resolution, n, plane)
     boundary = geom.boundary if margin > 0 else None
     if boundary is not None:
@@ -970,15 +987,23 @@ def _cells_within_or_overlapping(
     crosses = wraps & (rings[:, :, 0].max(axis=1) > half * (1 + 1e-12))
     plain = ~cap & ~crosses
 
+    def cells(mask: np.ndarray) -> Any:
+        polys = shapely.polygons(rings[mask])
+        if boundary is not None and (polar & mask).any():
+            # Above the leaves, a polar cell is its bounding box.
+            box_rows = polar[mask]
+            polys[box_rows] = shapely.envelope(polys[box_rows])
+        return polys
+
     if plain.any():
-        polys = shapely.polygons(rings[plain])
+        polys = cells(plain)
         keep[plain] = within(polys) if full else meets(geom, polys)
     if crosses.any() and not full:
         # A crossing cell can only be fully inside a geometry that itself
         # crosses, which callers must have split, so it is never `full`; it
         # overlaps the geometry if its unwrapped ring meets the geometry or
         # the geometry shifted one turn east.
-        polys = shapely.polygons(rings[crosses])
+        polys = cells(crosses)
         shifted = translate(geom, xoff=2 * half)
         keep[crosses] = meets(geom, polys) | meets(shifted, polys)
     if cap.any():

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -717,6 +717,15 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
                     assert_array_equal(row, np.array(d[c]))
         # n below 2 clamps to 2, like boundary(); empty input gives an empty array.
         first = [str(c) for c in cell_sets[0]]
+        # A cell's boundary is a function of the cell alone: the same whether
+        # it is computed by itself, with its neighbours, or with cells of
+        # another resolution, and a shared edge has one set of coordinates.
+        block = [f"Q3{a}{b}" for a in range(9) for b in range(9)] + ["Q30", "N", "S8"]
+        for n in (2, 4):
+            together = rdggs.boundary_array(block, n=n, plane=False)
+            for k, index in enumerate(block):
+                alone = rdggs.boundary_array([index], n=n, plane=False)[0]
+                assert_array_equal(together[k], alone, index)
         self.assertEqual(rdggs.boundary_array(first, n=1).shape, (9, 4, 2))
         self.assertEqual(rdggs.boundary_array([], n=3).shape, (0, 8, 2))
         # Invalid indices give NaN rows in place, valid ones are unaffected.

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -1001,6 +1001,49 @@ class RhpWrappersTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             rhpw.polyfill(nz, 3, plane=False, min_res=-1)
 
+    def test_polyfill_descent_matches_leaf_test(self):
+        # Descending from resolution 0 gives the same cells as testing every
+        # cell at the target resolution (min_res=res). The coarse decisions
+        # must therefore contain the leaf ones: a coarse polar cell's
+        # 6-point polygon is not good enough (the resolution-1 dart N6's
+        # chord at 70N sits a degree inside its true edge), so polar cells
+        # above the leaves are judged by their bounding box instead.
+        bands = [
+            sh.box(-170, 69.9, 170, 70.1),
+            sh.box(-170, 70.1, 170, 70.3),
+            sh.box(100, 60.0, 179, 60.2),
+            sh.box(-179, -70.1, 179, -69.9),
+            sh.box(-90.6, 42, -89.4, 80),
+            sh.Polygon([(0, 45), (60, 45), (30, 88)]),
+            # Edges on cell edges (multiples of 10 degrees are resolution-2
+            # cell edges): whether a cell touching the geometry counts must
+            # not depend on which other cells it is tested alongside, which
+            # takes a boundary that is a function of the cell alone.
+            sh.box(10, 60, 40, 75),
+            sh.box(-60, -80, 60, -55),
+        ]
+        for geom in bands:
+            for res in (3, 4, 5):
+                for mode in ("center", "full", "overlapping"):
+                    leaf = rhpw.polyfill(
+                        geom, res, plane=False, containment=mode, min_res=res
+                    )
+                    self.assertEqual(
+                        rhpw.polyfill(geom, res, plane=False, containment=mode),
+                        leaf,
+                        (geom.bounds, res, mode),
+                    )
+                    self.assertEqual(
+                        rhpw.polyfill(
+                            geom, res, plane=False, containment=mode, min_res=1
+                        ),
+                        leaf,
+                        (geom.bounds, res, mode, 1),
+                    )
+        # The two cells the dart's chord lost.
+        band = rhpw.polyfill(bands[0], 4, plane=False, containment="overlapping")
+        self.assertTrue({"N6212", "N6252"} <= band)
+
     def test_linetrace(self):
         # Test data
         p_ls = sh.LineString(

--- a/tests/test_rhp_wrappers.py
+++ b/tests/test_rhp_wrappers.py
@@ -860,6 +860,147 @@ class RhpWrappersTestCase(unittest.TestCase):
                     rhpw.polyfill(nz, 5, plane=False, containment=mode), cells, mode
                 )
 
+    def test_polyfill_array(self):
+        # polyfill_array returns the cells polyfill returns, as a sorted numpy
+        # string array without duplicates, and None where polyfill does.
+        import numpy as np
+
+        nz = sh.Polygon(
+            [
+                (166.0, -46.8),
+                (169.5, -47.5),
+                (174.5, -42.0),
+                (178.8, -37.8),
+                (177.0, -35.5),
+                (173.5, -34.0),
+                (171.5, -36.5),
+                (166.5, -43.5),
+            ]
+        )
+        holed = sh.Polygon(
+            [(-10, -10), (50, -10), (50, 40), (-10, 40)],
+            holes=[[(-5, 5), (25, 20), (45, 5)], [(-5, 25), (25, 30), (45, 25)]],
+        )
+        multi = sh.MultiPolygon(
+            [holed, sh.Polygon([(0, 75), (-30, 42), (0, 42), (30, 42)])]
+        )
+        R = gs.WGS84_003.ellipsoid.R_A
+        planar = sh.Polygon(
+            [(0.1 * R, 0.1 * R), (0.9 * R, 0.2 * R), (0.5 * R, 0.7 * R)]
+        )
+        cases = [(nz, 4, False), (nz, 5, False), (multi, 3, False), (planar, 3, True)]
+        for geom, res, plane in cases:
+            for mode in ("center", "full", "overlapping"):
+                arr = rhpw.polyfill_array(geom, res, plane=plane, containment=mode)
+                want = rhpw.polyfill(geom, res, plane=plane, containment=mode)
+                self.assertIsInstance(arr, np.ndarray)
+                self.assertEqual(arr.dtype.kind, "U")
+                self.assertEqual(set(arr.tolist()), want, (res, plane, mode))
+                self.assertEqual(len(arr), len(want), (res, plane, mode))
+                self.assertEqual(arr.tolist(), sorted(arr.tolist()), (res, plane, mode))
+        # N_side = 2, and the order is the order of Cell objects. (Index
+        # strings are single-character digits, so N_side 2 and 3 only.)
+        dggs = gs.WGS84_002
+        arr = rhpw.polyfill_array(nz, 3, plane=False, dggs=dggs)
+        want = rhpw.polyfill(nz, 3, plane=False, dggs=dggs)
+        self.assertEqual(set(arr.tolist()), want)
+        self.assertEqual(len(arr), len(want))
+        cells = [dggs.cell([c[0]] + [int(d) for d in c[1:]]) for c in arr]
+        self.assertEqual(cells, sorted(cells))
+        # compress: the same compacted cells, sorted as strings.
+        square = sh.Polygon(((0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)))
+        arr = rhpw.polyfill_array(square, 6, plane=False, compress=True)
+        self.assertEqual(
+            arr.tolist(), sorted(rhpw.polyfill(square, 6, plane=False, compress=True))
+        )
+        # Nothing qualifies: an empty array. Malformed: None.
+        self.assertEqual(rhpw.polyfill_array(square, 2, plane=False).size, 0)
+        self.assertIsNone(rhpw.polyfill_array(sh.Polygon(), 2))
+        self.assertIsNone(rhpw.polyfill_array(sh.Point(1, 1), 2))
+
+    def test_polyfill_cover(self):
+        # compress=True returns the hierarchical cover: no cell coarser than
+        # min_res, no complete sibling group left unmerged, every cell with
+        # exactly one ancestor at min_res, and expanding every cell to the
+        # target resolution gives exactly the flat fill.
+        from itertools import product
+
+        from rhealpixdggs.conversion import compact_cells
+
+        nz = sh.Polygon(
+            [
+                (166.0, -46.8),
+                (169.5, -47.5),
+                (174.5, -42.0),
+                (178.8, -37.8),
+                (177.0, -35.5),
+                (173.5, -34.0),
+                (171.5, -36.5),
+                (166.5, -43.5),
+            ]
+        )
+        holed = sh.Polygon(
+            [(-10, -10), (50, -10), (50, 40), (-10, 40)],
+            holes=[[(-5, 5), (25, 20), (45, 5)], [(-5, 25), (25, 30), (45, 25)]],
+        )
+
+        def expand(index, res):
+            depth = res - (len(index) - 1)
+            return [index + "".join(t) for t in product("012345678", repeat=depth)]
+
+        for geom, res in ((nz, 6), (holed, 5)):
+            for mode in ("center", "full", "overlapping"):
+                flat = rhpw.polyfill(geom, res, plane=False, containment=mode)
+                for min_res in (0, 2, 4, res):
+                    cover = rhpw.polyfill(
+                        geom,
+                        res,
+                        plane=False,
+                        compress=True,
+                        containment=mode,
+                        min_res=min_res,
+                    )
+                    resolutions = {len(c) - 1 for c in cover}
+                    self.assertTrue(min(resolutions) >= min_res, (mode, min_res))
+                    self.assertTrue(max(resolutions) <= res, (mode, min_res))
+                    expanded = [x for c in cover for x in expand(c, res)]
+                    self.assertEqual(len(expanded), len(set(expanded)), (mode, min_res))
+                    self.assertEqual(set(expanded), flat, (mode, min_res))
+                    # Fully compact above min_res: no complete sibling group.
+                    if min_res < res:
+                        recompacted = compact_cells(
+                            {c for c in cover if len(c) - 1 == res}, N_side=3
+                        ) | {c for c in cover if len(c) - 1 < res}
+                        self.assertEqual(recompacted, cover, (mode, min_res))
+                    # The array form is the same cells in hierarchical order.
+                    arr = rhpw.polyfill_array(
+                        geom,
+                        res,
+                        plane=False,
+                        compress=True,
+                        containment=mode,
+                        min_res=min_res,
+                    )
+                    self.assertEqual(set(arr.tolist()), cover)
+                    self.assertEqual(arr.tolist(), sorted(arr.tolist()))
+                    if min_res == res:
+                        self.assertEqual(cover, flat)
+                # For full containment the cover is exactly the compaction of
+                # the flat fill: a parent is wholly inside iff all its children
+                # are.
+                if mode == "full":
+                    self.assertEqual(
+                        rhpw.polyfill(
+                            geom, res, plane=False, compress=True, containment=mode
+                        ),
+                        compact_cells(flat, N_side=3),
+                    )
+
+        with self.assertRaises(ValueError):
+            rhpw.polyfill(nz, 3, plane=False, compress=True, min_res=4)
+        with self.assertRaises(ValueError):
+            rhpw.polyfill(nz, 3, plane=False, min_res=-1)
+
     def test_linetrace(self):
         # Test data
         p_ls = sh.LineString(


### PR DESCRIPTION
## Summary

`polyfill` becomes a hierarchical fill on arrays, gains `min_res`, and is joined by `polyfill_array`. A follow-up commit fixes two faults in the descent found while checking that the `overlapping` cover actually covers the input polygon.

### Hierarchical fill (e181f0f)

- The fill descends from resolution `min_res` (new parameter, default 0). A cell wholly inside the geometry is kept whole, a cell missing it is dropped, and only cells the boundary passes through are split, down to `res`, where the remaining cells are decided by `containment`. Work grows with the boundary rather than the area.
- `compress=False` gives exactly the cells a cell-by-cell test at `res` gives. `compress=True` returns the coarse cells as they are: a cover with no cell coarser than `min_res` and no complete sibling group left unmerged, so every cell has exactly one ancestor at `min_res`. In `center` mode this differs from the previous post-hoc compaction along the boundary only; in `full` mode the two agree exactly.
- New `polyfill_array` returns the same cells as a sorted numpy string array, at about 40 bytes per cell against some 100 for a set entry.
- New `RHEALPixDGGS.cells_in_box`; cells are carried as int64 keys and processed in bounded chunks.
- New Zealand polygon at resolution 7: 24.5 s to 0.33 s. Resolution 9 (3.4 million cells): 3.1 s. Full numbers in CHANGES.rst.

### Descent agrees with the leaf test (8a88efd)

- Above the leaves, polar cells were judged on their 6-point boundary polygon, which for a coarse cell can lie a degree off the true curved edge. A thin band at 70N was judged clear of the resolution-1 dart N6 and every overlapping descendant was dropped, so the `overlapping` cover no longer covered the geometry. Polar cells above the leaves are now judged by their longitude-latitude bounding box, which contains the cell, as `center` mode already did.
- Whether a cell whose edge lies exactly on the geometry's edge (a box at whole degrees) counted depended on which cells it was tested alongside: `boundary_array` projected shared lattice points from whichever cell of the batch produced them first, and the point count per edge varied with the batch. `boundary_array` now projects each point from the coordinates its lattice key denotes, so a cell's boundary is a function of the cell alone, and the containment tests always sample 6 points per edge on the ellipsoid. Shared boundary coordinates can move by a last bit.

## Tests

- Descent from resolution 0 and 1 equals the leaf-only fill for thin polar bands, a polar triangle and whole-degree boxes in all modes at resolutions 3 to 5.
- Cover invariants for every mode and `min_res`; `full` cover equals compaction of the flat fill.
- `boundary_array` gives a cell the same boundary alone or in a batch.
- Full suite (178 tests), doctests, black and ruff pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
