### PR TITLE
Add Cell.ring and RHEALPixDGGS.rings for isolatitude ring numbers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,12 @@
+0.8.6
+^^^^^
+``Cell.ring()`` returns the isolatitude ring of a cell's nucleus, numbered
+0 at the north pole; every cell on a ring, in any base cell, has the same
+nucleus latitude. ``RHEALPixDGGS.rings(indices)`` is its array form over
+index strings, giving -1 for an invalid index and rejecting mixed
+resolutions, since ring numbers only compare within one resolution. Both
+are integer arithmetic on the index digits (issue #149).
+
 0.8.5
 ^^^^^
 ``rhp_wrappers.polyfill`` gains a ``containment`` parameter with H3's three

--- a/rhealpixdggs/cell.py
+++ b/rhealpixdggs/cell.py
@@ -332,6 +332,38 @@ class Cell:
             suid_col.append(col)
         return tuple(suid_row), tuple(suid_col)
 
+    def ring(self) -> int:
+        """
+        Return the isolatitude ring of this cell's nucleus. Rings are
+        numbered 0 at the north pole through ``n + 2 * q - 1`` at the south
+        pole, where ``n = N_side ** resolution`` cells span a base cell's
+        side and ``q = ceil(n / 2)`` rings fill each polar cap. Every cell on
+        a ring, in any base cell, has the same nucleus latitude. Ring numbers
+        are only comparable within one resolution.
+
+        EXAMPLES::
+
+            >>> from rhealpixdggs.dggs import WGS84_003
+            >>> suids = [['N', 4], ['N', 0], ['P', 4], ['S', 8]]
+            >>> [Cell(WGS84_003, s).ring() for s in suids]
+            [0, 1, 3, 5]
+
+        """
+        N = self.rdggs.N_side
+        n = N ** (len(self.suid) - 1)
+        q = -(-n // 2)
+        row = col = 0
+        for digit in self.suid[1:]:
+            r, c = cast("tuple[int, int]", self.rdggs.child_order[int(digit)])
+            row = row * N + r
+            col = col * N + c
+        if self.suid[0] not in (CELLS0[0], CELLS0[5]):
+            return q + row
+        m = max(abs(2 * row - (n - 1)), abs(2 * col - (n - 1))) // 2
+        if self.suid[0] == CELLS0[0]:
+            return m
+        return q + n + (q - 1 - m)
+
     @overload
     def width(self, plane: Literal[True] = ...) -> float: ...
 

--- a/rhealpixdggs/dggs.py
+++ b/rhealpixdggs/dggs.py
@@ -2058,6 +2058,45 @@ class RHEALPixDGGS:
             result[valid, 1] = y
         return result
 
+    def rings(self, indices: Iterable[str]) -> np.ndarray:
+        """
+        Return the isolatitude ring of each cell with index strings `indices`
+        as one int64 array: entry `k` is ``cell.ring()`` for the cell whose
+        ``str()`` is ``indices[k]``, or -1 for an invalid index. Ring numbers
+        are only comparable within one resolution, so the valid indices must
+        all share one resolution; otherwise raise a ValueError.
+
+        EXAMPLES::
+
+            >>> WGS84_003.rings(['N4', 'N0', 'P4', 'S8', 'bad']).tolist()
+            [0, 1, 3, 5, -1]
+
+        """
+        valid, face, digits, resolution = self._parse_indices(indices)
+        result = np.full(len(valid), -1, dtype=np.int64)
+        if not valid.any():
+            return result
+        resolutions = np.unique(resolution[valid])
+        if len(resolutions) > 1:
+            raise ValueError(
+                f"indices span resolutions {resolutions.tolist()}; "
+                "ring numbers are only comparable within one resolution"
+            )
+        N = self.N_side
+        k = int(resolutions[0])
+        n = N**k
+        q = -(-n // 2)
+        d = digits[valid][:, :k]
+        power = N ** np.arange(k - 1, -1, -1)
+        row = ((d // N) * power).sum(axis=1)
+        col = ((d % N) * power).sum(axis=1)
+        m = np.maximum(np.abs(2 * row - (n - 1)), np.abs(2 * col - (n - 1))) // 2
+        f = face[valid]
+        result[valid] = np.where(
+            f == 0, m, np.where(f == 5, q + n + (q - 1 - m), q + row)
+        )
+        return result
+
     def centroids(self, indices: Iterable[str], plane: bool = False) -> FloatArray:
         """
         Return the centroids of the cells with index strings `indices` as one

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -130,6 +130,40 @@ class SCENZGridCELLTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             Cell(rdggs, suid=(P, rdggs.N_side**2))
 
+    def test_ring_groups_cells_by_nucleus_latitude(self):
+        # ring() numbers the isolatitude rings 0 from the north pole. Cells
+        # on a ring share their nucleus latitude, latitudes fall with the
+        # ring number, and populations follow the cap/belt pattern for odd
+        # and even n.
+        grids = [
+            (WGS84_003, 0),
+            (WGS84_003_RADIANS, 1),
+            (WGS84_003, 2),
+            (WGS84_123, 2),
+            (WGS84_122, 3),
+        ]
+        for rdggs, resolution in grids:
+            n = rdggs.N_side**resolution
+            q = -(-n // 2)
+            latitudes: dict[int, set[float]] = {}
+            counts: dict[int, int] = {}
+            for cell in rdggs.grid(resolution):
+                ring = cell.ring()
+                lat = round(cell.nucleus(plane=False)[1], 9)
+                latitudes.setdefault(ring, set()).add(lat)
+                counts[ring] = counts.get(ring, 0) + 1
+            self.assertEqual(sorted(latitudes), list(range(n + 2 * q)))
+            self.assertTrue(all(len(s) == 1 for s in latitudes.values()))
+            ordered = [latitudes[i].pop() for i in range(n + 2 * q)]
+            self.assertEqual(ordered, sorted(ordered, reverse=True))
+            if n % 2:
+                cap = [1] + [8 * m for m in range(1, q)]
+            else:
+                cap = [8 * m + 4 for m in range(q)]
+            self.assertEqual(
+                [counts[i] for i in range(n + 2 * q)], cap + [4 * n] * n + cap[::-1]
+            )
+
     def test_suid_rowcol(self):
         for rdggs in [WGS84_123, WGS84_123_RADIANS]:
             # Should work for resolution 0 cells.

--- a/tests/test_dggs.py
+++ b/tests/test_dggs.py
@@ -597,6 +597,23 @@ class SCENZGridRHEALPixDGGSTestCase(unittest.TestCase):
         self.assertTrue(np.isnan(nuclei[~valid]).all())
         self.assertFalse(np.isnan(nuclei[valid]).any())
 
+    def test_rings_match_cell_ring(self):
+        # rings() reads the ring number off the index digits for all cells
+        # at once, agreeing with Cell.ring. Invalid indices give -1, and
+        # mixed resolutions are rejected because ring numbers only compare
+        # within one resolution.
+        from numpy.testing import assert_array_equal
+
+        for rdggs in (WGS84_003, WGS84_003_RADIANS, WGS84_123, WGS84_122):
+            for resolution in range(3):
+                cells = list(rdggs.grid(resolution))
+                got = rdggs.rings([str(c) for c in cells])
+                self.assertEqual(got.dtype.kind, "i")
+                assert_array_equal(got, [c.ring() for c in cells])
+        assert_array_equal(WGS84_003.rings(["N4", "bad", "P4"]), [0, -1, 3])
+        with self.assertRaises(ValueError):
+            WGS84_003.rings(["N4", "P"])
+
     def test_centroids_match_cell_centroid(self):
         # centroids() evaluates Cell.centroid's quadrature rules for all
         # cells of each shape at once; only the summation differs (array


### PR DESCRIPTION
## Summary

Closes #149, the first sub-issue of #148.

- `Cell.ring()` returns the isolatitude ring of a cell's nucleus, numbered 0 at the north pole through `n + 2q - 1` at the south pole, where `n = N_side ** resolution` and `q = ceil(n / 2)`. It is integer arithmetic on the row and column parts of the index digits, via the same `child_order` lookup `suid_rowcol` uses; nothing is projected.
- `RHEALPixDGGS.rings(indices)` is the array form over index strings, built on `_parse_indices` so it reads digits per level (correct for every `N_side`, see #146). An invalid index gives -1. Mixed resolutions raise a `ValueError`, since ring numbers are only comparable within one resolution.
- 0.8.6 entry in CHANGES.rst.

## Tests

- Every cell of five grids (`N_side` 2 and 3, resolutions 0 to 3, degrees and radians, two square placements) grouped by `ring()`: one nucleus latitude per ring, latitudes strictly decreasing with ring number, `n + 2q` rings, and cap and belt populations as tabulated in #148.
- `rings()` agrees with `Cell.ring()` for every cell of four grids at resolutions 0 to 2; the -1 sentinel and the mixed-resolution error.
- Also probed outside the tests: `N_side` 4 through the tuple API, resolution 15 indices, and a resolution-4 grid (39k cells, 17 ms) grouping into exactly 163 single-latitude rings.
- Full suite (180 tests), doctests, black, ruff and mypy pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)